### PR TITLE
feat(ci): add supported runtime identifiers from build matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,38 +44,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: windows-latest
-            runtime: win-x86
-            artifact_name: finnhub-mcp-win-x86.exe
+          # Windows - most common architectures
           - os: windows-latest
             runtime: win-x64
             artifact_name: finnhub-mcp-win-x64.exe
           - os: windows-latest
-            runtime: win-arm
-            artifact_name: finnhub-mcp-win-arm.exe
-          - os: windows-latest
             runtime: win-arm64
             artifact_name: finnhub-mcp-win-arm64.exe
 
+          # Linux - most common architectures
           - os: ubuntu-latest
             runtime: linux-x64
             artifact_name: finnhub-mcp-linux-x64
           - os: ubuntu-latest
-            runtime: linux-arm
-            artifact_name: finnhub-mcp-linux-arm
-          - os: ubuntu-latest
             runtime: linux-arm64
             artifact_name: finnhub-mcp-linux-arm64
-          - os: ubuntu-latest
-            runtime: linux-musl-x64
-            artifact_name: finnhub-mcp-linux-musl-x64
-          - os: ubuntu-latest
-            runtime: linux-musl-arm
-            artifact_name: finnhub-mcp-linux-musl-arm
-          - os: ubuntu-latest
-            runtime: linux-musl-arm64
-            artifact_name: finnhub-mcp-linux-musl-arm64
 
+          # macOS - both Intel and Apple Silicon
           - os: macos-latest
             runtime: osx-x64
             artifact_name: finnhub-mcp-osx-x64
@@ -123,7 +108,7 @@ jobs:
         shell: bash
         run: |
           cd ./publish
-          if [ "${{ matrix.runtime }}" == "win-x64" ]; then
+          if [[ "${{ matrix.runtime }}" == win-* ]]; then
             EXEC=$(find . -name "*.exe" -type f | head -1)
             mv "$EXEC" ${{ matrix.artifact_name }}
           else

--- a/src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj
+++ b/src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj
@@ -12,6 +12,7 @@
     <RepositoryUrl>https://github.com/salzaki/finnhub-mcp</RepositoryUrl>
     <PublishSymbols>false</PublishSymbols>
     <DebugType>None</DebugType>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup Label="Packages">
     <PackageReference Include="ModelContextProtocol" />


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR adds support for most common runtime identifiers and remove unsupported runtime identifiers that cause package resolution errors in the release workflow.

- ✅ **Removed problematic runtimes:**
  - `win-x86` (32-bit Windows - legacy)
  - `win-arm` (limited package support)
  - `linux-arm` (32-bit ARM - superseded by ARM64)
  - `linux-musl-*` variants (Alpine-specific, less common)

- ✅ **Kept mainstream runtimes:**
  - `win-x64` - Standard 64-bit Windows
  - `win-arm64` - Windows on ARM (Surface devices)
  - `linux-x64` - Standard 64-bit Linux
  - `linux-arm64` - ARM64 Linux (Raspberry Pi, AWS Graviton)
  - `osx-x64` - Intel Macs
  - `osx-arm64` - Apple Silicon Macs

- ✅ **Updated project configuration:**
  - Added `RuntimeIdentifiers` property to `FinnHub.MCP.Server.csproj`
  - Aligned project file with workflow matrix

### GitHub Links

N/A

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.