### PR TITLE
fix: resolve executable detection in prepare artifact step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -133,13 +133,28 @@ jobs:
             echo "Found Windows executable: $EXEC"
             mv "$EXEC" "${{ matrix.artifact_name }}"
           else
-            # macOS/Linux: Find the first executable file (POSIX-safe)
-            EXEC=$(find . -type f ! -name "*.dll" ! -name "*.so" ! -name "*.dylib" ! -name "*.json" ! -name "*.pdb" ! -name "*.*" | while read file; do
-              if [ -x "$file" ]; then
-                echo "$file"
+            # macOS/Linux: Find the first executable file
+            # The issue was here - the while loop was running in a subshell
+            # and the variable assignment wasn't preserved
+            EXEC=""
+
+            # Look for files without extensions that are executable
+            for file in *; do
+              if [ -f "$file" ] && [ -x "$file" ] && [[ "$file" != *.* ]]; then
+                EXEC="$file"
                 break
               fi
-            done)
+            done
+
+            # If no file without extension found, look for any executable
+            if [ -z "$EXEC" ]; then
+              for file in *; do
+                if [ -f "$file" ] && [ -x "$file" ]; then
+                  EXEC="$file"
+                  break
+                fi
+              done
+            fi
 
             if [ -z "$EXEC" ]; then
               echo "❌ No executable found in Unix build"


### PR DESCRIPTION
### Type of change

- [ ] Feature
- [x] Bug fix
- [ ] Metrics & Analytics
- [ ] Documentation
- [ ] Enhancement
- [ ] DevOps & Infra
- [ ] Others (refactor, small patch, etc.)

### What's in this PR

This PR resolves issue with executable detection in prepare artifact step by

- Fix subshell variable assignment issue in Unix executable detection
- Replace find/while loop with simple for loop to preserve `EXEC` variable
- Prioritize extension-less executables (like `FinnHub.MCP.Server)`
- Add fallback to any executable file if no extension-less executable found
- Resolves `No executable found in Unix build` error

### GitHub Links

N/A

### Tests

N/A

### Checklist

- [x] I have tested the changes locally.
- [ ] I have added/updated tests to cover my changes.
- [ ] I have updated the documentation to reflect the changes.
- [x] The code follows the project's coding standards.
- [x] All tests pass.
- [ ] Link all relevant issues from GitHub.<!-- If a relevant issue doesn't exist AND this is more than a simple hotfix, create relevant issues. -->
- [ ] Create unit tests where applicable.<!-- When possible, tests should encompass all reasonable use cases and failure states of the changes. -->
- [ ] I have manually verified this new feature works as advertised.<!-- What's the dumbest, fastest way to check whether this code works -->
- [ ] Add relevant documentation links.