### PR TITLE
feat(infra): implement FinnHubApiClient with robust error handling an…

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,7 @@
     <PackageVersion Include="DotNetEnv" Version="3.1.1" />
     <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.2" />
     <PackageVersion Include="JsonSchema.Net" Version="7.3.4" />
+    <PackageVersion Include="Polly" Version="8.6.1" />
   </ItemGroup>
 
   <ItemGroup Label="Microsoft">

--- a/src/FinnHub.MCP.Server.Application/Options/FinnHubEndpoint.cs
+++ b/src/FinnHub.MCP.Server.Application/Options/FinnHubEndpoint.cs
@@ -8,7 +8,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 
-namespace FinnHub.MCP.Server.SSE.Options;
+namespace FinnHub.MCP.Server.Application.Options;
 
 /// <summary>
 /// Represents a configuration model for FinnHub API endpoints used by the MCP Server.

--- a/src/FinnHub.MCP.Server.Application/Options/FinnHubOptions.cs
+++ b/src/FinnHub.MCP.Server.Application/Options/FinnHubOptions.cs
@@ -8,7 +8,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Diagnostics.CodeAnalysis;
 
-namespace FinnHub.MCP.Server.SSE.Options;
+namespace FinnHub.MCP.Server.Application.Options;
 
 /// <summary>
 /// Represents the configuration options for integrating with the FinnHub API service.

--- a/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolResponse.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
@@ -46,6 +47,7 @@ namespace FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 /// }
 /// </code>
 /// </example>
+[ExcludeFromCodeCoverage]
 public sealed class SearchSymbolResponse : BaseSearchResponse
 {
     /// <summary>

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -1,0 +1,287 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Search.Clients;
+using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Search;
+
+/// <summary>
+/// Provides HTTP client implementation for searching financial symbols via the FinnHub API.
+/// </summary>
+/// <remarks>
+/// This class implements the <see cref="ISearchClient"/> interface to provide symbol search functionality using the
+/// FinnHub REST API. It handles HTTP communication, error mapping, response deserialization, and proper resource
+/// disposal. The client supports configurable endpoints and includes comprehensive error handling and logging.
+/// </remarks>
+public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+{
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _finnHubOptions;
+    private readonly ILogger<FinnHubSearchApiClient> _logger;
+    private readonly JsonSerializerOptions _jsonOptions;
+    private bool _disposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FinnHubSearchApiClient"/> class.
+    /// </summary>
+    /// <param name="httpClientFactory">The HTTP client factory for creating HTTP clients.</param>
+    /// <param name="options">The FinnHub configuration options.</param>
+    /// <param name="logger">The logger for recording operations and errors.</param>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when any of the required parameters are <c>null</c>.
+    /// </exception>
+    public FinnHubSearchApiClient(
+        IHttpClientFactory httpClientFactory,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubSearchApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClientFactory.CreateClient("FinnHub");
+        this._finnHubOptions = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+
+        this._jsonOptions = new JsonSerializerOptions
+        {
+            WriteIndented = true,
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNameCaseInsensitive = true
+        };
+    }
+
+    /// <summary>
+    /// Searches for financial symbols asynchronously based on the provided query parameters.
+    /// </summary>
+    /// <param name="query">The search query containing the search criteria and parameters.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous search operation. The task result contains
+    /// a <see cref="SearchSymbolResponse"/> with the search results or error information.
+    /// </returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="query"/> is <c>null</c>.
+    /// </exception>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the search symbol endpoint is not configured or inactive.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">
+    /// Thrown when the client has been disposed.
+    /// </exception>
+    /// <exception cref="HttpRequestException">
+    /// Thrown when the HTTP request fails.
+    /// </exception>
+    /// <exception cref="TaskCanceledException">
+    /// Thrown when the request times out.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the operation is canceled via the <paramref name="cancellationToken"/>.
+    /// </exception>
+    public async Task<SearchSymbolResponse> SearchSymbolAsync(SearchSymbolQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+        ObjectDisposedException.ThrowIf(this._disposed, this);
+
+        var stopwatch = Stopwatch.StartNew();
+        var searchTimestamp = DateTime.UtcNow;
+
+        // Get the search endpoint
+        var searchEndpoint = this.GetSearchEndpoint();
+
+        if (searchEndpoint == null)
+        {
+            this._logger.LogError("Search symbol endpoint is not configured or inactive");
+            throw new ArgumentException("Search symbol endpoint is not configured or inactive");
+        }
+
+        var requestUri = this.BuildRequestUri(searchEndpoint, query);
+        this._logger.LogInformation("Requesting search symbols from FinnHub Api: {RequestUri}", requestUri);
+
+        try
+        {
+            this._logger.LogInformation("Starting symbol search for query: {Query} with ID: {QueryId}", query.Query, query.QueryId);
+
+            var stockSymbols = await this.ExecuteSearchRequestAsync(requestUri, cancellationToken);
+
+            return new SearchSymbolResponse
+            {
+                Symbols = stockSymbols.Select(MapToSymbolResult).ToList().AsReadOnly(),
+                Query = query.Query,
+                SearchDuration = stopwatch.Elapsed,
+                SearchTimestamp = searchTimestamp,
+                Source = "FinnHub",
+                IsFromCache = false
+            };
+        }
+
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request failed for symbol search: {Query}", query.Query);
+
+            throw;
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogWarning(ex, "Search request timed out for query: {Query}", query.Query);
+
+            throw;
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogInformation("Search operation was cancelled for query: {Query}", query.Query);
+
+            throw;
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Unexpected error during symbol search: {Query}", query.Query);
+            throw;
+        }
+    }
+
+    /// <summary>
+    /// Gets the active search endpoint URL from the configuration.
+    /// </summary>
+    /// <returns>The search endpoint URL if configured and active; otherwise, <c>null</c>.</returns>
+    private string? GetSearchEndpoint()
+    {
+        return this._finnHubOptions
+            .EndPoints
+            .FirstOrDefault(x => x is { IsActive: true, Name: "search-symbol" })
+            ?.Url;
+    }
+
+    /// <summary>
+    /// Builds the complete request URI for the symbol search API call.
+    /// </summary>
+    /// <param name="searchEndpoint">The search endpoint path.</param>
+    /// <param name="symbolSearchQuery">The search query parameters.</param>
+    /// <returns>The complete request URI with query parameters.</returns>
+    private string BuildRequestUri(string searchEndpoint, SearchSymbolQuery symbolSearchQuery)
+    {
+        var uriBuilder = new StringBuilder()
+            .Append(this._finnHubOptions.BaseUrl.TrimEnd('/'))
+            .Append('/')
+            .Append(searchEndpoint.TrimStart('/'))
+            .Append("?q=")
+            .Append(Uri.EscapeDataString(symbolSearchQuery.Query));
+
+        if (!string.IsNullOrWhiteSpace(symbolSearchQuery.Exchange))
+        {
+            uriBuilder
+                .Append("&exchange=")
+                .Append(Uri.EscapeDataString(symbolSearchQuery.Exchange));
+        }
+
+        // Add the API token if configured
+        if (!string.IsNullOrWhiteSpace(this._finnHubOptions.ApiKey))
+        {
+            uriBuilder
+                .Append("&token=")
+                .Append(Uri.EscapeDataString(this._finnHubOptions.ApiKey));
+        }
+
+        return uriBuilder.ToString();
+    }
+
+    /// <summary>
+    /// Releases all resources used by the <see cref="FinnHubSearchApiClient"/>.
+    /// </summary>
+    public void Dispose()
+    {
+        if (this._disposed)
+        {
+            return;
+        }
+
+        this._disposed = true;
+        this._httpClient.Dispose();
+
+        this._logger.LogDebug("SearchClient disposed");
+    }
+
+    /// <summary>
+    /// Executes the HTTP request to search for symbols and deserializes the response.
+    /// </summary>
+    /// <param name="requestUri">The complete request URI including query parameters.</param>
+    /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
+    /// <returns>
+    /// A task that represents the asynchronous operation. The task result contains
+    /// a read-only list of <see cref="FinnHubSymbolResult"/> objects.
+    /// </returns>
+    /// <exception cref="HttpRequestException">
+    /// Thrown when the HTTP request fails or returns an unsuccessful status code.
+    /// </exception>
+    /// <exception cref="JsonException">
+    /// Thrown when the response content cannot be deserialized.
+    /// </exception>
+    /// <exception cref="OperationCanceledException">
+    /// Thrown when the operation is canceled via the <paramref name="cancellationToken"/>.
+    /// </exception>
+    private async Task<IReadOnlyList<FinnHubSymbolResult>> ExecuteSearchRequestAsync(
+        string requestUri,
+        CancellationToken cancellationToken)
+    {
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+        requestMessage.Headers.Add("X-FinnHub-Token", this._finnHubOptions.ApiKey);
+
+        using var response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync(cancellationToken);
+
+        var finnHubSearchResponse = JsonSerializer.Deserialize<FinnHubSearchResponse>(content, this._jsonOptions);
+
+        if (finnHubSearchResponse is not { Count: > 0 })
+        {
+            this._logger.LogWarning("Received empty response from FinnHub Api");
+            return Array.Empty<FinnHubSymbolResult>().AsReadOnly();
+        }
+
+        return finnHubSearchResponse
+            .Result
+            .Select(x => new FinnHubSymbolResult
+            {
+                Symbol = x.Symbol,
+                Description = x.Description,
+                DisplaySymbol = x.DisplaySymbol,
+                Type = x.Type
+            })
+            .ToList()
+            .AsReadOnly();
+    }
+
+    /// <summary>
+    /// Maps a FinnHub API symbol result to the application symbol result model.
+    /// </summary>
+    /// <param name="finnHubSymbolResult">The API symbol result to map.</param>
+    /// <returns>A <see cref="StockSymbol"/> object mapped from the FinnHub symbol result.</returns>
+    /// <exception cref="ArgumentNullException">
+    /// Thrown when <paramref name="finnHubSymbolResult"/> is <c>null</c>.
+    /// </exception>
+    private static StockSymbol MapToSymbolResult(FinnHubSymbolResult finnHubSymbolResult)
+    {
+        return new StockSymbol
+        {
+            Symbol = finnHubSymbolResult.Symbol ?? string.Empty,
+            Description = finnHubSymbolResult.Description ?? string.Empty,
+            DisplaySymbol = finnHubSymbolResult.DisplaySymbol ?? finnHubSymbolResult.Symbol ?? string.Empty,
+            Type = finnHubSymbolResult.Type ?? string.Empty,
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSearchResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSearchResponse.cs
@@ -1,0 +1,28 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>
+/// Represents the FinnHub API response structure for symbol search.
+/// </summary>
+public sealed class FinnHubSearchResponse
+{
+    /// <summary>
+    /// Gets or sets the search results from the FinnHub API.
+    /// </summary>
+    [JsonPropertyName("result")]
+    public required List<FinnHubSymbolResult> Result { get; init; }
+
+    /// <summary>
+    /// Gets or sets the result count from the FinnHub API.
+    /// </summary>
+    [JsonPropertyName("count")]
+    public int Count { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSymbolResult.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSymbolResult.cs
@@ -1,0 +1,40 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>
+/// Represents a single symbol result from the FinnHub API.
+/// </summary>
+public sealed class FinnHubSymbolResult
+{
+    /// <summary>
+    /// Gets or sets the symbol ticker.
+    /// </summary>
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symbol description.
+    /// </summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Gets or sets the display symbol.
+    /// </summary>
+    [JsonPropertyName("displaySymbol")]
+    public string? DisplaySymbol { get; set; }
+
+    /// <summary>
+    /// Gets or sets the symbol type.
+    /// </summary>
+    [JsonPropertyName("type")]
+    public string? Type { get; set; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -1,0 +1,68 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Net.Http.Headers;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Search.Clients;
+using FinnHub.MCP.Server.Infrastructure.Clients.Search;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Polly;
+using Polly.CircuitBreaker;
+using Polly.Retry;
+
+namespace FinnHub.MCP.Server.Infrastructure.Extensions;
+
+public static class ServiceCollectionExtension
+{
+    public static void RegisterInfrastructure(this IServiceCollection services)
+    {
+        services.AddHttpClient("FinnHub", (provider, client) =>
+            {
+                var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;
+                client.BaseAddress = new Uri(options.BaseUrl);
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
+                client.DefaultRequestHeaders.UserAgent.ParseAdd("FinnHub-MCP-Server/1.0");
+                client.Timeout = TimeSpan.FromSeconds(30);
+                if (!string.IsNullOrWhiteSpace(options.ApiKey))
+                {
+                    client.DefaultRequestHeaders.Add("X-Finnhub-Token", options.ApiKey);
+                }
+            })
+            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            {
+                MaxConnectionsPerServer = 10,
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            })
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5))
+            .AddPolicyHandler(GetRetryPolicy())
+            .AddPolicyHandler(GetCircuitBreakerPolicy());
+
+        services.AddSingleton<ISearchClient, FinnHubSearchApiClient>();
+    }
+
+    private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy()
+    {
+        return Policy<HttpResponseMessage>
+            .HandleResult(r => !r.IsSuccessStatusCode)
+            .Or<HttpRequestException>()
+            .Or<TaskCanceledException>()
+            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+    }
+
+    private static AsyncCircuitBreakerPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+    {
+        return Policy<HttpResponseMessage>
+            .HandleResult(r => !r.IsSuccessStatusCode)
+            .Or<HttpRequestException>()
+            .CircuitBreakerAsync(
+                handledEventsAllowedBeforeBreaking: 3,
+                durationOfBreak: TimeSpan.FromSeconds(30)
+            );
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
+++ b/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
@@ -16,5 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Http" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
+    <PackageReference Include="Polly" />
   </ItemGroup>
 </Project>

--- a/src/FinnHub.MCP.Server.SSE/FinnHub.MCP.Server.SSE.csproj
+++ b/src/FinnHub.MCP.Server.SSE/FinnHub.MCP.Server.SSE.csproj
@@ -23,8 +23,11 @@
     <PackageReference Include="DotNetEnv" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" />
     <PackageReference Include="JsonSchema.Net" />
+    <PackageReference Include="Polly" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\FinnHub.MCP.Server.Application\FinnHub.MCP.Server.Application.csproj" />
+    <ProjectReference Include="..\FinnHub.MCP.Server.Infrastructure\FinnHub.MCP.Server.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/src/FinnHub.MCP.Server.SSE/Program.cs
+++ b/src/FinnHub.MCP.Server.SSE/Program.cs
@@ -5,12 +5,12 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
-using System.Net.Http.Headers;
 using System.Reflection;
 using DotNetEnv;
+using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Services;
+using FinnHub.MCP.Server.Infrastructure.Extensions;
 using FinnHub.MCP.Server.SSE.Common;
-using FinnHub.MCP.Server.SSE.Options;
 using FinnHub.MCP.Server.SSE.Tools.Search;
 
 var assembly = Assembly.GetEntryAssembly();
@@ -36,6 +36,8 @@ builder.Services
     .Bind(builder.Configuration.GetSection("FinnHub"))
     .ValidateDataAnnotations()
     .ValidateOnStart();
+
+builder.Services.RegisterInfrastructure();
 
 builder.Services.AddSingleton<ISearchService, SearchService>();
 builder.Services.AddSingleton<SearchSymbolTool>();
@@ -66,13 +68,6 @@ builder.Services
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
-
-builder.Services.AddHttpClient("FinnHub", client =>
-    {
-        client.BaseAddress = new Uri(builder.Configuration["FinnHub:BaseUrl"] ?? "https://finnhub.io/api/v1");
-        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-        client.Timeout = TimeSpan.FromSeconds(30);
-    });
 
 builder.Services.AddCors(options =>
 {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
@@ -1,0 +1,396 @@
+﻿
+// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+using FinnHub.MCP.Server.Infrastructure.Clients.Search;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Search;
+
+/// <summary>
+/// Unit tests for the <see cref="FinnHubSearchApiClient"/> class.
+/// </summary>
+public sealed class FinnHubSearchApiClientTests : IDisposable
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly IOptions<FinnHubOptions> _options;
+    private readonly ILogger<FinnHubSearchApiClient> _logger;
+    private readonly FinnHubOptions _finnHubOptions;
+    private FinnHubSearchApiClient _client;
+    private readonly HttpClient _httpClient;
+    private readonly MockHttpMessageHandler _messageHandler;
+
+    public FinnHubSearchApiClientTests()
+    {
+        this._httpClientFactory = Substitute.For<IHttpClientFactory>();
+        this._options = Substitute.For<IOptions<FinnHubOptions>>();
+        this._logger = Substitute.For<ILogger<FinnHubSearchApiClient>>();
+        this._messageHandler = new MockHttpMessageHandler();
+        this._httpClient = new HttpClient(this._messageHandler);
+
+        this._finnHubOptions = new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-api-key",
+            EndPoints =
+            [
+                new FinnHubEndPoint
+                {
+                    Name = "search-symbol",
+                    Url = "search",
+                    IsActive = true
+                }
+            ]
+        };
+
+        this._options.Value.Returns(this._finnHubOptions);
+        this._httpClientFactory.CreateClient("FinnHub").Returns(this._httpClient);
+
+        this._client = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
+    }
+
+    [Fact]
+    public void Constructor_WithNullHttpClientFactory_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new FinnHubSearchApiClient(null!, this._options, this._logger));
+    }
+
+    [Fact]
+    public void Constructor_WithNullOptions_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new FinnHubSearchApiClient(this._httpClientFactory, null!, this._logger));
+    }
+
+    [Fact]
+    public void Constructor_WithNullLogger_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() =>
+            new FinnHubSearchApiClient(this._httpClientFactory, this._options, null!));
+    }
+
+    [Fact]
+    public void Constructor_WithNullOptionsValue_ThrowsArgumentException()
+    {
+        // Arrange
+        var nullOptions = Substitute.For<IOptions<FinnHubOptions>>();
+        nullOptions.Value.Returns((FinnHubOptions)null!);
+
+        // Act & Assert
+        var exception = Assert.Throws<ArgumentException>(() =>
+            new FinnHubSearchApiClient(this._httpClientFactory, nullOptions, this._logger));
+
+        Assert.Equal("FinnHub options cannot be null. (Parameter 'options')", exception.Message);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithNullQuery_ThrowsArgumentNullException()
+    {
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentNullException>(() =>
+            this._client.SearchSymbolAsync(null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithDisposedClient_ThrowsObjectDisposedException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        this._client.Dispose();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithNoActiveEndpoint_ThrowsArgumentException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        this._finnHubOptions.EndPoints.Clear();
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+
+        Assert.Equal("Search symbol endpoint is not configured or inactive", exception.Message);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithInactiveEndpoint_ThrowsArgumentException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+
+        var finnHubOptions = new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-api-key",
+            EndPoints =
+            [
+                new FinnHubEndPoint
+                {
+                    Name = "search-symbol",
+                    Url = "search",
+                    IsActive = false
+                }
+            ]
+        };
+
+        this._options.Value.Returns(finnHubOptions);
+        this._httpClientFactory.CreateClient("FinnHub").Returns(this._httpClient);
+        this._client = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
+
+        // Act & Assert
+        var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+
+        Assert.Equal("Search symbol endpoint is not configured or inactive", exception.Message);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithValidQuery_ReturnsSuccessfulResponse()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        var expectedResponse = new FinnHubSearchResponse
+        {
+            Count = 1,
+            Result =
+            [
+                new FinnHubSymbolResult
+                {
+                    Symbol = "AAPL",
+                    Description = "Apple Inc",
+                    DisplaySymbol = "AAPL",
+                    Type = "Common Stock"
+                }
+            ]
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        });
+
+        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+
+        // Act
+        var result = await this._client.SearchSymbolAsync(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("AAPL", result.Query);
+        Assert.Equal("FinnHub", result.Source);
+        Assert.False(result.IsFromCache);
+        Assert.Single(result.Symbols);
+        Assert.Equal("AAPL", result.Symbols[0].Symbol);
+        Assert.Equal("Apple Inc", result.Symbols[0].Description);
+        Assert.Equal("AAPL", result.Symbols[0].DisplaySymbol);
+        Assert.Equal("Common Stock", result.Symbols[0].Type);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithQueryAndExchange_BuildsCorrectUri()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery
+        {
+            Query = "AAPL",
+            Exchange = "NASDAQ",
+            QueryId = Guid.NewGuid().ToString()
+        };
+
+        var expectedResponse = new FinnHubSearchResponse
+        {
+            Count = 0,
+            Result = new List<FinnHubSymbolResult>()
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        });
+
+        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+
+        // Act
+        await this._client.SearchSymbolAsync(query, CancellationToken.None);
+
+        // Assert
+        var requestUri = this._messageHandler.LastRequest?.RequestUri?.ToString();
+        Assert.NotNull(requestUri);
+        Assert.Contains("q=AAPL", requestUri);
+        Assert.Contains("exchange=NASDAQ", requestUri);
+        Assert.Contains("token=test-api-key", requestUri);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithEmptyResponse_ReturnsEmptySymbolsList()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "INVALID", QueryId = Guid.NewGuid().ToString() };
+        var expectedResponse = new FinnHubSearchResponse
+        {
+            Count = 0,
+            Result = []
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        });
+
+        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+
+        // Act
+        var result = await this._client.SearchSymbolAsync(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Empty(result.Symbols);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithHttpRequestException_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        this._messageHandler.SetException(new HttpRequestException("Network error"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithTaskCancelledException_ThrowsTaskCanceledException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        this._messageHandler.SetException(new TaskCanceledException("Request timed out", new TimeoutException()));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithCancellationToken_ThrowsOperationCanceledException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+            this._client.SearchSymbolAsync(query, cts.Token));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithUnauthorizedResponse_ThrowsHttpRequestException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        this._messageHandler.SetResponse(HttpStatusCode.Unauthorized, "Unauthorized");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<HttpRequestException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithInvalidJson_ThrowsJsonException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+        this._messageHandler.SetResponse(HttpStatusCode.OK, "invalid json");
+
+        // Act & Assert
+        await Assert.ThrowsAsync<JsonException>(() =>
+            this._client.SearchSymbolAsync(query, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_WithNullSymbolFields_HandlesNullValues()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { Query = "TEST", QueryId = Guid.NewGuid().ToString() };
+        var expectedResponse = new FinnHubSearchResponse
+        {
+            Count = 1,
+            Result =
+            [
+                new FinnHubSymbolResult
+                {
+                    Symbol = null,
+                    Description = null,
+                    DisplaySymbol = null,
+                    Type = null
+                }
+            ]
+        };
+
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+        {
+            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+        });
+
+        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+
+        // Act
+        var result = await this._client.SearchSymbolAsync(query, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Single(result.Symbols);
+        var symbol = result.Symbols.First();
+        Assert.Equal(string.Empty, symbol.Symbol);
+        Assert.Equal(string.Empty, symbol.Description);
+        Assert.Equal(string.Empty, symbol.DisplaySymbol);
+        Assert.Equal(string.Empty, symbol.Type);
+    }
+
+    [Fact]
+    public void Dispose_CalledOnce_DisposesResourcesAndLogsDebug()
+    {
+        // Act
+        this._client.Dispose();
+
+        // Assert
+        this._logger.Received(1).LogDebug("SearchClient disposed");
+    }
+
+    [Fact]
+    public void Dispose_CalledMultipleTimes_DoesNotThrow()
+    {
+        // Act & Assert
+        this._client.Dispose();
+        this._client.Dispose(); // Should not throw
+    }
+
+    public void Dispose()
+    {
+        this._client?.Dispose();
+        this._httpClient?.Dispose();
+        this._messageHandler?.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/FinnHub.MCP.Server.Infrastructure.Tests.Unit.csproj
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/FinnHub.MCP.Server.Infrastructure.Tests.Unit.csproj
@@ -16,5 +16,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\FinnHub.MCP.Server.Application\FinnHub.MCP.Server.Application.csproj" />
+    <ProjectReference Include="..\..\src\FinnHub.MCP.Server.Infrastructure\FinnHub.MCP.Server.Infrastructure.csproj" />
   </ItemGroup>
 </Project>

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/MockHttpMessageHandler.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/MockHttpMessageHandler.cs
@@ -1,0 +1,59 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit;
+
+/// <summary>
+/// Mock HTTP message handler for unit testing HTTP client behavior.
+/// </summary>
+public class MockHttpMessageHandler : HttpMessageHandler
+{
+    private HttpResponseMessage? _response;
+    private Exception? _exception;
+
+    public HttpRequestMessage? LastRequest { get; private set; }
+
+    public void SetResponse(HttpStatusCode statusCode, string content)
+    {
+        this._response = new HttpResponseMessage(statusCode)
+        {
+            Content = new StringContent(content, Encoding.UTF8, "application/json")
+        };
+
+        this._exception = null;
+    }
+
+    public void SetException(Exception exception)
+    {
+        this._exception = exception;
+        this._response = null;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        this.LastRequest = request;
+
+        if (this._exception != null)
+        {
+            throw this._exception;
+        }
+
+        return Task.FromResult(this._response ?? new HttpResponseMessage(HttpStatusCode.OK));
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            this._response?.Dispose();
+        }
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

- Implemented `FinnHubSearchApiClient` to support symbol search functionality via FinnHub’s REST API.
- Added named `HttpClient` registration using `IHttpClientFactory` with base URL and API key injection via `IOptions<FinnHubOptions>`.
- Integrated Polly for resilient request handling with retry and timeout strategies.
- Created DTOs (`FinnHubSymbolResponse`, `FinnHubSymbolItem`) to deserialise API response models cleanly.
- Introduced FinnHubEndpoint support for search configuration.
- Centralised infrastructure registration in AddFinnHubInfrastructure() and updated `Program.cs`.
- Added unit tests for search client covering success, empty result, invalid JSON, and HTTP failure scenarios.
- Updated package references to include `Polly` and `Microsoft.Extensions.Http.Polly`.

### GitHub Links

- Closes #52 

### Tests

- Run `dotnet test`

### Checklist

- [x] I have tested the changes locally.
- [x] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [x] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [x] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
