### PR TITLE
chore(c1): switch to official Release Please action from googleapis org

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,11 +4,23 @@ on:
   push:
     branches:
       - main
+      - release/
+    paths-ignore:
+      - '.github/**'
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
 
 jobs:
   release:
     name: 📦 Create GitHub Release
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
 
     steps:
       - name: 📥 Checkout
@@ -16,10 +28,11 @@ jobs:
 
       - name: 🔖 Release Please
         id: release
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           release-type: simple
           token: ${{ secrets.GITHUB_TOKEN }}
+          config-file: .release-please-config.json
 
   build:
     name: 🔧 Build & Upload Artifacts

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -7,7 +7,18 @@
   "packages": {
     ".": {
       "release-type": "dotnet",
-      "include-component-in-tag": false
+      "include-component-in-tag": false,
+      "changelog-sections": [
+        {"type": "feat", "section": "✨ Features", "hidden": false},
+        {"type": "fix", "section": "🐛 Bug Fixes", "hidden": false},
+        {"type": "perf", "section": "⚡ Performance", "hidden": false},
+        {"type": "refactor", "section": "♻️ Refactoring", "hidden": false},
+        {"type": "build", "section": "🔧 Build System", "hidden": false},
+        {"type": "ci", "section": "👷 CI/CD", "hidden": false},
+        {"type": "chore", "section": "🧹 Chores", "hidden": true},
+        {"type": "docs", "section": "📚 Documentation", "hidden": true},
+        {"type": "test", "section": "🧪 Tests", "hidden": true}
+      ]
     }
   }
 }


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [x] Others (refactor, small patch, etc.)

### What's in this PR

Replaces usage of `google-github-actions/release-please-action@v4` with `googleapis/release-please-action@v4` in release workflow.

### GitHub Links

Closes #85

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
