### PR TITLE
feat(ci): : use POSIX-compatible executable detection in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,7 +123,6 @@ jobs:
         run: |
           cd ./publish
 
-          # More robust executable detection
           if [[ "${{ matrix.runtime }}" == win-* ]]; then
             # Windows: Look for .exe files
             EXEC=$(find . -name "*.exe" -type f | head -1)
@@ -134,17 +133,20 @@ jobs:
             echo "Found Windows executable: $EXEC"
             mv "$EXEC" "${{ matrix.artifact_name }}"
           else
-            # Unix: Look for executable files (no extension)
-            EXEC=$(find . -type f -executable ! -name "*.dll" ! -name "*.so" ! -name "*.dylib" ! -name "*.json" ! -name "*.pdb" ! -name "*.*" | head -1)
-            if [ -z "$EXEC" ]; then
-              # Fallback: look for files without extensions
-              EXEC=$(find . -type f ! -name "*.*" | head -1)
-            fi
+            # macOS/Linux: Find the first executable file (POSIX-safe)
+            EXEC=$(find . -type f ! -name "*.dll" ! -name "*.so" ! -name "*.dylib" ! -name "*.json" ! -name "*.pdb" ! -name "*.*" | while read file; do
+              if [ -x "$file" ]; then
+                echo "$file"
+                break
+              fi
+            done)
+
             if [ -z "$EXEC" ]; then
               echo "❌ No executable found in Unix build"
               ls -la
               exit 1
             fi
+
             echo "Found Unix executable: $EXEC"
             mv "$EXEC" "${{ matrix.artifact_name }}"
             chmod +x "${{ matrix.artifact_name }}"


### PR DESCRIPTION
### Type of change

- [x] Feature
- [ ] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR updates `release.yml` which avoids using `-executable flag` in find, which is unsupported on macOS (BSD find). Replaces it with a portable check using test -x to locate executable files during artifact preparation.

### GitHub Links

N/A

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.