### PR TITLE
feat(schema): enforce pattern and length constraints for query and exchange inputs

### DIFF
--- a/src/FinnHub.MCP.Server.SSE/Tools/Search/SearchSymbolTool.cs
+++ b/src/FinnHub.MCP.Server.SSE/Tools/Search/SearchSymbolTool.cs
@@ -37,10 +37,14 @@ public sealed class SearchSymbolTool(
         .Properties(
             (Constants.Tools.SearchSymbols.Parameters.QueryName, new JsonSchemaBuilder()
                 .Type(SchemaValueType.String)
+                .Pattern(@"^[a-zA-Z0-9\s\-\._]{1,500}$")
+                .MaxLength(500)
                 .Required()
                 .Description(Constants.Tools.SearchSymbols.Parameters.QueryDescription)),
             (Constants.Tools.SearchSymbols.Parameters.ExchangeName, new JsonSchemaBuilder()
                 .Type(SchemaValueType.String)
+                .Pattern(@"^[A-Z0-9\-_]{1,50}$$")
+                .MaxLength(50)
                 .Description(Constants.Tools.SearchSymbols.Parameters.ExchangeDescription)
             ),
             (Constants.Tools.SearchSymbols.Parameters.LimitName, new JsonSchemaBuilder()


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [x] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR
This PR strengthens the JSON Schema definitions used in `SearchSymbolTool` by enforcing pattern and maxLength constraints that mirror the runtime validation logic. This ensures client-side and server-side validation are aligned for better security and developer experience.

### Changes Included

- [x] Added pattern and maxLength constraints to the query parameter in the tool’s schema
- [x] Added pattern and maxLength constraints to the exchange parameter
- [x] Ensured the patterns match exactly what is used in runtime sanitization
- [x] Improves input rejection early via schema enforcement before server-side processing

### GitHub Links

Closes #64 

### Tests

N/A

### Checklist

- [X] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [X] The code follows the project's coding standards.
- [X] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [X] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
