### PR TITLE
feat(http): implement connection pooling and resilience with Polly

### DIFF
--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -7,10 +7,12 @@
 
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Polly;
 using Polly.CircuitBreaker;
@@ -18,51 +20,104 @@ using Polly.Retry;
 
 namespace FinnHub.MCP.Server.Infrastructure.Extensions;
 
+/// <summary>
+/// Provides extension methods for registering infrastructure services such as typed HTTP clients
+/// and resilient policies using Polly for retry and circuit breaker behavior.
+/// </summary>
 public static class ServiceCollectionExtension
 {
+    /// <summary>
+    /// Registers infrastructure dependencies into the service collection, including
+    /// a typed HTTP client for the FinnHub API with connection pooling, headers, and resilience policies.
+    /// </summary>
+    /// <param name="services">The service collection to which services are added.</param>
     public static void RegisterInfrastructure(this IServiceCollection services)
     {
-        services.AddHttpClient("FinnHub", (provider, client) =>
+        services.AddHttpClient<ISearchApiClient, FinnHubSearchApiClient>("FinnHub", (provider, client) =>
             {
                 var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;
+
                 client.BaseAddress = new Uri(options.BaseUrl);
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
-                client.DefaultRequestHeaders.UserAgent.ParseAdd("FinnHub-MCP-Server/1.0");
+                client.DefaultRequestHeaders.Accept.Add(
+                    new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("FinnHub-MCP-Server", "1.0"));
                 client.Timeout = TimeSpan.FromSeconds(30);
+
                 if (!string.IsNullOrWhiteSpace(options.ApiKey))
                 {
                     client.DefaultRequestHeaders.Add("X-Finnhub-Token", options.ApiKey);
                 }
             })
-            .ConfigurePrimaryHttpMessageHandler(() => new HttpClientHandler
+            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
             {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(2),
                 MaxConnectionsPerServer = 10,
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             })
-            .SetHandlerLifetime(TimeSpan.FromMinutes(5))
-            .AddPolicyHandler(GetRetryPolicy())
-            .AddPolicyHandler(GetCircuitBreakerPolicy());
-
-        services.AddSingleton<ISearchApiClient, FinnHubSearchApiClient>();
+            .AddPolicyHandler((provider, _) =>
+            {
+                var logger = provider.GetRequiredService<ILogger<FinnHubSearchApiClient>>();
+                return GetRetryPolicy(logger);
+            })
+            .AddPolicyHandler((provider, _) =>
+            {
+                var logger = provider.GetRequiredService<ILogger<FinnHubSearchApiClient>>();
+                return GetCircuitBreakerPolicy(logger);
+            })
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 
-    private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy()
+    /// <summary>
+    /// Builds a retry policy using Polly with exponential backoff and logs each retry attempt.
+    /// </summary>
+    /// <param name="logger">The logger to record retry attempts and reasons.</param>
+    /// <returns>An asynchronous retry policy for HTTP responses.</returns>
+    private static AsyncRetryPolicy<HttpResponseMessage> GetRetryPolicy(ILogger logger)
     {
         return Policy<HttpResponseMessage>
-            .HandleResult(r => !r.IsSuccessStatusCode)
+            .HandleResult(res => !res.IsSuccessStatusCode)
             .Or<HttpRequestException>()
             .Or<TaskCanceledException>()
-            .WaitAndRetryAsync(3, retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)));
+            .WaitAndRetryAsync(
+                retryCount: 3,
+                sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                onRetry: (outcome, timespan, retryAttempt, context) =>
+                {
+                    context["Policy"] = "RetryPolicy";
+                    context["RequestUri"] = outcome.Result?.RequestMessage?.RequestUri?.ToString();
+
+                    var message = outcome.Exception?.Message
+                                  ?? outcome.Result?.StatusCode.ToString()
+                                  ?? "Unknown failure reason";
+
+                    logger.Log(LogLevel.Warning, "Retry {RetryAttempt} after {Delay}s due to: {Reason}", retryAttempt, timespan.TotalSeconds, message);
+                });
     }
 
-    private static AsyncCircuitBreakerPolicy<HttpResponseMessage> GetCircuitBreakerPolicy()
+    /// <summary>
+    /// Builds a circuit breaker policy using Polly that breaks after 3 failures for 30 seconds,
+    /// and logs state changes.
+    /// </summary>
+    /// <param name="logger">The logger to record circuit breaker events.</param>
+    /// <returns>An asynchronous circuit breaker policy for HTTP responses.</returns>
+    private static AsyncCircuitBreakerPolicy<HttpResponseMessage> GetCircuitBreakerPolicy(ILogger logger)
     {
         return Policy<HttpResponseMessage>
             .HandleResult(r => !r.IsSuccessStatusCode)
             .Or<HttpRequestException>()
             .CircuitBreakerAsync(
                 handledEventsAllowedBeforeBreaking: 3,
-                durationOfBreak: TimeSpan.FromSeconds(30)
-            );
+                durationOfBreak: TimeSpan.FromSeconds(30),
+                onBreak: (outcome, breakDelay) =>
+                {
+                    var statusCode = outcome.Result?.StatusCode;
+                    var message = outcome.Exception?.Message ?? statusCode?.ToString() ?? "Unknown error";
+
+                    logger.Log(LogLevel.Warning, "Circuit broken for {BreakDelay}s due to: {Reason}", breakDelay.TotalSeconds, message);
+                },
+                onReset: () =>
+                {
+                    logger.Log(LogLevel.Information, "Circuit reset.");
+                });
     }
 }


### PR DESCRIPTION
### Type of change

- [X] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR improves the resilience and performance of our FinnHub HTTP client integration by,

- [X] Leveraging connection pooling via `SocketsHttpHandler`
- [X] Introducing Polly-based retry and circuit breaker policies
- [X] Replacing `Console.WriteLine` statements with structured `ILogger` logging

### GitHub Links

Closes #59 

### Tests

Run `dotnet test`

### Checklist

- [X] I have tested the changes locally.
- [X] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [X] The code follows the project's coding standards.
- [X] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [X] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [X] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
