### PR TITLE
docs: align README with current codebase

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 ![Build Status](https://github.com/salzaki/finnhub-mcp/actions/workflows/dotnet.yml/badge.svg)
 ![codecov](https://codecov.io/gh/salzaki/finnhub-mcp/branch/main/graph/badge.svg)
 ![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)
-![.NET](https://img.shields.io/badge/.NET-8.0-blue.svg)
+![.NET](https://img.shields.io/badge/.NET-10.0-blue.svg)
 ![Architecture](https://img.shields.io/badge/Architecture-Clean-green)
 ![MCP](https://img.shields.io/badge/AI-MCP-purple)
 ![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)
@@ -15,99 +15,53 @@
 
 </h4>
 
-**⚠️ This repository is under active development. The service will be live soon. Stay tuned! ⚠️**
-
 # 👋 Welcome to Finnhub MCP Server
 
 ## 🎯 Project Overview
 
-A robust **Model Context Protocol (MCP) Server** that integrates with **[Finnhub](https://finnhub.io/)**'s institutional-grade financial data APIs. Provides both Server-Sent Events (SSE) and Standard Input/Output (STDIO) transport protocols for streaming live financial data with modern .NET practices and Finnhub API best practices.
+A **Model Context Protocol (MCP) Server** built on the official [ModelContextProtocol C# SDK](https://www.nuget.org/packages/ModelContextProtocol) that exposes **[Finnhub](https://finnhub.io/)**'s financial-data APIs to MCP-compatible clients (Claude Desktop, IDE assistants, and other agents). The server can be hosted over HTTP or STDIO and follows Clean Architecture across three projects: `Server` (transport + MCP surface), `Server.Application` (domain), and `Server.Infrastructure` (Finnhub HTTP client + serialization).
 
 ## 🚀 Key Features
 
-- ✅ **Symbol Search Tool** with validated and sanitized user input
-- ✅ **Finnhub API Rate Limiting**
-    - Respects free tier limits (60 requests/minute)
-    - Implements exponential backoff for 429 responses
-    - Configurable rate limiting for different subscription tiers
-- ✅ **Robust Input Validation**
-    - Query & exchange inputs sanitized using regex patterns
-    - Length and pattern constraints enforced at runtime and via JSON Schema
-    - Symbol validation against Finnhub's supported formats
-- ✅ **Secure by Default**
-    - Actively defends against common injection vectors (`<script>`, SQL-style, etc.)
-    - Allowed character sets enforced through schema and code
-    - API key stored securely via environment variables
-- ✅ **Resilient HTTP Communication**
-    - Typed `HttpClient` with retry & circuit breaker policies (via [Polly](https://github.com/App-vNext/Polly))
-    - Connection pooling with `SocketsHttpHandler`
-    - Automatic retry with jitter for failed requests
-- ✅ **WebSocket Support** (Coming Soon)
-    - Real-time streaming via Finnhub WebSocket API
-    - Automatic reconnection handling
-    - Subscription management for multiple symbols
+- ✅ **MCP Tools and Resources** wired to the official `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` packages
+- ✅ **Symbol Search Tool** with input validation and sanitization (regex-based length and character constraints)
+- ✅ **Exchanges Resource** exposed at `finnhub://resources/exchanges` for venue metadata (currently a stub pending the live Finnhub `/stock/exchange` wiring)
+- ✅ **Resilient HTTP Communication** — typed `HttpClient` with retry, timeout, and circuit-breaker policies via `Microsoft.Extensions.Http.Resilience` and Polly
+- ✅ **Source-generated JSON** through `System.Text.Json` `JsonSerializerContext` for low-allocation, AOT-friendly (de)serialization
+- ✅ **Strongly-typed configuration** — `FinnHubOptions` bound from `appsettings.json` with data-annotation validation on startup
+- ✅ **API key kept out of source** — read from the `FINNHUB_API_KEY` environment variable (or a local `.env` in development via `DotNetEnv`)
+- ✅ **Dual transport** — HTTP (`MapMcp`) for hosted scenarios and STDIO for desktop MCP clients
 
-## 📊 Finnhub API Integration & Best Practices
-
-This server implements Finnhub's recommended best practices:
-
-### Rate Limiting
-- **Free Tier**: 60 requests/minute with automatic throttling
-- **Premium Tiers**: Configurable limits based on your subscription
-- Implements exponential backoff for rate limit responses (HTTP 429)
-- Request queuing to prevent API limit violations
-
-### Error Handling
-- Comprehensive error handling for all Finnhub API responses
-- Graceful degradation when API is unavailable
-- Retry logic with exponential backoff for transient failures
-- Proper handling of 401 (Unauthorized) and 429 (Rate Limit) responses
-
-### Data Validation
-- Input sanitization for all symbol and parameter inputs
-- Validates symbols against Finnhub's supported formats
-- Exchange code validation for international markets
-- Query parameter encoding to prevent injection attacks
-
-### Performance Optimization
-- HTTP connection pooling and reuse
-- Efficient JSON deserialization with System.Text.Json
-- Async/await patterns throughout for non-blocking operations
-- Memory-efficient streaming for large datasets
-
-## 🚧 Available & Upcoming MCP Tools
+## 🚧 Available & Upcoming MCP Capabilities
 
 ### ✅ Currently Available
-- **Symbol Search Tool** — search for stock symbols with fuzzy matching
+- **`search-symbol`** tool — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10)
+- **`finnhub://resources/exchanges`** resource — catalog of stock exchanges (code, name, country, MIC, timezone, trading hours)
 
 ### 🔄 In Development
-- **Real-Time Quote Tool** — live prices for stock, forex & crypto
-- **Company Profile Tool** — detailed company information and metrics
-- **Basic Financial Tool** — key financial metrics and ratios
+- Wire `ExchangesResource` to the live Finnhub `/stock/exchange` endpoint
+- **Real-Time Quote Tool** — live prices for stocks, FX, and crypto
+- **Company Profile Tool** — company information and metrics
+- **Basic Financials Tool** — key financial metrics and ratios
 
-### 📋 Planned Features
-- **Advanced Fundamentals Tool** — comprehensive financial statements
-- **Earnings Calendar Tool** — track earnings release dates and estimates
-- **News & Sentiment Tool** — company news with sentiment analysis
-- **Insider Trading Tool** — insider transaction data
-- **Market Status Tool** — trading hours and market holidays
-- **Technical Indicators** — RSI, MACD, moving averages
-- **Economic Data Tool** — GDP, inflation, employment data
-- **Crypto Data Tool** — cryptocurrency prices and market data
+### 📋 Planned
+- Earnings calendar, news & sentiment, insider trading, market status
+- Technical indicators (RSI, MACD, moving averages)
+- Economic data and crypto market data
+- WebSocket transport for streaming Finnhub feeds
 
 ## 🚀 Getting Started
 
 ### 📋 Prerequisites
 
-- [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0) or later
+- [.NET 10 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/10.0)
 - A valid [Finnhub API Key](https://finnhub.io/dashboard) (free tier available)
 
 ### 🔑 Getting Your Finnhub API Key
 
 1. Visit [Finnhub.io](https://finnhub.io/) and create a free account
-2. Navigate to your [Dashboard](https://finnhub.io/dashboard)
-3. Copy your API key from the dashboard
-4. **Note**: Free tier provides 60 requests/minute and access to basic market data
+2. Open your [Dashboard](https://finnhub.io/dashboard) and copy the API key
+3. Free tier provides 60 requests/minute and basic market data
 
 ### 📦 Installation
 
@@ -119,176 +73,197 @@ dotnet restore
 
 ### 🔐 API Key Configuration
 
-**Security Note**: Never commit your API key to version control. Always use environment variables or secure configuration management.
+> **Security note:** never commit your API key. Use environment variables or a local `.env` file that is git-ignored.
 
 #### Option 1: Environment Variable (Recommended)
 
-**macOS/Linux:**
+**macOS/Linux**
+
 ```bash
 export FINNHUB_API_KEY="your_api_key_here"
 ```
 
-**Windows PowerShell:**
+**Windows PowerShell**
+
 ```powershell
 $env:FINNHUB_API_KEY="your_api_key_here"
 ```
 
-**Windows Command Prompt:**
+**Windows Command Prompt**
+
 ```cmd
 set FINNHUB_API_KEY=your_api_key_here
 ```
 
-#### Option 2: .env File (Development Only)
+#### Option 2: `.env` File (Development Only)
 
-Create a `.env` file in the root directory:
+Create a `.env` file at the repository root — `DotNetEnv` loads it automatically when the host environment is `Development`:
+
 ```bash
 echo "FINNHUB_API_KEY=your_api_key_here" > .env
 ```
 
-**Important**: The `.env` file is automatically loaded during development but should never be committed to version control.
-
 ### 🚀 Running the Server
 
-#### HTTP Transport (Default)
+#### HTTP Transport (default port `8080`)
+
+```bash
+dotnet run --project src/FinnHub.MCP.Server
+```
+
+The server binds to `http://localhost:8080/` unless you override it:
+
 ```bash
 dotnet run --project src/FinnHub.MCP.Server --urls http://localhost:5101
 ```
 
 #### STDIO Transport
+
 ```bash
 dotnet run --project src/FinnHub.MCP.Server -- --stdio
 ```
 
-#### Docker Support
-```bash
-docker build -t finnhub-mcp .
-docker run -e FINNHUB_API_KEY="your_api_key_here" -p 5101:5101 finnhub-mcp
+### 🌐 HTTP Endpoints
+
+When running in HTTP mode the following endpoints are exposed:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /` | Application banner — name, version, environment, status |
+| `MapMcp()` routes | Official MCP HTTP transport endpoints |
+| `GET /mcp/sse` | Server-Sent Events keep-alive stream |
+| `POST /mcp/streamable` | StreamableHTTP transport stub |
+| `GET /mcp/health` | Lightweight health probe |
+| `/swagger` | OpenAPI UI (Development only) |
+
+## 📖 Usage
+
+The recommended way to interact with the server is through an MCP-compatible client (e.g. Claude Desktop, an MCP-aware IDE plugin, or `mcp-inspector`) configured to either spawn the binary over STDIO or connect to the HTTP transport.
+
+Example STDIO entry for Claude Desktop's `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "finnhub": {
+      "command": "dotnet",
+      "args": [
+        "run",
+        "--project",
+        "/absolute/path/to/finnhub-mcp/src/FinnHub.MCP.Server",
+        "--",
+        "--stdio"
+      ],
+      "env": {
+        "FINNHUB_API_KEY": "your_api_key_here"
+      }
+    }
+  }
+}
 ```
 
-## 📖 API Usage Examples
+### Tool: `search-symbol`
 
-### Symbol Search
-```bash
-# Search for Apple stock
-curl -X POST "http://localhost:5101/mcp/tools/symbol_search" \
-  -H "Content-Type: application/json" \
-  -d '{"query": "AAPL"}'
-```
+Parameters:
 
-### Real-Time Quote (Coming Soon)
-```bash
-# Get real-time quote for Apple
-curl -X POST "http://localhost:5101/mcp/tools/quote" \
-  -H "Content-Type: application/json" \
-  -d '{"symbol": "AAPL"}'
-```
+- `query` *(string, required)* — ticker, company name, ISIN, or CUSIP. 1–500 chars, letters/digits/space/`-`/`_`/`.` only.
+- `exchange` *(string, optional)* — uppercase exchange code matching `[A-Z0-9\-_]{1,50}`, e.g. `US`, `L`.
+- `limit` *(int, optional)* — 1–100, defaults to 10.
+
+### Resource: `finnhub://resources/exchanges`
+
+Returns the list of stock exchanges available through the provider as `application/json`.
 
 ## ⚙️ Configuration
 
-### Rate Limiting Configuration
-```json
-{
-  "Finnhub": {
-    "RateLimit": {
-      "RequestsPerMinute": 60,
-      "BurstLimit": 10,
-      "RetryAfterSeconds": 60
-    }
-  }
-}
-```
+Configuration is loaded from `appsettings.json`, an optional environment-specific `appsettings.{Environment}.json`, environment variables, and command-line arguments — in that order. The `FINNHUB_API_KEY` environment variable, if present, overrides `FinnHub:ApiKey`.
 
-### Logging Configuration
-```json
-{
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "FinnHub.MCP.Server": "Debug",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  }
-}
-```
+`FinnHubOptions` (bound from the `FinnHub` section) drives the API key, base URL, and per-endpoint settings. CORS allows any origin in `Development`; in other environments it reads from the `AllowedOrigins` array.
 
 ## 🧪 Testing
 
-### Unit Tests
-```bash
-dotnet test src/FinnHub.MCP.Server.Tests
-```
+The solution ships with three xUnit unit-test projects, mocked using **NSubstitute** and measured with **coverlet**:
 
-### Integration Tests
 ```bash
-# Set test API key
-export FINNHUB_TEST_API_KEY="your_test_api_key"
-dotnet test src/FinnHub.MCP.Server.IntegrationTests
-```
+# Run the full test suite
+dotnet test
 
-### Load Testing
-```bash
-# Test rate limiting behavior
-dotnet run --project tests/FinnHub.MCP.LoadTests
+# Run a single project
+dotnet test tests/FinnHub.MCP.Server.Application.Tests.Unit
+dotnet test tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit
+dotnet test tests/FinnHub.MCP.Server.Tests.Unit
+
+# With coverage (uses coverlet.runsettings at the repo root)
+dotnet test --settings coverlet.runsettings
 ```
 
 ## 🔧 Development
 
-### Building from Source
+### Build
+
 ```bash
 dotnet build
 ```
 
-### Running with Hot Reload
+### Hot reload
+
 ```bash
-dotnet watch run --project src/FinnHub.MCP.Server
+dotnet watch --project src/FinnHub.MCP.Server
 ```
 
-### Code Quality
+### Format & analyzers
+
 ```bash
-# Run code analysis
 dotnet format
-dotnet run --project tools/CodeAnalysis
 ```
 
-## 📊 Monitoring & Observability
+`TreatWarningsAsErrors` is enabled in `Directory.Build.props`, so any analyzer or compiler warning will fail the build.
 
-- **Health Checks**: `/health` endpoint for monitoring
-- **Metrics**: Prometheus metrics via `/metrics`
-- **Tracing**: OpenTelemetry integration
-- **Logging**: Structured logging with Serilog
+## 🏗️ Project Structure
+
+```
+src/
+├── FinnHub.MCP.Server/                    # ASP.NET Core host, MCP transport wiring, Tools, Resources
+├── FinnHub.MCP.Server.Application/        # Domain models, queries, services, exceptions
+└── FinnHub.MCP.Server.Infrastructure/     # Finnhub HTTP client, DTOs, JSON context, DI registration
+tests/
+├── FinnHub.MCP.Server.Application.Tests.Unit/
+├── FinnHub.MCP.Server.Infrastructure.Tests.Unit/
+└── FinnHub.MCP.Server.Tests.Unit/
+```
 
 ## 🛠️ Tech Stack
 
-- **Framework**: [.NET 8](https://dotnet.microsoft.com/) with ASP.NET Core
-- **Resilience**: [Polly](https://github.com/App-vNext/Polly) for retry policies and circuit breakers
-- **Validation**: [JsonSchema.Net](https://github.com/gregsdennis/json-everything) for input validation
-- **Testing**: [xUnit](https://xunit.net/) with [Moq](https://github.com/moq/moq4) for mocking
-- **Configuration**: [DotNetEnv](https://github.com/tonerdo/dotnet-env) for environment management
-- **Logging**: [Serilog](https://serilog.net/) for structured logging
-- **Monitoring**: [OpenTelemetry](https://opentelemetry.io/) for observability
-- **CI/CD**: GitHub Actions with automated testing and deployment
+- **Framework:** [.NET 10](https://dotnet.microsoft.com/) with ASP.NET Core
+- **MCP SDK:** [`ModelContextProtocol`](https://www.nuget.org/packages/ModelContextProtocol) and [`ModelContextProtocol.AspNetCore`](https://www.nuget.org/packages/ModelContextProtocol.AspNetCore)
+- **Resilience:** [Polly](https://github.com/App-vNext/Polly) via `Microsoft.Extensions.Http.Resilience` and `Microsoft.Extensions.Http.Polly`
+- **Serialization:** `System.Text.Json` with source-generated `JsonSerializerContext`
+- **Testing:** [xUnit](https://xunit.net/), [NSubstitute](https://nsubstitute.github.io/), [coverlet](https://github.com/coverlet-coverage/coverlet)
+- **Configuration:** [DotNetEnv](https://github.com/tonerdo/dotnet-env)
+- **OpenAPI:** `Microsoft.AspNetCore.OpenApi` + `Swashbuckle.AspNetCore`
+- **CI/CD:** GitHub Actions with [release-please](https://github.com/googleapis/release-please) for automated versioning
 
-### Development Setup
+## 🤝 Contributing
+
 1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Make your changes
-4. Add tests for new functionality
-5. Ensure all tests pass (`dotnet test`)
+2. Create a feature branch (`git checkout -b feat/short-description`)
+3. Make your changes and add tests
+4. Ensure `dotnet build` and `dotnet test` both pass
+5. Use [Conventional Commits](https://www.conventionalcommits.org/) — release-please depends on them
 6. Submit a pull request
 
 ## 📄 License
 
-This project is licensed under the MIT License, see [LICENSE](LICENSE) file for details.
+Licensed under the MIT License — see [LICENSE](LICENSE) for details.
 
 ## 🙏 Acknowledgments
 
-- [FinnHub.io](https://finnhub.io/) for providing excellent financial data APIs
-- [Model Context Protocol](https://github.com/modelcontextprotocol) for the MCP specification
-- The .NET community for excellent libraries and tools
+- [Finnhub.io](https://finnhub.io/) for the financial-data APIs
+- The [Model Context Protocol](https://github.com/modelcontextprotocol) team and the official C# SDK
+- The .NET community for the surrounding ecosystem
 
 ## 📞 Support
 
-- **Issues**: [GitHub Issues](https://github.com/SalZaki/finnhub-mcp/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/SalZaki/finnhub-mcp/discussions)
-- **Documentation**: [Wiki](https://github.com/SalZaki/finnhub-mcp/wiki)
-- **Finnhub Support**: [Finnhub Documentation](https://finnhub.io/docs/api)
+- **Issues:** [GitHub Issues](https://github.com/SalZaki/finnhub-mcp/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/SalZaki/finnhub-mcp/discussions)
+- **Finnhub API:** [Finnhub Documentation](https://finnhub.io/docs/api)


### PR DESCRIPTION
## Summary

Replaces the closed PR #131 with a fresh branch from post-refactor `main`.

The README had drifted from reality and now also needs to reflect the `Result<T>` refactor merged in #132:

- Claimed .NET 8 — project actually targets `net10.0`
- Default port listed as 5101 — actual default is 8080 (`Program.cs`)
- Test stack listed as xUnit + Moq — actually xUnit + NSubstitute
- Listed Serilog / OpenTelemetry / JsonSchema.Net — none are referenced packages
- Documented a Dockerfile, Load Tests project, and CodeAnalysis tool that don't exist
- Mentioned `/health` and `/metrics` endpoints that aren't implemented (only `/mcp/health` exists)
- Still flagged the project as "live soon" despite being at v1.11.0

What's added or corrected:

- Documents the `finnhub://resources/exchanges` MCP resource shipped in v1.11.0
- Lists the real HTTP endpoints (`/`, `/mcp`, `/mcp/sse`, `/mcp/streamable`, `/mcp/health`, `/swagger` in Dev)
- Documents the actual `search-symbol` parameter constraints (1–500 char query, exchange regex, limit 1–100)
- Adds a Claude Desktop STDIO config example for MCP clients
- Adds a Project Structure section reflecting the Clean Architecture layout
- Notes `TreatWarningsAsErrors` and the source-generated `FinnHubJsonContext`
- Updates the `dotnet test` commands to point at the real test project paths

### Why a new branch

PR #131 was opened on a branch based on pre-refactor `main` and a Copilot Autofix commit reverted the .NET 10 badge back to .NET 8 (incorrect). Rather than rebase that confused history, this PR starts clean from the current `main` and contains exactly one commit touching only `README.md`.

## Test plan

- [ ] Render the README on GitHub and verify badges, tables, and code blocks
- [ ] Confirm the Claude Desktop STDIO config snippet matches the working setup
- [ ] Verify the listed HTTP endpoints against `Program.cs`