### PR TITLE
refactor(http): inject named HttpClient directly into FinnHubSearchApiClient

### DIFF
--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -38,19 +38,19 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient, IDisposable
     /// <summary>
     /// Initializes a new instance of the <see cref="FinnHubSearchApiClient"/> class.
     /// </summary>
-    /// <param name="httpClientFactory">Factory to create named HTTP clients.</param>
+    /// <param name="httpClient">Named HTTP clients.</param>
     /// <param name="options">Configuration options for the FinnHub API.</param>
     /// <param name="logger">Logger for diagnostics and monitoring.</param>
     public FinnHubSearchApiClient(
-        IHttpClientFactory httpClientFactory,
+        HttpClient httpClient,
         IOptions<FinnHubOptions> options,
         ILogger<FinnHubSearchApiClient> logger)
     {
-        ArgumentNullException.ThrowIfNull(httpClientFactory);
+        ArgumentNullException.ThrowIfNull(httpClient);
         ArgumentNullException.ThrowIfNull(options);
         ArgumentNullException.ThrowIfNull(logger);
 
-        this._httpClient = httpClientFactory.CreateClient("FinnHub");
+        this._httpClient = httpClient;
         this._finnHubOptions = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
         this._logger = logger;
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -33,13 +33,12 @@ public static class ServiceCollectionExtension
     /// <param name="services">The service collection to which services are added.</param>
     public static void RegisterInfrastructure(this IServiceCollection services)
     {
-        services.AddHttpClient<ISearchApiClient, FinnHubSearchApiClient>("FinnHub", (provider, client) =>
+        services.AddHttpClient<ISearchApiClient, FinnHubSearchApiClient>("FinnHub-Search-Client", (provider, client) =>
             {
                 var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;
 
                 client.BaseAddress = new Uri(options.BaseUrl);
-                client.DefaultRequestHeaders.Accept.Add(
-                    new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
                 client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("FinnHub-MCP-Server", "1.0"));
                 client.Timeout = TimeSpan.FromSeconds(30);
 

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -62,9 +62,14 @@ mcpServerOptionsBuilder.Configure<IServiceProvider>((mcpServerOptions, servicePr
     };
 });
 
-builder.Services
-    .AddMcpServer()
-    .WithHttpTransport();
+if (args.Contains("--stdio"))
+{
+    builder.Services.AddMcpServer().WithStdioServerTransport();
+}
+else
+{
+    builder.Services.AddMcpServer().WithHttpTransport();
+}
 
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
@@ -25,7 +25,6 @@ namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Search;
 /// </summary>
 public sealed class FinnHubSearchApiClientTests : IDisposable
 {
-    private readonly IHttpClientFactory _httpClientFactory;
     private readonly IOptions<FinnHubOptions> _options;
     private readonly ILogger<FinnHubSearchApiClient> _logger;
     private readonly FinnHubOptions _finnHubOptions;
@@ -35,7 +34,6 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
 
     public FinnHubSearchApiClientTests()
     {
-        this._httpClientFactory = Substitute.For<IHttpClientFactory>();
         this._options = Substitute.For<IOptions<FinnHubOptions>>();
         this._logger = Substitute.For<ILogger<FinnHubSearchApiClient>>();
         this._messageHandler = new MockHttpMessageHandler();
@@ -57,8 +55,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
         };
 
         this._options.Value.Returns(this._finnHubOptions);
-        this._httpClientFactory.CreateClient("FinnHub").Returns(this._httpClient);
-        this._sut = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
+        this._sut = new FinnHubSearchApiClient(this._httpClient, this._options, this._logger);
     }
 
     [Fact]
@@ -74,7 +71,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new FinnHubSearchApiClient(this._httpClientFactory, null!, this._logger));
+            new FinnHubSearchApiClient(this._httpClient, null!, this._logger));
     }
 
     [Fact]
@@ -82,7 +79,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
-            new FinnHubSearchApiClient(this._httpClientFactory, this._options, null!));
+            new FinnHubSearchApiClient(this._httpClient, this._options, null!));
     }
 
     [Fact]
@@ -94,7 +91,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
 
         // Act & Assert
         var exception = Assert.Throws<ArgumentException>(() =>
-            new FinnHubSearchApiClient(this._httpClientFactory, nullOptions, this._logger));
+            new FinnHubSearchApiClient(this._httpClient, nullOptions, this._logger));
 
         Assert.Equal("FinnHub options cannot be null. (Parameter 'options')", exception.Message);
     }
@@ -155,8 +152,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
         };
 
         this._options.Value.Returns(finnHubOptions);
-        this._httpClientFactory.CreateClient("FinnHub").Returns(this._httpClient);
-        this._sut = new FinnHubSearchApiClient(this._httpClientFactory, this._options, this._logger);
+        this._sut = new FinnHubSearchApiClient(this._httpClient, this._options, this._logger);
 
         // Act & Assert
         var exception = await Assert.ThrowsAsync<ArgumentException>(() =>


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [x] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR refactors the FinnHubSearchApiClient to directly inject a named HttpClient ("FinnHub-Search-Client") instead of relying on IHttpClientFactory. This improves clarity, reduces DI complexity, and aligns with .NET best practices for typed/named clients.

### Changes
- [X] Direct HttpClient Injection: The constructor for FinnHubSearchApiClient now accepts an HttpClient directly.
- [X] Named Client Registration: Registered "FinnHub-Search-Client" using AddHttpClient in ServiceCollectionExtension.
- [X] Removed IHttpClientFactory: Eliminated redundant logic and factory lookup.
- [X] Resilience Policies Intact: Retry and circuit breaker policies still apply via Polly handlers.
- [X] Startup Logic Updated: MCP startup transport logic uses SearchSymbolTool as expected.
- [X] General Cleanup: Minor formatting and consistency improvements.

### GitHub Links

Closes #71 

### Tests

run `dotnet test`

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [x] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
