### PR TITLE
fix: replace boilerplate server instructions with Finnhub guidance

### DIFF
--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -26,10 +26,14 @@ public static class Constants
 
         /// <summary>
         /// Default instructions provided to AI models when interacting with this server.
-        /// Guides the model to assume C# as the default programming language and maintain
-        /// brief, professional responses.
+        /// Orients the model toward aggregation-first tools that default to token-efficient
+        /// summaries and toward intent-based tool discovery rather than full schema enumeration.
         /// </summary>
-        public const string Instructions = "If no programming language is specified, assume C#. Keep your responses brief and professional.";
+        public const string Instructions =
+            "This server exposes Finnhub financial data through aggregation-first tools that default to " +
+            "token-efficient summaries. When tool discovery is needed, use search-tools first to find the " +
+            "right tool by intent rather than enumerating the full schema set. Every tool accepts " +
+            "view: summary|standard|full to control response detail and fields for sparse projections.";
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Replaces the demo-era `Server.Instructions` boilerplate ("If no programming language is specified, assume C#. Keep your responses brief and professional.") with a financial-data-server-appropriate orientation that nudges the LLM toward this server's aggregation-first tool pattern.

New text:

> This server exposes Finnhub financial data through aggregation-first tools that default to token-efficient summaries. When tool discovery is needed, use search-tools first to find the right tool by intent rather than enumerating the full schema set. Every tool accepts view: summary|standard|full to control response detail and fields for sparse projections.

The string ships through `McpServerOptions.ServerInstructions` (`src/FinnHub.MCP.Server/Program.cs:72`) and is visible to the LLM at every session start, so the misleading current value was shaping behaviour on every connection.

## Why now

Standalone cleanup ahead of a larger token-conscious tool-fabric milestone (see `.planning/specs/01-product-surface.md`, Open Question §7.8). Wanted to land this independently so the milestone PR stays focused on the contract change rather than wording.

`search-tools` is referenced ahead of its implementation deliberately — the server-level instruction is the right place to advertise discovery semantics, and the string can be revisited once the tool ships.

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors under `TreatWarningsAsErrors`
- [x] `dotnet test` — all 48 tests pass across the three test projects
- [x] `dotnet format --verify-no-changes` — clean
- [x] No tests assert against the previous string literal (grepped both `src/` and `tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)