### PR TITLE
chore(ci): resolve incorrect coverage collection paths in test workflow

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -80,7 +80,6 @@ jobs:
             echo "Running tests for $project"
             dotnet test $project \
               --configuration Release \
-              --no-build \
               --verbosity normal \
               -p:CollectCoverage=true \
               -p:CoverletOutputFormat=cobertura \

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -62,47 +62,69 @@ jobs:
 
     steps:
       - name: 📥 Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: 🧰 Setup .NET SDK
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.0.x'
 
+      - name: 📦 Restore dependencies
+        run: dotnet restore ./finnhub-mcp.sln
+
       - name: 🧪 Run unit tests with coverage
         run: |
+          mkdir -p TestResults
           mkdir -p coverage
-          for project in \
-            ./tests/FinnHub.MCP.Server.Application.Tests.Unit/FinnHub.MCP.Server.Application.Tests.Unit.csproj \
-            ./tests/FinnHub.MCP.Server.Tests.Unit/FinnHub.MCP.Server.Tests.Unit.csproj \
-            ./tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/FinnHub.MCP.Server.Infrastructure.Tests.Unit.csproj
-          do
-            echo "Running tests for $project"
-            dotnet test $project \
-              --configuration Release \
-              --verbosity normal \
-              -p:CollectCoverage=true \
-              -p:CoverletOutputFormat=cobertura \
-              -p:ExcludeByAttribute=GeneratedCodeAttribute \
-              -p:MergeWith='./coverage/coverage.json' \
-              -p:CoverletOutput="./coverage/"
-          done
 
-      - name: 📂 Show coverage files
-        run: find ./coverage -name '*.cobertura.xml'
+          # Run all tests with coverage and collect results
+          dotnet test ./finnhub-mcp.sln \
+            --configuration Release \
+            --verbosity normal \
+            --logger "trx;LogFileName=test-results.trx" \
+            --results-directory ./TestResults \
+            --collect:"XPlat Code Coverage" \
+            --settings coverlet.runsettings \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=cobertura \
+            -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.ExcludeByAttribute=GeneratedCodeAttribute
+
+      - name: 📂 Move coverage files
+        run: |
+          # Find and move coverage files to a consistent location
+          find ./TestResults -name "coverage.cobertura.xml" -exec cp {} ./coverage/ \;
+          # Also copy any .trx files
+          find ./TestResults -name "*.trx" -exec cp {} ./coverage/ \;
+
+      - name: 📂 Show coverage and test files
+        run: |
+          echo "Coverage files:"
+          find ./coverage -name "*.xml" -o -name "*.trx"
+          echo "TestResults directory:"
+          find ./TestResults -type f
 
       - name: 📤 Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/**/*.cobertura.xml
+          files: ./coverage/coverage.cobertura.xml
           flags: unit-tests
           name: codecov-finnhub-mcp
           fail_ci_if_error: true
           verbose: true
 
+      - name: 📊 Publish test results
+        uses: dorny/test-reporter@v1
+        if: always()
+        with:
+          name: .NET Tests
+          path: ./TestResults/*.trx
+          reporter: dotnet-trx
+
       - name: 📁 Upload test results
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: test-results
-          path: ./coverage/
+          path: |
+            ./TestResults/
+            ./coverage/

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -83,19 +83,19 @@ jobs:
               --verbosity normal \
               -p:CollectCoverage=true \
               -p:CoverletOutputFormat=cobertura \
-              -p:CoverletOutput=./coverage/ \
-              -p:MergeWith=./coverage/coverage.json \
-              -p:ExcludeByAttribute=GeneratedCodeAttribute
+              -p:ExcludeByAttribute=GeneratedCodeAttribute \
+              -p:MergeWith='./coverage/coverage.json' \
+              -p:CoverletOutput="./coverage/"
           done
 
       - name: 📂 Show coverage files
-        run: find ./coverage
+        run: find ./coverage -name '*.cobertura.xml'
 
       - name: 📤 Upload coverage to Codecov
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage/coverage.cobertura.xml
+          files: ./coverage/**/*.cobertura.xml
           flags: unit-tests
           name: codecov-finnhub-mcp
           fail_ci_if_error: true

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -80,13 +80,13 @@ jobs:
             echo "Running tests for $project"
             dotnet test $project \
               --configuration Release \
-              --collect:'XPlat Code Coverage' \
+              --no-build \
               --verbosity normal \
               -p:CollectCoverage=true \
               -p:CoverletOutputFormat=cobertura \
-              -p:ExcludeByAttribute=GeneratedCodeAttribute \
-              -p:MergeWith='./coverage/coverage.json' \
-              -p:CoverletOutput="./coverage/"
+              -p:CoverletOutput=./coverage/ \
+              -p:MergeWith=./coverage/coverage.json \
+              -p:ExcludeByAttribute=GeneratedCodeAttribute
           done
 
       - name: 📂 Show coverage files
@@ -107,4 +107,3 @@ jobs:
         with:
           name: test-results
           path: ./coverage/
-

--- a/coverlet.runsettings
+++ b/coverlet.runsettings
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<RunSettings>
+  <DataCollectionRunSettings>
+    <DataCollectors>
+      <DataCollector friendlyName="XPlat Code Coverage">
+        <Configuration>
+          <Format>cobertura</Format>
+          <ExcludeByAttribute>GeneratedCodeAttribute,CompilerGeneratedAttribute,ExcludeFromCodeCoverageAttribute</ExcludeByAttribute>
+          <ExcludeByFile>**/Migrations/**/*,**/bin/**/*,**/obj/**/*</ExcludeByFile>
+          <SingleHit>false</SingleHit>
+          <UseSourceLink>true</UseSourceLink>
+          <IncludeTestAssembly>false</IncludeTestAssembly>
+        </Configuration>
+      </DataCollector>
+    </DataCollectors>
+  </DataCollectionRunSettings>
+</RunSettings>


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [x] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR updates the test job in the GitHub Actions workflow to correctly handle coverage collection across multiple test projects using Coverlet. It eliminates the `--collect:'XPlat Code Coverage'` option which caused coverage files to be written into per-run folders (e.g. /TestResults/{GUID}/).


The fix ensures that
- All coverage files are output to ./coverage/
- Merging and uploading to `Codecov` works reliably
- The test-coverage artifact is available for further analysis

Checklist
- [ ] Removed `--collect:'XPlat Code Coverage'`
- [ ] Added explicit coverage output path
- [ ] Confirmed `coverage.cobertura.xml` is generated

### GitHub Links

Closes #87

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [x] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [x] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
