### PR TITLE
Add finnhub api health check

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,6 +10,9 @@
   </ItemGroup>
   <ItemGroup Label="Common">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16"/>
+    <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.2" />
+    <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="9.6.0" />
   </ItemGroup>
 </Project>

--- a/src/MCP.FinnHub.Server.SSE/HealthChecks/FinnHubHealthCheck.cs
+++ b/src/MCP.FinnHub.Server.SSE/HealthChecks/FinnHubHealthCheck.cs
@@ -1,0 +1,35 @@
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Options;
+using MCP.FinnHub.Server.SSE.Options;
+
+namespace MCP.FinnHub.Server.SSE.HealthChecks;
+
+public sealed class FinnHubHealthCheck(IHttpClientFactory httpClientFactory, IOptions<FinnHubOptions> options)
+    : IHealthCheck
+{
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient("finnhub");
+    private readonly FinnHubOptions _options = options.Value;
+
+    public async Task<HealthCheckResult> CheckHealthAsync(
+        HealthCheckContext context,
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            using var request = new HttpRequestMessage(HttpMethod.Get, $"{this._options.BaseUrl}/quote?symbol=IBM");
+            request.Headers.Add("X-Finnhub-Token", this._options.ApiKey);
+            var response = await this._httpClient.SendAsync(request, cancellationToken);
+            return response.IsSuccessStatusCode
+                ? HealthCheckResult.Healthy("FinnHub API is reachable.")
+                : HealthCheckResult.Unhealthy($"FinnHub API returned status code {response.StatusCode}.");
+        }
+        catch (HttpRequestException ex)
+        {
+            return HealthCheckResult.Unhealthy("Exception occurred while accessing FinnHub API.", ex);
+        }
+        catch (TaskCanceledException ex)
+        {
+            return HealthCheckResult.Degraded("FinnHub API request timed out.", ex);
+        }
+    }
+}

--- a/src/MCP.FinnHub.Server.SSE/MCP.FinnHub.Server.SSE.csproj
+++ b/src/MCP.FinnHub.Server.SSE/MCP.FinnHub.Server.SSE.csproj
@@ -7,7 +7,7 @@
     <AssemblyTitle>MCP.FinnHub.Server.SSE</AssemblyTitle>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Title>MCP FinnHub Server SSE</Title>
+    <Title>FinnHub MCP Server (SSE)</Title>
     <Description>
       A real-time financial data streaming server built with the official Model Context Protocol (MCP) C# SDK.
       Integrates with the FinnHub API and provides Server-Sent Events (SSE) endpoints to stream live financial data.
@@ -21,5 +21,8 @@
     <PackageReference Include="ModelContextProtocol.AspNetCore" />
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" />
     <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="DotNetEnv" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
+    <PackageReference Include="Microsoft.Extensions.Http.Resilience" />
   </ItemGroup>
 </Project>

--- a/src/MCP.FinnHub.Server.SSE/appsettings.Development.json
+++ b/src/MCP.FinnHub.Server.SSE/appsettings.Development.json
@@ -6,7 +6,7 @@
     }
   },
   "FinnHub": {
-    "ApiKey": "your-api-key-here",
+    "ApiKey": "",
     "BaseUrl": "https://finnhub.io/api/v1",
     "TimeoutSeconds": 10,
     "Endpoints": [

--- a/src/MCP.FinnHub.Server.SSE/appsettings.json
+++ b/src/MCP.FinnHub.Server.SSE/appsettings.json
@@ -7,7 +7,7 @@
   },
   "AllowedHosts": "*",
   "FinnHub": {
-    "ApiKey": "your-api-key-here",
+    "ApiKey": "",
     "BaseUrl": "https://finnhub.io/api/v1",
     "TimeoutSeconds": 10,
     "Endpoints": [


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Other

### What's in this PR

- Implemented a custom `IHealthCheck` class (`FinnHubHealthCheck`) to verify connectivity to the FinnHub API.
- Health check uses `HttpClientFactory` and injects the API key from configuration (`FinnHubOptions`).
- Returns:
  - `Healthy` if API responds with `200 OK`
  - `Unhealthy` if API fails or responds with an error status
- Tagged as `ready` and included in `/health/ready` probe
- Updated `Program.cs` to:
  - Register named `HttpClient` (`"finnhub"`)
  - Register `FinnHubHealthCheck`
  - Use `ValidateOnStart` to ensure configuration is valid

### GitHub Links

- Closes #29

### Tests

- Manually verified health check results using `/health/ready` endpoint
- Simulated failure states by removing the API key or disconnecting network
- Unit tests written using xUnit + NSubstitute for:
  - Healthy response
  - API error
  - Exception during HTTP call

### Checklist

- [x] I have tested the health check locally.
- [x] I added automated unit tests for this check.
- [x] The health check respects timeouts and error handling.
- [x] Configuration uses `IOptions<FinnHubOptions>`.
- [x] All code passes project coding conventions.
- [x] This PR is linked to a GitHub issue or task.
