### PR TITLE
refactor(json): replace JsonSerializer.Deserialize with source generation context

### DIFF
--- a/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
+++ b/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
@@ -8,6 +8,10 @@
   <ImplicitUsings>enable</ImplicitUsings>
   <Nullable>enable</Nullable>
   <Title>FinnHub MCP Server Infrastructure</Title>
+  <PublishTrimmed>true</PublishTrimmed>
+  <TrimMode>link</TrimMode>
+  <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
+  <EnableTrimAnalyzer>true</EnableTrimAnalyzer>
 </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\FinnHub.MCP.Server.Application\FinnHub.MCP.Server.Application.csproj" />

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -5,9 +5,17 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+
 namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 
-public class FinnHubJsonContext
-{
-    
-}
+[ExcludeFromCodeCoverage]
+[JsonSourceGenerationOptions(
+    PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower,
+    WriteIndented = true,
+    DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    PropertyNameCaseInsensitive = true)]
+[JsonSerializable(typeof(FinnHubSearchResponse))]
+public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -1,0 +1,13 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Infrastructure.Serialization;
+
+public class FinnHubJsonContext
+{
+    
+}


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [X] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR replaces runtime-based `JsonSerializer.Deserialize<T>` usage with compile-time generated source context `FinnHubJsonContext` to support .NET trimming and single file publishing.

### Changes
- [X] Added FinnHubJsonContext with `[JsonSerializable]` types used in FinnHubSearchApiClient.
- [X] Removed unsafe `JsonSerializerOptions` usage with SnakeCaseLower.
- [X] Updated deserialisation to use `JsonSerializer.Deserialize(..., FinnHubJsonContext.Default.FooType)`.
- [X] Ensured compatibility with `PublishTrimmed=true` and fixed `IL2026` warnings.
- [X] Verified parity with existing deserialisation through tests.

### GitHub Links

Closes #79 

### Tests

Run `dotnet test`

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [x] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
