### PR TITLE
test(validation): add unit tests for query and exchange parameter validation

### DIFF
--- a/finnhub-mcp.sln
+++ b/finnhub-mcp.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinnHub.MCP.Server.Infrastr
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinnHub.MCP.Server.Infrastructure.Tests.Unit", "tests\FinnHub.MCP.Server.Infrastructure.Tests.Unit\FinnHub.MCP.Server.Infrastructure.Tests.Unit.csproj", "{D04CD22E-378A-42A7-BF8E-AC435D50D63C}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FinnHub.MCP.Server.Tests.Unit", "tests\FinnHub.MCP.Server.Tests.Unit\FinnHub.MCP.Server.Tests.Unit.csproj", "{B39F92C8-A3FC-4026-938B-5EFEDD5E345E}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{D04CD22E-378A-42A7-BF8E-AC435D50D63C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D04CD22E-378A-42A7-BF8E-AC435D50D63C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D04CD22E-378A-42A7-BF8E-AC435D50D63C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B39F92C8-A3FC-4026-938B-5EFEDD5E345E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B39F92C8-A3FC-4026-938B-5EFEDD5E345E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B39F92C8-A3FC-4026-938B-5EFEDD5E345E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B39F92C8-A3FC-4026-938B-5EFEDD5E345E}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{859E69D9-3195-4DFC-A463-107739C456F1} = {D728C487-FA3C-4698-B853-4FB8041E6374}
@@ -48,5 +54,6 @@ Global
 		{B052238C-9665-48CC-98D2-0E40F009E096} = {D728C487-FA3C-4698-B853-4FB8041E6374}
 		{AF1878FD-FCF5-48A3-BB87-DEAA56D5D0E6} = {D728C487-FA3C-4698-B853-4FB8041E6374}
 		{D04CD22E-378A-42A7-BF8E-AC435D50D63C} = {A7AF5572-5130-4729-9302-1DB158FB8A08}
+		{B39F92C8-A3FC-4026-938B-5EFEDD5E345E} = {A7AF5572-5130-4729-9302-1DB158FB8A08}
 	EndGlobalSection
 EndGlobal

--- a/src/FinnHub.MCP.Server.SSE/FinnHub.MCP.Server.SSE.csproj
+++ b/src/FinnHub.MCP.Server.SSE/FinnHub.MCP.Server.SSE.csproj
@@ -30,4 +30,9 @@
     <ProjectReference Include="..\FinnHub.MCP.Server.Application\FinnHub.MCP.Server.Application.csproj" />
     <ProjectReference Include="..\FinnHub.MCP.Server.Infrastructure\FinnHub.MCP.Server.Infrastructure.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <Parameter>FinnHub.MCP.Server.Tests.Unit</Parameter>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/FinnHub.MCP.Server.SSE/FinnHub.MCP.Server.SSE.csproj
+++ b/src/FinnHub.MCP.Server.SSE/FinnHub.MCP.Server.SSE.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
   <ItemGroup>
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-      <Parameter>FinnHub.MCP.Server.Tests.Unit</Parameter>
+      <_Parameter1>FinnHub.MCP.Server.Tests.Unit</_Parameter1>
     </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/FinnHub.MCP.Server.SSE/Tools/Search/SearchSymbolTool.cs
+++ b/src/FinnHub.MCP.Server.SSE/Tools/Search/SearchSymbolTool.cs
@@ -30,6 +30,8 @@ public sealed class SearchSymbolTool(
     private static readonly Lazy<JsonElement> s_serializedSchema = new(() =>
         JsonSerializer.SerializeToElement(s_toolSchema));
 
+    internal static JsonSchema ToolSchema => s_toolSchema;
+
     /// <summary>
     /// Defines the JSON schema for tool inputs, including query, exchange, and result limit.
     /// </summary>

--- a/tests/FinnHub.MCP.Server.Tests.Unit/FinnHub.MCP.Server.Tests.Unit.csproj
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/FinnHub.MCP.Server.Tests.Unit.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+<PropertyGroup>
+  <TargetFramework>net8.0</TargetFramework>
+  <ImplicitUsings>enable</ImplicitUsings>
+  <Nullable>enable</Nullable>
+  <IsPackable>false</IsPackable>
+  <IsTestProject>true</IsTestProject>
+  <RootNamespace>FinnHub.MCP.Server.Tests.Unit</RootNamespace>
+</PropertyGroup>
+<ItemGroup>
+  <PackageReference Include="coverlet.collector" />
+  <PackageReference Include="Microsoft.NET.Test.Sdk" />
+  <PackageReference Include="xunit" />
+  <PackageReference Include="xunit.runner.visualstudio" />
+  <PackageReference Include="NSubstitute" />
+</ItemGroup>
+<ItemGroup>
+  <ProjectReference Include="..\..\src\FinnHub.MCP.Server.SSE\FinnHub.MCP.Server.SSE.csproj" />
+</ItemGroup>
+</Project>

--- a/tests/FinnHub.MCP.Server.Tests.Unit/FinnHub.MCP.Server.Tests.Unit.csproj
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/FinnHub.MCP.Server.Tests.Unit.csproj
@@ -6,6 +6,7 @@
   <IsPackable>false</IsPackable>
   <IsTestProject>true</IsTestProject>
   <RootNamespace>FinnHub.MCP.Server.Tests.Unit</RootNamespace>
+  <AssemblyName>FinnHub.MCP.Server.Tests.Unit</AssemblyName>
 </PropertyGroup>
 <ItemGroup>
   <PackageReference Include="coverlet.collector" />

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/BaseSearchToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/BaseSearchToolTests.cs
@@ -1,0 +1,95 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using ModelContextProtocol.Protocol;
+using ModelContextProtocol.Server;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Search;
+
+using System.Text.Json;
+using Xunit;
+using FinnHub.MCP.Server.SSE.Tools.Search;
+
+public class BaseSearchToolTests
+{
+    private static Dictionary<string, JsonElement> BuildArgs(string key, string value) =>
+        new()
+        {
+            [key] = JsonSerializer.SerializeToElement(value)
+        };
+
+    [Theory]
+    [InlineData("AAPL", false)]
+    [InlineData("X", false)]
+    [InlineData("X-NYSE_2024", false)]
+    [InlineData("", true)]
+    [InlineData("   ", true)]
+    [InlineData("<script>", true)]
+    [InlineData(null, true)]
+    public void ValidateAndGetQuery_HandlesVariousInputs(string? input, bool shouldThrow)
+    {
+        var args = BuildArgs("query", input ?? "");
+
+        if (shouldThrow)
+        {
+            Assert.Throws<ArgumentException>(() => BaseSearchToolTestImpl.ValidateAndGetQuery(args));
+        }
+        else
+        {
+            var result = BaseSearchToolTestImpl.ValidateAndGetQuery(args);
+            Assert.Equal(input?.Trim(), result);
+        }
+    }
+
+    [Theory]
+    [InlineData("NASDAQ", false)]
+    [InlineData("X-NYSE", false)]
+    [InlineData("ABC_DEF", false)]
+    [InlineData("", false)]
+    [InlineData("nasdaq", false)]
+    [InlineData("X#INVALID", true)]
+    [InlineData("TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG_TOOLONG", true)]
+    public void ValidateAndGetExchange_HandlesVariousInputs(string? input, bool shouldThrow)
+    {
+        var args = BuildArgs("exchange", input ?? string.Empty);
+
+        if (shouldThrow)
+        {
+            Assert.Throws<ArgumentException>(() => BaseSearchToolTestImpl.ValidateAndGetExchange(args));
+        }
+        else
+        {
+            var result = BaseSearchToolTestImpl.ValidateAndGetExchange(args);
+            if (string.IsNullOrWhiteSpace(input))
+            {
+                Assert.Null(result);
+            }
+            else
+            {
+                Assert.Equal(input.Trim().ToUpperInvariant(), result);
+            }
+        }
+    }
+
+    private sealed class BaseSearchToolTestImpl : BaseSearchTool
+    {
+        public static new string ValidateAndGetQuery(IReadOnlyDictionary<string, JsonElement>? args,
+            string paramName = "query", int min = 1, int max = 500) =>
+            BaseSearchTool.ValidateAndGetQuery(args, paramName, min, max);
+
+        public static new string? ValidateAndGetExchange(IReadOnlyDictionary<string, JsonElement>? args,
+            string paramName = "exchange") =>
+            BaseSearchTool.ValidateAndGetExchange(args, paramName);
+
+        public override ValueTask<CallToolResponse> InvokeAsync(RequestContext<CallToolRequestParams> request, CancellationToken cancellationToken = new CancellationToken())
+        {
+            throw new NotImplementedException();
+        }
+
+        public override Tool ProtocolTool => new();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/BaseSearchToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/BaseSearchToolTests.cs
@@ -5,15 +5,13 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Text.Json;
+using FinnHub.MCP.Server.SSE.Tools.Search;
 using ModelContextProtocol.Protocol;
 using ModelContextProtocol.Server;
+using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Search;
-
-using System.Text.Json;
-using Xunit;
-using FinnHub.MCP.Server.SSE.Tools.Search;
-
 public class BaseSearchToolTests
 {
     private static Dictionary<string, JsonElement> BuildArgs(string key, string value) =>
@@ -28,6 +26,7 @@ public class BaseSearchToolTests
     [InlineData("X-NYSE_2024", false)]
     [InlineData("", true)]
     [InlineData("   ", true)]
+    [InlineData("<tag>", true)]
     [InlineData("<script>", true)]
     [InlineData(null, true)]
     public void ValidateAndGetQuery_HandlesVariousInputs(string? input, bool shouldThrow)


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [x] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR introduces comprehensive unit tests for input validation logic used in BaseSearchTool, focusing on,

- `ValidateAndGetQuery`
- `ValidateAndGetExchange`

Changes Included
- [x] Valid and invalid cases for ValidateAndGetQuery
- [x] Edge case handling (whitespace, min/max lengths, disallowed characters)
- [x] Optional exchange param handling and sanitisation logic
- [x] Alignment with JSON schema enforcement
- [x] Trimming and normalisation behaviour for exchange

### GitHub Links

Closes #67 

### Tests

Run `dotnet test`

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [x] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
