### PR TITLE
[TASK-17] Add healthcheck endpoints

### DIFF
--- a/src/MCP.FinnHub.Server.SSE/Options/FinnHubEndpoint.cs
+++ b/src/MCP.FinnHub.Server.SSE/Options/FinnHubEndpoint.cs
@@ -1,7 +1,9 @@
 using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MCP.FinnHub.Server.SSE.Options;
 
+[ExcludeFromCodeCoverage]
 public sealed class FinnHubEndpoint
 {
     [Required]

--- a/src/MCP.FinnHub.Server.SSE/Options/FinnHubOptions.cs
+++ b/src/MCP.FinnHub.Server.SSE/Options/FinnHubOptions.cs
@@ -1,7 +1,9 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.Diagnostics.CodeAnalysis;
 
 namespace MCP.FinnHub.Server.SSE.Options;
 
+[ExcludeFromCodeCoverage]
 public sealed class FinnHubOptions
 {
     [Required]

--- a/src/MCP.FinnHub.Server.SSE/Program.cs
+++ b/src/MCP.FinnHub.Server.SSE/Program.cs
@@ -1,4 +1,6 @@
 using MCP.FinnHub.Server.SSE.Options;
+using Microsoft.AspNetCore.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -15,6 +17,9 @@ builder.Services
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
+
+builder.Services.AddHealthChecks()
+    .AddCheck("self", () => HealthCheckResult.Healthy(), tags: ["live"]);
 
 builder.Services.AddCors(options =>
 {
@@ -35,6 +40,35 @@ if (app.Environment.IsDevelopment())
     app.UseSwaggerUI();
 }
 
+HealthCheckOptions CreateHealthOptions() => new()
+{
+    ResultStatusCodes =
+    {
+        [HealthStatus.Healthy] = StatusCodes.Status200OK,
+        [HealthStatus.Degraded] = StatusCodes.Status200OK,
+        [HealthStatus.Unhealthy] = StatusCodes.Status503ServiceUnavailable
+    },
+    ResponseWriter = async (context, report) =>
+    {
+        context.Response.ContentType = "application/json";
+        var response = new
+        {
+            status = report.Status.ToString(),
+            checks = report.Entries.Select(entry => new
+            {
+                name = entry.Key,
+                status = entry.Value.Status.ToString(),
+                description = entry.Value.Description,
+                duration = entry.Value.Duration
+            }),
+            totalDuration = report.TotalDuration
+        };
+        await context.Response.WriteAsJsonAsync(response);
+    }
+};
+
+app.MapHealthChecks("/health/ready", CreateHealthOptions());
+app.MapHealthChecks("/health/live", CreateHealthOptions());
 app.UseCors();
 app.UseHttpsRedirection();
 


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Other

### What's in this PR

- Introduced `/health/ready` and `/health/live` endpoints for readiness and liveness checks
- Both endpoints return structured JSON including:
  - Overall status
  - Individual health check results (name, status, description, duration)
  - Total duration of the health report
- Added a basic "self" health check to validate service liveness
- Mapped health statuses to appropriate HTTP response codes
  - `Healthy` → 200 OK
  - `Degraded` → 200 OK
  - `Unhealthy` → 503 Service Unavailable

### GitHub Links

- Closes #17 

### Tests

- N/A

### Checklist

- [x] I have tested the endpoints locally
- [x] I verified JSON structure and status mappings
- [x] I registered at least one health check (self)
- [x] The code follows the project's coding and design standards
