### PR TITLE
feat(config): resolve appsettings.json path relative to binary directory

### DIFF
--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -28,7 +28,11 @@ if (builder.Environment.IsDevelopment())
     Env.TraversePath().Load();
 }
 
+var exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;
+var exeDirectory = exePath is not null ? Path.GetDirectoryName(exePath) : Directory.GetCurrentDirectory();
+
 builder.Configuration
+    .SetBasePath(exeDirectory!)
     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
     .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
     .AddEnvironmentVariables()


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR addresses a critical issue where `appsettings.json` was not found when running the binary using tools like `npx` or after `npm install`. This was due to .NET resolving paths relative to the current working directory instead of the executable's location.

### GitHub Links

N/A

### Tests

N/A

### Checklist

- [ ] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [ ] The code follows the project's coding standards.
- [ ] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.

<!--
  If within the scope of this PR, add documentation directly to the doc fix project.
  If outside of the scope of this PR, add issues to Linear that references this PR to track documentation that must be added to supplement these changes.
-->
