### PR TITLE
feat(service): introduce domain-specific exceptions for symbol search

### DIFF
--- a/diff.txt
+++ b/diff.txt
@@ -1,0 +1,922 @@
+diff --git a/src/FinnHub.MCP.Server.Application/Exceptions/FinnHubMcpServerException.cs b/src/FinnHub.MCP.Server.Application/Exceptions/FinnHubMcpServerException.cs
+index 388e394..0e39386 100644
+--- a/src/FinnHub.MCP.Server.Application/Exceptions/FinnHubMcpServerException.cs
++++ b/src/FinnHub.MCP.Server.Application/Exceptions/FinnHubMcpServerException.cs
+@@ -7,4 +7,5 @@
+ 
+ namespace FinnHub.MCP.Server.Application.Exceptions;
+ 
+-public abstract class FinnHubMcpServerException(string message) : ApplicationException(message);
++public abstract class FinnHubMcpServerException(string message, Exception? inner = null)
++    : ApplicationException(message, inner);
+diff --git a/src/FinnHub.MCP.Server.Application/Search/BaseSearchResponse.cs b/src/FinnHub.MCP.Server.Application/Search/BaseSearchResponse.cs
+index fd34d31..8ce6d84 100644
+--- a/src/FinnHub.MCP.Server.Application/Search/BaseSearchResponse.cs
++++ b/src/FinnHub.MCP.Server.Application/Search/BaseSearchResponse.cs
+@@ -47,6 +47,9 @@ public abstract class BaseSearchResponse
+     [JsonPropertyName("query")]
+     public string Query { get; init; } = string.Empty;
+ 
++    [JsonPropertyName("query_id")]
++    public string QueryId { get; init; } = string.Empty;
++
+     /// <summary>
+     /// Gets the duration of time taken to execute the search operation.
+     /// </summary>
+diff --git a/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolException.cs b/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolException.cs
+index 86b4059..857b5c3 100644
+--- a/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolException.cs
++++ b/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolException.cs
+@@ -5,8 +5,33 @@
+ //  </copyright>
+ // ---------------------------------------------------------------------------------------------------------------------
+ 
++using System.Net;
+ using FinnHub.MCP.Server.Application.Exceptions;
+ 
+-namespace FinnHub.MCP.Server.Application.Search;
++namespace FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+ 
+-public class SearchSymbolException(string mess) : FinnHubMcpServerException(mess);
++public abstract class SearchSymbolException(string message, Exception? inner = null)
++    : FinnHubMcpServerException(message, inner)
++{
++    public virtual string ErrorCode => "SEARCH_SYMBOL_ERROR";
++}
++
++public sealed class SearchSymbolHttpException(string message, HttpStatusCode statusCode, string? responseContent = null)
++    : SearchSymbolException(message)
++{
++    public HttpStatusCode StatusCode { get; } = statusCode;
++
++    public string? ResponseContent { get; } = responseContent;
++}
++
++public sealed class SearchSymbolTimeoutException(string message, Exception? innerException = null)
++    : SearchSymbolException(message, innerException);
++
++public sealed class SearchSymbolDeserializationException(string message, Exception? innerException = null)
++    : SearchSymbolException(message, innerException);
++
++public sealed class SearchSymbolCancelledException(string message, Exception? innerException = null)
++    : SearchSymbolException(message, innerException);
++
++public sealed class SearchSymbolUnexpectedException(string message, Exception? innerException = null)
++    : SearchSymbolException(message, innerException);
+diff --git a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+index 77a2d1d..6902e87 100644
+--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
++++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+@@ -28,37 +28,36 @@ public sealed class SearchService(
+         {
+             var response = await searchClient.SearchSymbolAsync(query, cancellationToken);
+ 
+-            logger.Log(LogLevel.Information, "Retrieved {ResponseTotalCount} symbols for query: {Query}", response.TotalCount, query);
++            logger.Log(LogLevel.Information, "Retrieved {ResponseTotalCount} symbols for query: {Query}",
++                response.TotalCount, query);
+ 
+             return response.HasResults
+                 ? new Result<SearchSymbolResponse>().Success(response)
+                 : new Result<SearchSymbolResponse>().Failure("No search symbol(s) found.", ResultErrorType.NotFound);
+         }
+-        catch (HttpRequestException ex)
++        catch (SearchSymbolHttpException ex)
+         {
+-            logger.Log(LogLevel.Error, ex, "HTTP request to FinnHub Api failed for query: {Query}", query.Query);
+-
+-            return new Result<SearchSymbolResponse>()
+-                .Failure("Service temporarily unavailable", ResultErrorType.ServiceUnavailable);
++            logger.LogError(ex, "HTTP error from FinnHub API for query: {Query} (Status: {StatusCode})", query.Query, ex.StatusCode.ToString());
++            return new Result<SearchSymbolResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+         }
+-        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
++        catch (SearchSymbolTimeoutException ex)
+         {
+             logger.Log(LogLevel.Warning, ex, "Request to FinnHub Api timed out for query: {Query}", query.Query);
+-
+-            return new Result<SearchSymbolResponse>()
+-                .Failure("Request timed out", ResultErrorType.Timeout);
++            return new Result<SearchSymbolResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+         }
+-        catch (JsonException ex)
++        catch (SearchSymbolDeserializationException ex)
+         {
+             logger.Log(LogLevel.Error, ex, "Failed to deserialize response from FinnHub Api for query: {Query}", query.Query);
+-
+-            return new Result<SearchSymbolResponse>()
+-                .Failure("Invalid response from service", ResultErrorType.InvalidResponse);
++            return new Result<SearchSymbolResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
++        }
++        catch (SearchSymbolException ex)
++        {
++            logger.LogError(ex, "Unexpected symbol search failure for query: {Query}", query.Query);
++            return new Result<SearchSymbolResponse>().Failure("Symbol search failed unexpectedly");
+         }
+         catch (Exception ex)
+         {
+             logger.Log(LogLevel.Error, ex, "Unexpected error occurred while searching symbols for query: {Query}", query.Query);
+-
+             throw;
+         }
+     }
+diff --git a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+index 7500ace..0a52d58 100644
+--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
++++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+@@ -6,6 +6,7 @@
+ // ---------------------------------------------------------------------------------------------------------------------
+ 
+ using System.Diagnostics;
++using System.Net;
+ using System.Text;
+ using System.Text.Json;
+ using System.Text.Json.Serialization;
+@@ -22,9 +23,8 @@ namespace FinnHub.MCP.Server.Infrastructure.Clients.Search;
+ /// Provides HTTP client implementation for searching financial symbols via the FinnHub API.
+ /// </summary>
+ /// <remarks>
+-/// This class implements the <see cref="ISearchClient"/> interface to provide symbol search functionality using the
+-/// FinnHub REST API. It handles HTTP communication, error mapping, response deserialization, and proper resource
+-/// disposal. The client supports configurable endpoints and includes comprehensive error handling and logging.
++/// Implements <see cref="ISearchClient"/> to offer search functionality via FinnHub’s REST API.
++/// This includes endpoint configuration, error handling, deserialization, and logging.
+ /// </remarks>
+ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+ {
+@@ -37,12 +37,9 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+     /// <summary>
+     /// Initializes a new instance of the <see cref="FinnHubSearchApiClient"/> class.
+     /// </summary>
+-    /// <param name="httpClientFactory">The HTTP client factory for creating HTTP clients.</param>
+-    /// <param name="options">The FinnHub configuration options.</param>
+-    /// <param name="logger">The logger for recording operations and errors.</param>
+-    /// <exception cref="ArgumentNullException">
+-    /// Thrown when any of the required parameters are <c>null</c>.
+-    /// </exception>
++    /// <param name="httpClientFactory">Factory to create named HTTP clients.</param>
++    /// <param name="options">Configuration options for the FinnHub API.</param>
++    /// <param name="logger">Logger for diagnostics and monitoring.</param>
+     public FinnHubSearchApiClient(
+         IHttpClientFactory httpClientFactory,
+         IOptions<FinnHubOptions> options,
+@@ -66,33 +63,15 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+     }
+ 
+     /// <summary>
+-    /// Searches for financial symbols asynchronously based on the provided query parameters.
++    ///
+     /// </summary>
+-    /// <param name="query">The search query containing the search criteria and parameters.</param>
+-    /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
+-    /// <returns>
+-    /// A task that represents the asynchronous search operation. The task result contains
+-    /// a <see cref="SearchSymbolResponse"/> with the search results or error information.
+-    /// </returns>
+-    /// <exception cref="ArgumentNullException">
+-    /// Thrown when <paramref name="query"/> is <c>null</c>.
+-    /// </exception>
+-    /// <exception cref="ArgumentException">
+-    /// Thrown when the search symbol endpoint is not configured or inactive.
+-    /// </exception>
+-    /// <exception cref="ObjectDisposedException">
+-    /// Thrown when the client has been disposed.
+-    /// </exception>
+-    /// <exception cref="HttpRequestException">
+-    /// Thrown when the HTTP request fails.
+-    /// </exception>
+-    /// <exception cref="TaskCanceledException">
+-    /// Thrown when the request times out.
+-    /// </exception>
+-    /// <exception cref="OperationCanceledException">
+-    /// Thrown when the operation is canceled via the <paramref name="cancellationToken"/>.
+-    /// </exception>
+-    public async Task<SearchSymbolResponse> SearchSymbolAsync(SearchSymbolQuery query, CancellationToken cancellationToken)
++    /// <param name="query"></param>
++    /// <param name="cancellationToken"></param>
++    /// <returns></returns>
++    /// <exception cref="SearchSymbolUnexpectedException"></exception>
++    public async Task<SearchSymbolResponse> SearchSymbolAsync(
++        SearchSymbolQuery query,
++        CancellationToken cancellationToken = default)
+     {
+         ArgumentNullException.ThrowIfNull(query);
+         ObjectDisposedException.ThrowIf(this._disposed, this);
+@@ -100,64 +79,37 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+         var stopwatch = Stopwatch.StartNew();
+         var searchTimestamp = DateTime.UtcNow;
+ 
+-        // Get the search endpoint
+-        var searchEndpoint = this.GetSearchEndpoint();
+-
+-        if (searchEndpoint == null)
+-        {
+-            this._logger.LogError("Search symbol endpoint is not configured or inactive");
+-            throw new ArgumentException("Search symbol endpoint is not configured or inactive");
+-        }
+-
+-        var requestUri = this.BuildRequestUri(searchEndpoint, query);
+-        this._logger.LogInformation("Requesting search symbols from FinnHub Api: {RequestUri}", requestUri);
++        this._logger.LogInformation("Starting symbol search for query: {Query} with ID: {QueryId}", query.Query, query.QueryId);
+ 
+         try
+         {
+-            this._logger.LogInformation("Starting symbol search for query: {Query} with ID: {QueryId}", query.Query, query.QueryId);
+-
+-            var stockSymbols = await this.ExecuteSearchRequestAsync(requestUri, cancellationToken);
+-
+-            return new SearchSymbolResponse
+-            {
+-                Symbols = stockSymbols.Select(MapToSymbolResult).ToList().AsReadOnly(),
+-                Query = query.Query,
+-                SearchDuration = stopwatch.Elapsed,
+-                SearchTimestamp = searchTimestamp,
+-                Source = "FinnHub",
+-                IsFromCache = false
+-            };
+-        }
++            var searchEndpoint = this.GetSearchEndpoint();
++            ValidateEndpoint(searchEndpoint);
+ 
+-        catch (HttpRequestException ex)
+-        {
+-            this._logger.LogError(ex, "HTTP request failed for symbol search: {Query}", query.Query);
++            var requestUri = this.BuildRequestUri(searchEndpoint, query);
++            this._logger.LogInformation("Requesting search symbols from FinnHub API: {RequestUri}", requestUri);
+ 
+-            throw;
+-        }
+-        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+-        {
+-            this._logger.LogWarning(ex, "Search request timed out for query: {Query}", query.Query);
++            var stockSymbols = await this.ExecuteSearchRequestAsync(requestUri, cancellationToken).ConfigureAwait(false);
+ 
+-            throw;
++            return CreateSuccessResponse(query, stopwatch.Elapsed, searchTimestamp, stockSymbols);
+         }
+-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
++        catch (Exception ex) when (ex is not (
++                     SearchSymbolHttpException or
++                     SearchSymbolDeserializationException or
++                     SearchSymbolTimeoutException or
++                     SearchSymbolCancelledException or
++                     SearchSymbolUnexpectedException or
++                     ArgumentException))
+         {
+-            this._logger.LogInformation("Search operation was cancelled for query: {Query}", query.Query);
+-
+-            throw;
+-        }
+-        catch (Exception ex)
+-        {
+-            this._logger.LogError(ex, "Unexpected error during symbol search: {Query}", query.Query);
+-            throw;
++            this._logger.LogError(ex, "Unexpected error during symbol search for query: {Query}", query.Query);
++            throw new SearchSymbolUnexpectedException($"Unexpected error during symbol search: {query.Query}", ex);
+         }
+     }
+ 
+     /// <summary>
+     /// Gets the active search endpoint URL from the configuration.
+     /// </summary>
+-    /// <returns>The search endpoint URL if configured and active; otherwise, <c>null</c>.</returns>
++    /// <returns>The search endpoint URL, or <c>null</c> if none is active.</returns>
+     private string? GetSearchEndpoint()
+     {
+         return this._finnHubOptions
+@@ -167,41 +119,19 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+     }
+ 
+     /// <summary>
+-    /// Builds the complete request URI for the symbol search API call.
++    /// Validates that the search endpoint is properly configured.
+     /// </summary>
+-    /// <param name="searchEndpoint">The search endpoint path.</param>
+-    /// <param name="symbolSearchQuery">The search query parameters.</param>
+-    /// <returns>The complete request URI with query parameters.</returns>
+-    private string BuildRequestUri(string searchEndpoint, SearchSymbolQuery symbolSearchQuery)
++    /// <param name="searchEndpoint">The endpoint to validate.</param>
++    /// <exception cref="ArgumentException">Thrown if endpoint is null or whitespace.</exception>
++    private static void ValidateEndpoint(string? searchEndpoint)
+     {
+-        var uriBuilder = new StringBuilder()
+-            .Append(this._finnHubOptions.BaseUrl.TrimEnd('/'))
+-            .Append('/')
+-            .Append(searchEndpoint.TrimStart('/'))
+-            .Append("?q=")
+-            .Append(Uri.EscapeDataString(symbolSearchQuery.Query));
+-
+-        if (!string.IsNullOrWhiteSpace(symbolSearchQuery.Exchange))
++        if (string.IsNullOrWhiteSpace(searchEndpoint) || string.IsNullOrEmpty(searchEndpoint))
+         {
+-            uriBuilder
+-                .Append("&exchange=")
+-                .Append(Uri.EscapeDataString(symbolSearchQuery.Exchange));
+-        }
+-
+-        // Add the API token if configured
+-        if (!string.IsNullOrWhiteSpace(this._finnHubOptions.ApiKey))
+-        {
+-            uriBuilder
+-                .Append("&token=")
+-                .Append(Uri.EscapeDataString(this._finnHubOptions.ApiKey));
++            throw new ArgumentException("Search symbol endpoint is not configured or inactive");
+         }
+-
+-        return uriBuilder.ToString();
+     }
+ 
+-    /// <summary>
+-    /// Releases all resources used by the <see cref="FinnHubSearchApiClient"/>.
+-    /// </summary>
++    /// <inheritdoc />
+     public void Dispose()
+     {
+         if (this._disposed)
+@@ -212,68 +142,81 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+         this._disposed = true;
+         this._httpClient.Dispose();
+ 
+-        this._logger.LogDebug("SearchClient disposed");
++        this._logger.Log(LogLevel.Debug, "FinnHubSearchApiClient disposed.");
+     }
+ 
+     /// <summary>
+-    /// Executes the HTTP request to search for symbols and deserializes the response.
++    /// Executes the HTTP request to the FinnHub API and processes the response.
+     /// </summary>
+-    /// <param name="requestUri">The complete request URI including query parameters.</param>
+-    /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
+-    /// <returns>
+-    /// A task that represents the asynchronous operation. The task result contains
+-    /// a read-only list of <see cref="FinnHubSymbolResult"/> objects.
+-    /// </returns>
+-    /// <exception cref="HttpRequestException">
+-    /// Thrown when the HTTP request fails or returns an unsuccessful status code.
+-    /// </exception>
+-    /// <exception cref="JsonException">
+-    /// Thrown when the response content cannot be deserialized.
+-    /// </exception>
+-    /// <exception cref="OperationCanceledException">
+-    /// Thrown when the operation is canceled via the <paramref name="cancellationToken"/>.
+-    /// </exception>
++    /// <param name="requestUri">The full request URI.</param>
++    /// <param name="cancellationToken">The cancellation token.</param>
++    /// <returns>A list of search results.</returns>
+     private async Task<IReadOnlyList<FinnHubSymbolResult>> ExecuteSearchRequestAsync(
+         string requestUri,
+         CancellationToken cancellationToken)
+     {
+-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+-        requestMessage.Headers.Add("X-FinnHub-Token", this._finnHubOptions.ApiKey);
++        using var requestMessage = this.CreateHttpRequest(requestUri);
+ 
+-        using var response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+-        response.EnsureSuccessStatusCode();
++        var response = await this.SendRequestAsync(requestMessage, requestUri, cancellationToken).ConfigureAwait(false);
+ 
+-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
++        return await this.ProcessResponseAsync(response, requestUri, cancellationToken).ConfigureAwait(false);
++    }
+ 
+-        var finnHubSearchResponse = JsonSerializer.Deserialize<FinnHubSearchResponse>(content, this._jsonOptions);
++    /// <summary>
++    /// Creates an HTTP request with the FinnHub API key.
++    /// </summary>
++    /// <param name="requestUri">The request URI.</param>
++    /// <returns>The configured <see cref="HttpRequestMessage"/>.</returns>
++    private HttpRequestMessage CreateHttpRequest(string requestUri)
++    {
++        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+ 
+-        if (finnHubSearchResponse is not { Count: > 0 })
++        if (!string.IsNullOrWhiteSpace(this._finnHubOptions.ApiKey))
+         {
+-            this._logger.LogWarning("Received empty response from FinnHub Api");
+-            return Array.Empty<FinnHubSymbolResult>().AsReadOnly();
++            request.Headers.Add("X-FinnHub-Token", this._finnHubOptions.ApiKey);
+         }
+ 
+-        return finnHubSearchResponse
+-            .Result
+-            .Select(x => new FinnHubSymbolResult
+-            {
+-                Symbol = x.Symbol,
+-                Description = x.Description,
+-                DisplaySymbol = x.DisplaySymbol,
+-                Type = x.Type
+-            })
+-            .ToList()
+-            .AsReadOnly();
++        return request;
++    }
++
++    /// <summary>
++    /// Sends an HTTP request and wraps known failure cases into domain-specific exceptions.
++    /// </summary>
++    /// <param name="requestMessage">The HTTP request message.</param>
++    /// <param name="requestUri">The originating URI for logging context.</param>
++    /// <param name="cancellationToken">The cancellation token.</param>
++    /// <returns>The HTTP response message.</returns>
++    private async Task<HttpResponseMessage> SendRequestAsync(
++        HttpRequestMessage requestMessage,
++        string requestUri,
++        CancellationToken cancellationToken)
++    {
++        try
++        {
++            return await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
++        }
++        catch (HttpRequestException ex)
++        {
++            this._logger.LogError(ex, "HTTP request to FinnHub API failed. URI: {RequestUri}", requestUri);
++            throw new SearchSymbolHttpException($"HTTP request to FinnHub API failed: {requestUri}", HttpStatusCode.InternalServerError);
++        }
++        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
++        {
++            this._logger.LogError(ex, "Symbol search request timed out: {RequestUri}", requestUri);
++            throw new SearchSymbolTimeoutException($"Symbol search timed out: {requestUri}", ex);
++        }
++        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
++        {
++            this. _logger.LogWarning("Symbol search operation was cancelled: {RequestUri}", requestUri);
++            throw new SearchSymbolCancelledException($"Symbol search cancelled: {requestUri}");
++        }
+     }
+ 
+     /// <summary>
+-    /// Maps a FinnHub API symbol result to the application symbol result model.
++    ///
+     /// </summary>
+-    /// <param name="finnHubSymbolResult">The API symbol result to map.</param>
+-    /// <returns>A <see cref="StockSymbol"/> object mapped from the FinnHub symbol result.</returns>
+-    /// <exception cref="ArgumentNullException">
+-    /// Thrown when <paramref name="finnHubSymbolResult"/> is <c>null</c>.
+-    /// </exception>
++    /// <param name="finnHubSymbolResult">The raw result from the FinnHub API.</param>
++    /// <returns>A <see cref="StockSymbol"/> mapped result.</returns>
+     private static StockSymbol MapToSymbolResult(FinnHubSymbolResult finnHubSymbolResult)
+     {
+         return new StockSymbol
+@@ -281,7 +224,169 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
+             Symbol = finnHubSymbolResult.Symbol ?? string.Empty,
+             Description = finnHubSymbolResult.Description ?? string.Empty,
+             DisplaySymbol = finnHubSymbolResult.DisplaySymbol ?? finnHubSymbolResult.Symbol ?? string.Empty,
+-            Type = finnHubSymbolResult.Type ?? string.Empty,
++            Type = finnHubSymbolResult.Type ?? string.Empty
+         };
+     }
++
++    /// <summary>
++    /// Builds the final success response object.
++    /// </summary>
++    /// <param name="query">The original query submitted by the client.</param>
++    /// <param name="duration">How long the search took to execute.</param>
++    /// <param name="timestamp">The UTC timestamp when search began.</param>
++    /// <param name="stockSymbols">The raw symbol results.</param>
++    /// <returns>A <see cref="SearchSymbolResponse"/> object to return to the MCP client.</returns>
++    private static SearchSymbolResponse CreateSuccessResponse(
++        SearchSymbolQuery query,
++        TimeSpan duration,
++        DateTime timestamp,
++        IReadOnlyList<FinnHubSymbolResult> stockSymbols)
++    {
++        return new SearchSymbolResponse
++        {
++            Query = query.Query,
++            QueryId = query.QueryId,
++            SearchDuration = duration,
++            SearchTimestamp = timestamp,
++            Source = "finnhub-api",
++            Symbols = stockSymbols
++                .Select(MapToSymbolResult)
++                .ToList()
++                .AsReadOnly(),
++        };
++    }
++
++    /// <summary>
++    /// Validates the HTTP response, throws meaningful exceptions on failure,
++    /// and deserializes valid responses into a list of <see cref="FinnHubSymbolResult"/>.
++    /// </summary>
++    /// <param name="response">The HTTP response message from FinnHub API.</param>
++    /// <param name="requestUri">The originating request URI (for logging and debugging).</param>
++    /// <param name="cancellationToken">The token used to monitor for cancellation requests.</param>
++    /// <returns>A list of <see cref="FinnHubSymbolResult"/> if response is successful.</returns>
++    /// <exception cref="SearchSymbolHttpException">When the API response status is not successful.</exception>
++    /// <exception cref="SearchSymbolDeserializationException">When the API response cannot be parsed.</exception>
++    private async Task<IReadOnlyList<FinnHubSymbolResult>> ProcessResponseAsync(
++        HttpResponseMessage response,
++        string requestUri,
++        CancellationToken cancellationToken)
++    {
++        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
++
++        if (!response.IsSuccessStatusCode)
++        {
++            await this.HandleErrorResponseAsync(response, contentStream, cancellationToken);
++        }
++
++        return await this.DeserializeResponseAsync(contentStream, requestUri, cancellationToken).ConfigureAwait(false);
++    }
++
++     /// <summary>
++    /// Handles HTTP responses with non-success status codes by reading the body and logging an appropriate message.
++    /// </summary>
++    /// <param name="response">The response with error status.</param>
++    /// <param name="contentStream">The stream containing response body.</param>
++    /// <param name="cancellationToken">A cancellation token.</param>
++    /// <exception cref="SearchSymbolHttpException">Thrown with enriched details about the error.</exception>
++    private async Task HandleErrorResponseAsync(
++        HttpResponseMessage response,
++        Stream contentStream,
++        CancellationToken cancellationToken)
++    {
++        var statusCode = response.StatusCode;
++        contentStream.Position = 0;
++
++        using var reader = new StreamReader(contentStream);
++        var errorBody = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
++
++        if ((int)statusCode >= 400 && (int)statusCode < 500)
++        {
++            this._logger.LogWarning("Client error from FinnHub API: {StatusCode} - {Content}", statusCode, errorBody);
++        }
++        else
++        {
++            this._logger.LogError("Server error from FinnHub API: {StatusCode} - {Content}", statusCode, errorBody);
++        }
++
++        throw new SearchSymbolHttpException(
++            $"FinnHub API returned error status {statusCode}. See logs for more detail.",
++            statusCode,
++            errorBody);
++    }
++
++    /// <summary>
++    /// Deserializes a successful JSON response into a strongly typed result object.
++    /// </summary>
++    /// <param name="contentStream">The response content stream.</param>
++    /// <param name="requestUri">The request URI (used for logging context).</param>
++    /// <param name="cancellationToken">The cancellation token.</param>
++    /// <returns>A list of <see cref="FinnHubSymbolResult"/> or an empty list.</returns>
++    /// <exception cref="SearchSymbolDeserializationException">If deserialization fails.</exception>
++    private async Task<IReadOnlyList<FinnHubSymbolResult>> DeserializeResponseAsync(
++        Stream contentStream,
++        string requestUri,
++        CancellationToken cancellationToken)
++    {
++        try
++        {
++            var response = await JsonSerializer
++                .DeserializeAsync<FinnHubSearchResponse>(contentStream, this._jsonOptions, cancellationToken)
++                .ConfigureAwait(false);
++
++            if (response?.Count == 0 || response?.Result == null || response.Result.Count == 0)
++            {
++                this._logger.LogInformation("FinnHub returned no results for request: {RequestUri}", requestUri);
++                return Array.Empty<FinnHubSymbolResult>().AsReadOnly();
++            }
++
++            return response.Result
++                .Select(result => new FinnHubSymbolResult
++                {
++                    Symbol = result.Symbol,
++                    Description = result.Description,
++                    DisplaySymbol = result.DisplaySymbol,
++                    Type = result.Type
++                })
++                .ToList()
++                .AsReadOnly();
++        }
++        catch (JsonException ex)
++        {
++            this._logger.LogError(ex, "Failed to deserialize FinnHub API response.");
++            throw new SearchSymbolDeserializationException("Invalid JSON returned from FinnHub API.", ex);
++        }
++    }
++
++    /// <summary>
++    /// Constructs the full request URI for the FinnHub symbol search endpoint.
++    /// </summary>
++    /// <param name="searchEndpoint">The endpoint path to be used for symbol search.</param>
++    /// <param name="query">The search query containing symbol and exchange information.</param>
++    /// <returns>A fully qualified request URI string with query parameters.</returns>
++    /// <exception cref="ArgumentNullException">Thrown if <paramref name="searchEndpoint"/> or <paramref name="query"/> is null.</exception>
++    private string BuildRequestUri(string? searchEndpoint, SearchSymbolQuery query)
++    {
++        ArgumentNullException.ThrowIfNull(searchEndpoint);
++        ArgumentNullException.ThrowIfNull(query);
++
++        var baseUrl = this._finnHubOptions.BaseUrl.TrimEnd('/');
++        var endpoint = searchEndpoint.TrimStart('/');
++        var queryParam = Uri.EscapeDataString(query.Query);
++
++        var uriBuilder = new StringBuilder()
++            .Append(baseUrl)
++            .Append('/')
++            .Append(endpoint)
++            .Append("?q=")
++            .Append(queryParam);
++
++        if (!string.IsNullOrWhiteSpace(query.Exchange))
++        {
++            uriBuilder
++                .Append("&exchange=")
++                .Append(Uri.EscapeDataString(query.Exchange));
++        }
++
++        return uriBuilder.ToString();
++    }
+ }
+diff --git a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
+index 54c2a88..c0e4d3c 100644
+--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
++++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
+@@ -5,6 +5,7 @@
+ //  </copyright>
+ // ---------------------------------------------------------------------------------------------------------------------
+ 
++using System.Net;
+ using FinnHub.MCP.Server.Application.Search.Clients;
+ using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+ using FinnHub.MCP.Server.Application.Search.Services;
+@@ -176,7 +177,7 @@ public sealed class SearchServiceTests
+         var query = new SearchSymbolQuery { QueryId = "test", Query = "AAPL" };
+         this._searchClient
+             .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
+-            .ThrowsAsync(new HttpRequestException("Network error"));
++            .ThrowsAsync(new SearchSymbolHttpException("Service temporarily unavailable", HttpStatusCode.ServiceUnavailable));
+ 
+         // Act
+         var result = await this._service.SearchSymbolAsync(query, CancellationToken.None);
+@@ -195,7 +196,7 @@ public sealed class SearchServiceTests
+     {
+         // Arrange
+         var query = new SearchSymbolQuery { QueryId = "test", Query = "AAPL" };
+-        var timeoutException = new TaskCanceledException("Operation timed out", new TimeoutException());
++        var timeoutException = new SearchSymbolTimeoutException("Request timed out", new TimeoutException());
+ 
+         this._searchClient
+             .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
+diff --git a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+index 8a66fd4..3ea6059 100644
+--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
++++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+@@ -28,7 +28,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+     private readonly IOptions<FinnHubOptions> _options;
+     private readonly ILogger<FinnHubSearchApiClient> _logger;
+     private readonly FinnHubOptions _finnHubOptions;
+-    private FinnHubSearchApiClient _client;
++    private FinnHubSearchApiClient _sut;
+     private readonly HttpClient _httpClient;
+     private readonly MockHttpMessageHandler _messageHandler;
+ 
+@@ -57,8 +57,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+ 
+         this._options.Value.Returns(this._finnHubOptions);
+         this._httpClientFactory.CreateClient("FinnHub").Returns(this._httpClient);
+-
+-        this._client = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
++        this._sut = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
+     }
+ 
+     [Fact]
+@@ -104,7 +103,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+     {
+         // Act & Assert
+         await Assert.ThrowsAsync<ArgumentNullException>(() =>
+-            this._client.SearchSymbolAsync(null!, CancellationToken.None));
++            this._sut.SearchSymbolAsync(null!, CancellationToken.None));
+     }
+ 
+     [Fact]
+@@ -112,11 +111,11 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+     {
+         // Arrange
+         var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+-        this._client.Dispose();
++        this._sut.Dispose();
+ 
+         // Act & Assert
+         await Assert.ThrowsAsync<ObjectDisposedException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+     }
+ 
+     [Fact]
+@@ -128,7 +127,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+ 
+         // Act & Assert
+         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+ 
+         Assert.Equal("Search symbol endpoint is not configured or inactive", exception.Message);
+     }
+@@ -156,11 +155,11 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+ 
+         this._options.Value.Returns(finnHubOptions);
+         this._httpClientFactory.CreateClient("FinnHub").Returns(this._httpClient);
+-        this._client = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
++        this._sut = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
+ 
+         // Act & Assert
+         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+ 
+         Assert.Equal("Search symbol endpoint is not configured or inactive", exception.Message);
+     }
+@@ -193,12 +192,13 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+ 
+         // Act
+-        var result = await this._client.SearchSymbolAsync(query, CancellationToken.None);
++        var result = await this._sut.SearchSymbolAsync(query, CancellationToken.None);
+ 
+         // Assert
+         Assert.NotNull(result);
+         Assert.Equal("AAPL", result.Query);
+-        Assert.Equal("FinnHub", result.Source);
++        Assert.NotNull(result.QueryId);
++        Assert.Equal("finnhub-api", result.Source);
+         Assert.False(result.IsFromCache);
+         Assert.Single(result.Symbols);
+         Assert.Equal("AAPL", result.Symbols[0].Symbol);
+@@ -221,7 +221,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         var expectedResponse = new FinnHubSearchResponse
+         {
+             Count = 0,
+-            Result = new List<FinnHubSymbolResult>()
++            Result = []
+         };
+ 
+         var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+@@ -232,14 +232,13 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+ 
+         // Act
+-        await this._client.SearchSymbolAsync(query, CancellationToken.None);
++        await this._sut.SearchSymbolAsync(query, CancellationToken.None);
+ 
+         // Assert
+         var requestUri = this._messageHandler.LastRequest?.RequestUri?.ToString();
+         Assert.NotNull(requestUri);
+         Assert.Contains("q=AAPL", requestUri);
+         Assert.Contains("exchange=NASDAQ", requestUri);
+-        Assert.Contains("token=test-api-key", requestUri);
+     }
+ 
+     [Fact]
+@@ -253,7 +252,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+             Result = []
+         };
+ 
+-        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
++        var jsonResponse =  JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+         {
+             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+         });
+@@ -261,7 +260,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+ 
+         // Act
+-        var result = await this._client.SearchSymbolAsync(query, CancellationToken.None);
++        var result = await this._sut.SearchSymbolAsync(query, CancellationToken.None);
+ 
+         // Assert
+         Assert.NotNull(result);
+@@ -276,20 +275,20 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         this._messageHandler.SetException(new HttpRequestException("Network error"));
+ 
+         // Act & Assert
+-        await Assert.ThrowsAsync<HttpRequestException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++        await Assert.ThrowsAsync<SearchSymbolHttpException>(() =>
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+     }
+ 
+     [Fact]
+-    public async Task SearchSymbolAsync_WithTaskCancelledException_ThrowsTaskCanceledException()
++    public async Task SearchSymbolAsync_WithTaskCancelledException_ThrowsSearchSymbolTimeoutException()
+     {
+         // Arrange
+         var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+         this._messageHandler.SetException(new TaskCanceledException("Request timed out", new TimeoutException()));
+ 
+         // Act & Assert
+-        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++        await Assert.ThrowsAsync<SearchSymbolTimeoutException>(() =>
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+     }
+ 
+     [Fact]
+@@ -301,39 +300,39 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         await cts.CancelAsync();
+ 
+         // Act & Assert
+-        await Assert.ThrowsAsync<TaskCanceledException>(() =>
+-            this._client.SearchSymbolAsync(query, cts.Token));
++        await Assert.ThrowsAsync<SearchSymbolCancelledException>(() =>
++            this._sut.SearchSymbolAsync(query, cts.Token));
+     }
+ 
+     [Fact]
+     public async Task SearchSymbolAsync_WithUnauthorizedResponse_ThrowsHttpRequestException()
+     {
+         // Arrange
+-        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
++        var query = new SearchSymbolQuery {Query = "AAPL", QueryId = Guid.NewGuid().ToString()};
+         this._messageHandler.SetResponse(HttpStatusCode.Unauthorized, "Unauthorized");
+ 
+         // Act & Assert
+-        await Assert.ThrowsAsync<HttpRequestException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++        await Assert.ThrowsAsync<SearchSymbolHttpException>(() =>
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+     }
+ 
+     [Fact]
+     public async Task SearchSymbolAsync_WithInvalidJson_ThrowsJsonException()
+     {
+         // Arrange
+-        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
+-        this._messageHandler.SetResponse(HttpStatusCode.OK, "invalid json");
++        var query = new SearchSymbolQuery {Query = "AAPL", QueryId = Guid.NewGuid().ToString()};
++        this._messageHandler.SetResponse(HttpStatusCode.OK, "invalid_json");
+ 
+         // Act & Assert
+-        await Assert.ThrowsAsync<JsonException>(() =>
+-            this._client.SearchSymbolAsync(query, CancellationToken.None));
++        await Assert.ThrowsAsync<SearchSymbolDeserializationException>(() =>
++            this._sut.SearchSymbolAsync(query, CancellationToken.None));
+     }
+ 
+     [Fact]
+     public async Task SearchSymbolAsync_WithNullSymbolFields_HandlesNullValues()
+     {
+         // Arrange
+-        var query = new SearchSymbolQuery { Query = "TEST", QueryId = Guid.NewGuid().ToString() };
++        var query = new SearchSymbolQuery {Query = "TEST", QueryId = Guid.NewGuid().ToString()};
+         var expectedResponse = new FinnHubSearchResponse
+         {
+             Count = 1,
+@@ -357,40 +356,44 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
+         this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+ 
+         // Act
+-        var result = await this._client.SearchSymbolAsync(query, CancellationToken.None);
++        var result = await this._sut.SearchSymbolAsync(query, CancellationToken.None);
+ 
+         // Assert
+         Assert.NotNull(result);
+         Assert.Single(result.Symbols);
+-        var symbol = result.Symbols.First();
+-        Assert.Equal(string.Empty, symbol.Symbol);
+-        Assert.Equal(string.Empty, symbol.Description);
+-        Assert.Equal(string.Empty, symbol.DisplaySymbol);
+-        Assert.Equal(string.Empty, symbol.Type);
++        Assert.Equal(string.Empty, result.Symbols[0].Symbol);
++        Assert.Equal(string.Empty, result.Symbols[0].Description);
++        Assert.Equal(string.Empty, result.Symbols[0].DisplaySymbol);
++        Assert.Equal(string.Empty, result.Symbols[0].Type);
+     }
+ 
+     [Fact]
+     public void Dispose_CalledOnce_DisposesResourcesAndLogsDebug()
+     {
+         // Act
+-        this._client.Dispose();
++        this._sut.Dispose();
+ 
+         // Assert
+-        this._logger.Received(1).LogDebug("SearchClient disposed");
++        this._logger.Received(1).Log(
++            LogLevel.Debug,
++            Arg.Any<EventId>(),
++            Arg.Is<object>(v => v.ToString() == "FinnHubSearchApiClient disposed."),
++            Arg.Any<Exception>(),
++            Arg.Any<Func<object, Exception, string>>()!);
+     }
+ 
+     [Fact]
+     public void Dispose_CalledMultipleTimes_DoesNotThrow()
+     {
+         // Act & Assert
+-        this._client.Dispose();
+-        this._client.Dispose(); // Should not throw
++        this._sut.Dispose();
++        this._sut.Dispose();
+     }
+ 
+     public void Dispose()
+     {
+-        this._client?.Dispose();
+-        this._httpClient?.Dispose();
+-        this._messageHandler?.Dispose();
++        this._sut.Dispose();
++        this._httpClient.Dispose();
++        this._messageHandler.Dispose();
+     }
+ }

--- a/src/FinnHub.MCP.Server.Application/Exceptions/FinnHubMcpServerException.cs
+++ b/src/FinnHub.MCP.Server.Application/Exceptions/FinnHubMcpServerException.cs
@@ -1,0 +1,11 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Exceptions;
+
+public abstract class FinnHubMcpServerException(string message, Exception? inner = null)
+    : ApplicationException(message, inner);

--- a/src/FinnHub.MCP.Server.Application/Search/BaseSearchResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/BaseSearchResponse.cs
@@ -47,6 +47,9 @@ public abstract class BaseSearchResponse
     [JsonPropertyName("query")]
     public string Query { get; init; } = string.Empty;
 
+    [JsonPropertyName("query_id")]
+    public string QueryId { get; init; } = string.Empty;
+
     /// <summary>
     /// Gets the duration of time taken to execute the search operation.
     /// </summary>

--- a/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolException.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Features/SearchSymbol/SearchSymbolException.cs
@@ -1,0 +1,37 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+
+namespace FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+
+public abstract class SearchSymbolException(string message, Exception? inner = null)
+    : FinnHubMcpServerException(message, inner)
+{
+    public virtual string ErrorCode => "SEARCH_SYMBOL_ERROR";
+}
+
+public sealed class SearchSymbolHttpException(string message, HttpStatusCode statusCode, string? responseContent = null)
+    : SearchSymbolException(message)
+{
+    public HttpStatusCode StatusCode { get; } = statusCode;
+
+    public string? ResponseContent { get; } = responseContent;
+}
+
+public sealed class SearchSymbolTimeoutException(string message, Exception? innerException = null)
+    : SearchSymbolException(message, innerException);
+
+public sealed class SearchSymbolDeserializationException(string message, Exception? innerException = null)
+    : SearchSymbolException(message, innerException);
+
+public sealed class SearchSymbolCancelledException(string message, Exception? innerException = null)
+    : SearchSymbolException(message, innerException);
+
+public sealed class SearchSymbolUnexpectedException(string message, Exception? innerException = null)
+    : SearchSymbolException(message, innerException);

--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
@@ -5,7 +5,6 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
-using System.Text.Json;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;

--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
@@ -28,37 +28,36 @@ public sealed class SearchService(
         {
             var response = await searchClient.SearchSymbolAsync(query, cancellationToken);
 
-            logger.Log(LogLevel.Information, "Retrieved {ResponseTotalCount} symbols for query: {Query}", response.TotalCount, query);
+            logger.Log(LogLevel.Information, "Retrieved {ResponseTotalCount} symbols for query: {Query}",
+                response.TotalCount, query);
 
             return response.HasResults
                 ? new Result<SearchSymbolResponse>().Success(response)
                 : new Result<SearchSymbolResponse>().Failure("No search symbol(s) found.", ResultErrorType.NotFound);
         }
-        catch (HttpRequestException ex)
+        catch (SearchSymbolHttpException ex)
         {
-            logger.Log(LogLevel.Error, ex, "HTTP request to FinnHub Api failed for query: {Query}", query.Query);
-
-            return new Result<SearchSymbolResponse>()
-                .Failure("Service temporarily unavailable", ResultErrorType.ServiceUnavailable);
+            logger.LogError(ex, "HTTP error from FinnHub API for query: {Query} (Status: {StatusCode})", query.Query, ex.StatusCode.ToString());
+            return new Result<SearchSymbolResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
-        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        catch (SearchSymbolTimeoutException ex)
         {
             logger.Log(LogLevel.Warning, ex, "Request to FinnHub Api timed out for query: {Query}", query.Query);
-
-            return new Result<SearchSymbolResponse>()
-                .Failure("Request timed out", ResultErrorType.Timeout);
+            return new Result<SearchSymbolResponse>().Failure("Request timed out", ResultErrorType.Timeout);
         }
-        catch (JsonException ex)
+        catch (SearchSymbolDeserializationException ex)
         {
             logger.Log(LogLevel.Error, ex, "Failed to deserialize response from FinnHub Api for query: {Query}", query.Query);
-
-            return new Result<SearchSymbolResponse>()
-                .Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return new Result<SearchSymbolResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (SearchSymbolException ex)
+        {
+            logger.LogError(ex, "Unexpected symbol search failure for query: {Query}", query.Query);
+            return new Result<SearchSymbolResponse>().Failure("Symbol search failed unexpectedly");
         }
         catch (Exception ex)
         {
             logger.Log(LogLevel.Error, ex, "Unexpected error occurred while searching symbols for query: {Query}", query.Query);
-
             throw;
         }
     }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -6,6 +6,7 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Diagnostics;
+using System.Net;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -22,9 +23,8 @@ namespace FinnHub.MCP.Server.Infrastructure.Clients.Search;
 /// Provides HTTP client implementation for searching financial symbols via the FinnHub API.
 /// </summary>
 /// <remarks>
-/// This class implements the <see cref="ISearchClient"/> interface to provide symbol search functionality using the
-/// FinnHub REST API. It handles HTTP communication, error mapping, response deserialization, and proper resource
-/// disposal. The client supports configurable endpoints and includes comprehensive error handling and logging.
+/// Implements <see cref="ISearchClient"/> to offer search functionality via FinnHub’s REST API.
+/// This includes endpoint configuration, error handling, deserialization, and logging.
 /// </remarks>
 public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
 {
@@ -37,12 +37,9 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="FinnHubSearchApiClient"/> class.
     /// </summary>
-    /// <param name="httpClientFactory">The HTTP client factory for creating HTTP clients.</param>
-    /// <param name="options">The FinnHub configuration options.</param>
-    /// <param name="logger">The logger for recording operations and errors.</param>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when any of the required parameters are <c>null</c>.
-    /// </exception>
+    /// <param name="httpClientFactory">Factory to create named HTTP clients.</param>
+    /// <param name="options">Configuration options for the FinnHub API.</param>
+    /// <param name="logger">Logger for diagnostics and monitoring.</param>
     public FinnHubSearchApiClient(
         IHttpClientFactory httpClientFactory,
         IOptions<FinnHubOptions> options,
@@ -66,33 +63,15 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
     }
 
     /// <summary>
-    /// Searches for financial symbols asynchronously based on the provided query parameters.
+    ///
     /// </summary>
-    /// <param name="query">The search query containing the search criteria and parameters.</param>
-    /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
-    /// <returns>
-    /// A task that represents the asynchronous search operation. The task result contains
-    /// a <see cref="SearchSymbolResponse"/> with the search results or error information.
-    /// </returns>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="query"/> is <c>null</c>.
-    /// </exception>
-    /// <exception cref="ArgumentException">
-    /// Thrown when the search symbol endpoint is not configured or inactive.
-    /// </exception>
-    /// <exception cref="ObjectDisposedException">
-    /// Thrown when the client has been disposed.
-    /// </exception>
-    /// <exception cref="HttpRequestException">
-    /// Thrown when the HTTP request fails.
-    /// </exception>
-    /// <exception cref="TaskCanceledException">
-    /// Thrown when the request times out.
-    /// </exception>
-    /// <exception cref="OperationCanceledException">
-    /// Thrown when the operation is canceled via the <paramref name="cancellationToken"/>.
-    /// </exception>
-    public async Task<SearchSymbolResponse> SearchSymbolAsync(SearchSymbolQuery query, CancellationToken cancellationToken)
+    /// <param name="query"></param>
+    /// <param name="cancellationToken"></param>
+    /// <returns></returns>
+    /// <exception cref="SearchSymbolUnexpectedException"></exception>
+    public async Task<SearchSymbolResponse> SearchSymbolAsync(
+        SearchSymbolQuery query,
+        CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(query);
         ObjectDisposedException.ThrowIf(this._disposed, this);
@@ -100,64 +79,37 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
         var stopwatch = Stopwatch.StartNew();
         var searchTimestamp = DateTime.UtcNow;
 
-        // Get the search endpoint
-        var searchEndpoint = this.GetSearchEndpoint();
-
-        if (searchEndpoint == null)
-        {
-            this._logger.LogError("Search symbol endpoint is not configured or inactive");
-            throw new ArgumentException("Search symbol endpoint is not configured or inactive");
-        }
-
-        var requestUri = this.BuildRequestUri(searchEndpoint, query);
-        this._logger.LogInformation("Requesting search symbols from FinnHub Api: {RequestUri}", requestUri);
+        this._logger.LogInformation("Starting symbol search for query: {Query} with ID: {QueryId}", query.Query, query.QueryId);
 
         try
         {
-            this._logger.LogInformation("Starting symbol search for query: {Query} with ID: {QueryId}", query.Query, query.QueryId);
+            var searchEndpoint = this.GetSearchEndpoint();
+            ValidateEndpoint(searchEndpoint);
 
-            var stockSymbols = await this.ExecuteSearchRequestAsync(requestUri, cancellationToken);
+            var requestUri = this.BuildRequestUri(searchEndpoint, query);
+            this._logger.LogInformation("Requesting search symbols from FinnHub API: {RequestUri}", requestUri);
 
-            return new SearchSymbolResponse
-            {
-                Symbols = stockSymbols.Select(MapToSymbolResult).ToList().AsReadOnly(),
-                Query = query.Query,
-                SearchDuration = stopwatch.Elapsed,
-                SearchTimestamp = searchTimestamp,
-                Source = "FinnHub",
-                IsFromCache = false
-            };
+            var stockSymbols = await this.ExecuteSearchRequestAsync(requestUri, cancellationToken).ConfigureAwait(false);
+
+            return CreateSuccessResponse(query, stopwatch.Elapsed, searchTimestamp, stockSymbols);
         }
-
-        catch (HttpRequestException ex)
+        catch (Exception ex) when (ex is not (
+                     SearchSymbolHttpException or
+                     SearchSymbolDeserializationException or
+                     SearchSymbolTimeoutException or
+                     SearchSymbolCancelledException or
+                     SearchSymbolUnexpectedException or
+                     ArgumentException))
         {
-            this._logger.LogError(ex, "HTTP request failed for symbol search: {Query}", query.Query);
-
-            throw;
-        }
-        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
-        {
-            this._logger.LogWarning(ex, "Search request timed out for query: {Query}", query.Query);
-
-            throw;
-        }
-        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
-        {
-            this._logger.LogInformation("Search operation was cancelled for query: {Query}", query.Query);
-
-            throw;
-        }
-        catch (Exception ex)
-        {
-            this._logger.LogError(ex, "Unexpected error during symbol search: {Query}", query.Query);
-            throw;
+            this._logger.LogError(ex, "Unexpected error during symbol search for query: {Query}", query.Query);
+            throw new SearchSymbolUnexpectedException($"Unexpected error during symbol search: {query.Query}", ex);
         }
     }
 
     /// <summary>
     /// Gets the active search endpoint URL from the configuration.
     /// </summary>
-    /// <returns>The search endpoint URL if configured and active; otherwise, <c>null</c>.</returns>
+    /// <returns>The search endpoint URL, or <c>null</c> if none is active.</returns>
     private string? GetSearchEndpoint()
     {
         return this._finnHubOptions
@@ -167,41 +119,19 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
     }
 
     /// <summary>
-    /// Builds the complete request URI for the symbol search API call.
+    /// Validates that the search endpoint is properly configured.
     /// </summary>
-    /// <param name="searchEndpoint">The search endpoint path.</param>
-    /// <param name="symbolSearchQuery">The search query parameters.</param>
-    /// <returns>The complete request URI with query parameters.</returns>
-    private string BuildRequestUri(string searchEndpoint, SearchSymbolQuery symbolSearchQuery)
+    /// <param name="searchEndpoint">The endpoint to validate.</param>
+    /// <exception cref="ArgumentException">Thrown if endpoint is null or whitespace.</exception>
+    private static void ValidateEndpoint(string? searchEndpoint)
     {
-        var uriBuilder = new StringBuilder()
-            .Append(this._finnHubOptions.BaseUrl.TrimEnd('/'))
-            .Append('/')
-            .Append(searchEndpoint.TrimStart('/'))
-            .Append("?q=")
-            .Append(Uri.EscapeDataString(symbolSearchQuery.Query));
-
-        if (!string.IsNullOrWhiteSpace(symbolSearchQuery.Exchange))
+        if (string.IsNullOrWhiteSpace(searchEndpoint) || string.IsNullOrEmpty(searchEndpoint))
         {
-            uriBuilder
-                .Append("&exchange=")
-                .Append(Uri.EscapeDataString(symbolSearchQuery.Exchange));
+            throw new ArgumentException("Search symbol endpoint is not configured or inactive");
         }
-
-        // Add the API token if configured
-        if (!string.IsNullOrWhiteSpace(this._finnHubOptions.ApiKey))
-        {
-            uriBuilder
-                .Append("&token=")
-                .Append(Uri.EscapeDataString(this._finnHubOptions.ApiKey));
-        }
-
-        return uriBuilder.ToString();
     }
 
-    /// <summary>
-    /// Releases all resources used by the <see cref="FinnHubSearchApiClient"/>.
-    /// </summary>
+    /// <inheritdoc />
     public void Dispose()
     {
         if (this._disposed)
@@ -212,68 +142,81 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
         this._disposed = true;
         this._httpClient.Dispose();
 
-        this._logger.LogDebug("SearchClient disposed");
+        this._logger.Log(LogLevel.Debug, "FinnHubSearchApiClient disposed.");
     }
 
     /// <summary>
-    /// Executes the HTTP request to search for symbols and deserializes the response.
+    /// Executes the HTTP request to the FinnHub API and processes the response.
     /// </summary>
-    /// <param name="requestUri">The complete request URI including query parameters.</param>
-    /// <param name="cancellationToken">A cancellation token to cancel the asynchronous operation.</param>
-    /// <returns>
-    /// A task that represents the asynchronous operation. The task result contains
-    /// a read-only list of <see cref="FinnHubSymbolResult"/> objects.
-    /// </returns>
-    /// <exception cref="HttpRequestException">
-    /// Thrown when the HTTP request fails or returns an unsuccessful status code.
-    /// </exception>
-    /// <exception cref="JsonException">
-    /// Thrown when the response content cannot be deserialized.
-    /// </exception>
-    /// <exception cref="OperationCanceledException">
-    /// Thrown when the operation is canceled via the <paramref name="cancellationToken"/>.
-    /// </exception>
+    /// <param name="requestUri">The full request URI.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of search results.</returns>
     private async Task<IReadOnlyList<FinnHubSymbolResult>> ExecuteSearchRequestAsync(
         string requestUri,
         CancellationToken cancellationToken)
     {
-        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
-        requestMessage.Headers.Add("X-FinnHub-Token", this._finnHubOptions.ApiKey);
+        using var requestMessage = this.CreateHttpRequest(requestUri);
 
-        using var response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
-        response.EnsureSuccessStatusCode();
+        var response = await this.SendRequestAsync(requestMessage, requestUri, cancellationToken).ConfigureAwait(false);
 
-        var content = await response.Content.ReadAsStringAsync(cancellationToken);
-
-        var finnHubSearchResponse = JsonSerializer.Deserialize<FinnHubSearchResponse>(content, this._jsonOptions);
-
-        if (finnHubSearchResponse is not { Count: > 0 })
-        {
-            this._logger.LogWarning("Received empty response from FinnHub Api");
-            return Array.Empty<FinnHubSymbolResult>().AsReadOnly();
-        }
-
-        return finnHubSearchResponse
-            .Result
-            .Select(x => new FinnHubSymbolResult
-            {
-                Symbol = x.Symbol,
-                Description = x.Description,
-                DisplaySymbol = x.DisplaySymbol,
-                Type = x.Type
-            })
-            .ToList()
-            .AsReadOnly();
+        return await this.ProcessResponseAsync(response, requestUri, cancellationToken).ConfigureAwait(false);
     }
 
     /// <summary>
-    /// Maps a FinnHub API symbol result to the application symbol result model.
+    /// Creates an HTTP request with the FinnHub API key.
     /// </summary>
-    /// <param name="finnHubSymbolResult">The API symbol result to map.</param>
-    /// <returns>A <see cref="StockSymbol"/> object mapped from the FinnHub symbol result.</returns>
-    /// <exception cref="ArgumentNullException">
-    /// Thrown when <paramref name="finnHubSymbolResult"/> is <c>null</c>.
-    /// </exception>
+    /// <param name="requestUri">The request URI.</param>
+    /// <returns>The configured <see cref="HttpRequestMessage"/>.</returns>
+    private HttpRequestMessage CreateHttpRequest(string requestUri)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        if (!string.IsNullOrWhiteSpace(this._finnHubOptions.ApiKey))
+        {
+            request.Headers.Add("X-FinnHub-Token", this._finnHubOptions.ApiKey);
+        }
+
+        return request;
+    }
+
+    /// <summary>
+    /// Sends an HTTP request and wraps known failure cases into domain-specific exceptions.
+    /// </summary>
+    /// <param name="requestMessage">The HTTP request message.</param>
+    /// <param name="requestUri">The originating URI for logging context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The HTTP response message.</returns>
+    private async Task<HttpResponseMessage> SendRequestAsync(
+        HttpRequestMessage requestMessage,
+        string requestUri,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub API failed. URI: {RequestUri}", requestUri);
+            throw new SearchSymbolHttpException($"HTTP request to FinnHub API failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Symbol search request timed out: {RequestUri}", requestUri);
+            throw new SearchSymbolTimeoutException($"Symbol search timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this. _logger.LogWarning("Symbol search operation was cancelled: {RequestUri}", requestUri);
+            throw new SearchSymbolCancelledException($"Symbol search cancelled: {requestUri}");
+        }
+    }
+
+    /// <summary>
+    ///
+    /// </summary>
+    /// <param name="finnHubSymbolResult">The raw result from the FinnHub API.</param>
+    /// <returns>A <see cref="StockSymbol"/> mapped result.</returns>
     private static StockSymbol MapToSymbolResult(FinnHubSymbolResult finnHubSymbolResult)
     {
         return new StockSymbol
@@ -281,7 +224,169 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
             Symbol = finnHubSymbolResult.Symbol ?? string.Empty,
             Description = finnHubSymbolResult.Description ?? string.Empty,
             DisplaySymbol = finnHubSymbolResult.DisplaySymbol ?? finnHubSymbolResult.Symbol ?? string.Empty,
-            Type = finnHubSymbolResult.Type ?? string.Empty,
+            Type = finnHubSymbolResult.Type ?? string.Empty
         };
+    }
+
+    /// <summary>
+    /// Builds the final success response object.
+    /// </summary>
+    /// <param name="query">The original query submitted by the client.</param>
+    /// <param name="duration">How long the search took to execute.</param>
+    /// <param name="timestamp">The UTC timestamp when search began.</param>
+    /// <param name="stockSymbols">The raw symbol results.</param>
+    /// <returns>A <see cref="SearchSymbolResponse"/> object to return to the MCP client.</returns>
+    private static SearchSymbolResponse CreateSuccessResponse(
+        SearchSymbolQuery query,
+        TimeSpan duration,
+        DateTime timestamp,
+        IReadOnlyList<FinnHubSymbolResult> stockSymbols)
+    {
+        return new SearchSymbolResponse
+        {
+            Query = query.Query,
+            QueryId = query.QueryId,
+            SearchDuration = duration,
+            SearchTimestamp = timestamp,
+            Source = "finnhub-api",
+            Symbols = stockSymbols
+                .Select(MapToSymbolResult)
+                .ToList()
+                .AsReadOnly(),
+        };
+    }
+
+    /// <summary>
+    /// Validates the HTTP response, throws meaningful exceptions on failure,
+    /// and deserializes valid responses into a list of <see cref="FinnHubSymbolResult"/>.
+    /// </summary>
+    /// <param name="response">The HTTP response message from FinnHub API.</param>
+    /// <param name="requestUri">The originating request URI (for logging and debugging).</param>
+    /// <param name="cancellationToken">The token used to monitor for cancellation requests.</param>
+    /// <returns>A list of <see cref="FinnHubSymbolResult"/> if response is successful.</returns>
+    /// <exception cref="SearchSymbolHttpException">When the API response status is not successful.</exception>
+    /// <exception cref="SearchSymbolDeserializationException">When the API response cannot be parsed.</exception>
+    private async Task<IReadOnlyList<FinnHubSymbolResult>> ProcessResponseAsync(
+        HttpResponseMessage response,
+        string requestUri,
+        CancellationToken cancellationToken)
+    {
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorResponseAsync(response, contentStream, cancellationToken);
+        }
+
+        return await this.DeserializeResponseAsync(contentStream, requestUri, cancellationToken).ConfigureAwait(false);
+    }
+
+     /// <summary>
+    /// Handles HTTP responses with non-success status codes by reading the body and logging an appropriate message.
+    /// </summary>
+    /// <param name="response">The response with error status.</param>
+    /// <param name="contentStream">The stream containing response body.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <exception cref="SearchSymbolHttpException">Thrown with enriched details about the error.</exception>
+    private async Task HandleErrorResponseAsync(
+        HttpResponseMessage response,
+        Stream contentStream,
+        CancellationToken cancellationToken)
+    {
+        var statusCode = response.StatusCode;
+        contentStream.Position = 0;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+
+        if ((int)statusCode >= 400 && (int)statusCode < 500)
+        {
+            this._logger.LogWarning("Client error from FinnHub API: {StatusCode} - {Content}", statusCode, errorBody);
+        }
+        else
+        {
+            this._logger.LogError("Server error from FinnHub API: {StatusCode} - {Content}", statusCode, errorBody);
+        }
+
+        throw new SearchSymbolHttpException(
+            $"FinnHub API returned error status {statusCode}. See logs for more detail.",
+            statusCode,
+            errorBody);
+    }
+
+    /// <summary>
+    /// Deserializes a successful JSON response into a strongly typed result object.
+    /// </summary>
+    /// <param name="contentStream">The response content stream.</param>
+    /// <param name="requestUri">The request URI (used for logging context).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A list of <see cref="FinnHubSymbolResult"/> or an empty list.</returns>
+    /// <exception cref="SearchSymbolDeserializationException">If deserialization fails.</exception>
+    private async Task<IReadOnlyList<FinnHubSymbolResult>> DeserializeResponseAsync(
+        Stream contentStream,
+        string requestUri,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await JsonSerializer
+                .DeserializeAsync<FinnHubSearchResponse>(contentStream, this._jsonOptions, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (response?.Count == 0 || response?.Result == null || response.Result.Count == 0)
+            {
+                this._logger.LogInformation("FinnHub returned no results for request: {RequestUri}", requestUri);
+                return Array.Empty<FinnHubSymbolResult>().AsReadOnly();
+            }
+
+            return response.Result
+                .Select(result => new FinnHubSymbolResult
+                {
+                    Symbol = result.Symbol,
+                    Description = result.Description,
+                    DisplaySymbol = result.DisplaySymbol,
+                    Type = result.Type
+                })
+                .ToList()
+                .AsReadOnly();
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize FinnHub API response.");
+            throw new SearchSymbolDeserializationException("Invalid JSON returned from FinnHub API.", ex);
+        }
+    }
+
+    /// <summary>
+    /// Constructs the full request URI for the FinnHub symbol search endpoint.
+    /// </summary>
+    /// <param name="searchEndpoint">The endpoint path to be used for symbol search.</param>
+    /// <param name="query">The search query containing symbol and exchange information.</param>
+    /// <returns>A fully qualified request URI string with query parameters.</returns>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="searchEndpoint"/> or <paramref name="query"/> is null.</exception>
+    private string BuildRequestUri(string? searchEndpoint, SearchSymbolQuery query)
+    {
+        ArgumentNullException.ThrowIfNull(searchEndpoint);
+        ArgumentNullException.ThrowIfNull(query);
+
+        var baseUrl = this._finnHubOptions.BaseUrl.TrimEnd('/');
+        var endpoint = searchEndpoint.TrimStart('/');
+        var queryParam = Uri.EscapeDataString(query.Query);
+
+        var uriBuilder = new StringBuilder()
+            .Append(baseUrl)
+            .Append('/')
+            .Append(endpoint)
+            .Append("?q=")
+            .Append(queryParam);
+
+        if (!string.IsNullOrWhiteSpace(query.Exchange))
+        {
+            uriBuilder
+                .Append("&exchange=")
+                .Append(Uri.EscapeDataString(query.Exchange));
+        }
+
+        return uriBuilder.ToString();
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -207,7 +207,7 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
         }
         catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
         {
-            this. _logger.LogWarning("Symbol search operation was cancelled: {RequestUri}", requestUri);
+            this._logger.LogWarning("Symbol search operation was cancelled: {RequestUri}", requestUri);
             throw new SearchSymbolCancelledException($"Symbol search cancelled: {requestUri}");
         }
     }
@@ -281,7 +281,7 @@ public sealed class FinnHubSearchApiClient : ISearchClient, IDisposable
         return await this.DeserializeResponseAsync(contentStream, requestUri, cancellationToken).ConfigureAwait(false);
     }
 
-     /// <summary>
+    /// <summary>
     /// Handles HTTP responses with non-success status codes by reading the body and logging an appropriate message.
     /// </summary>
     /// <param name="response">The response with error status.</param>

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Net;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Application.Search.Services;
@@ -176,7 +177,7 @@ public sealed class SearchServiceTests
         var query = new SearchSymbolQuery { QueryId = "test", Query = "AAPL" };
         this._searchClient
             .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
-            .ThrowsAsync(new HttpRequestException("Network error"));
+            .ThrowsAsync(new SearchSymbolHttpException("Service temporarily unavailable", HttpStatusCode.ServiceUnavailable));
 
         // Act
         var result = await this._service.SearchSymbolAsync(query, CancellationToken.None);
@@ -195,7 +196,7 @@ public sealed class SearchServiceTests
     {
         // Arrange
         var query = new SearchSymbolQuery { QueryId = "test", Query = "AAPL" };
-        var timeoutException = new TaskCanceledException("Operation timed out", new TimeoutException());
+        var timeoutException = new SearchSymbolTimeoutException("Request timed out", new TimeoutException());
 
         this._searchClient
             .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
@@ -252,7 +252,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
             Result = []
         };
 
-        var jsonResponse =  JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
+        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
         });
@@ -308,7 +308,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     public async Task SearchSymbolAsync_WithUnauthorizedResponse_ThrowsHttpRequestException()
     {
         // Arrange
-        var query = new SearchSymbolQuery {Query = "AAPL", QueryId = Guid.NewGuid().ToString()};
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
         this._messageHandler.SetResponse(HttpStatusCode.Unauthorized, "Unauthorized");
 
         // Act & Assert
@@ -320,7 +320,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     public async Task SearchSymbolAsync_WithInvalidJson_ThrowsJsonException()
     {
         // Arrange
-        var query = new SearchSymbolQuery {Query = "AAPL", QueryId = Guid.NewGuid().ToString()};
+        var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
         this._messageHandler.SetResponse(HttpStatusCode.OK, "invalid_json");
 
         // Act & Assert
@@ -332,7 +332,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     public async Task SearchSymbolAsync_WithNullSymbolFields_HandlesNullValues()
     {
         // Arrange
-        var query = new SearchSymbolQuery {Query = "TEST", QueryId = Guid.NewGuid().ToString()};
+        var query = new SearchSymbolQuery { Query = "TEST", QueryId = Guid.NewGuid().ToString() };
         var expectedResponse = new FinnHubSearchResponse
         {
             Count = 1,


### PR DESCRIPTION
### Type of change

- [X] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR introduces domain-specific exceptions for symbol search and improve error handling.
- Added `SearchSymbolHttpException`, `TimeoutException`, `DeserializationException`, and related types.
- Replaced general try/catch in `SearchService` and `FinnHubSearchApiClient` with fine-grained exception handling.
- Improved logging to include query context and HTTP status codes.
- Added missing `QueryId` to `BaseSearchResponse`.
- Updated unit tests to validate new exception flows and logging behaviour.

### GitHub Links

Closes #55 

### Tests

Run `dotnet test`

### Checklist

- [x] I have tested the changes locally.
- [x] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [x] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [x] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
