### PR TITLE
fix(ci-cd): remove deprecated v3 artifact actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
           fi
 
       - name: 📤 Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
           path: artifacts/${{ matrix.artifact_name }}
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: 📥 Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
 
       - name: 🔄 Generate Conventional Changelog
         id: changelog


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR updates deprecated GitHub Actions for artifact upload/download to use the latest v4 versions.

### Changes
- [X] Replaced `actions/upload-artifact@v3 `→ `@v4`
- [X] Replaced `actions/download-artifact@v3` → `@v4`
- [X] Verified compatibility across all jobs using artifacts

### GitHub Links

Closes #75 

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
