### PR TITLE
feat(P2): HybridCache layer with tiered TTLs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,6 +20,7 @@
 
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0"/>
+    <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />

--- a/README.md
+++ b/README.md
@@ -196,6 +196,22 @@ A response that exceeds its declared view's token ceiling is rebuilt by the tool
 
 Returns the list of stock exchanges available through the provider as `application/json`.
 
+### Response caching
+
+Every Application service is fronted by `Microsoft.Extensions.Caching.Hybrid.HybridCache` with per-endpoint TTL tiers. Identical requests within the tier's TTL short-circuit the upstream Finnhub call.
+
+Tiers (defaults shown):
+
+| Tier | Default TTL | Used for |
+|---|---|---|
+| `Quote` | 10s | Live market data |
+| `News` | 60s | News articles, sentiment, symbol search |
+| `Financials` | 1h | Reported financials, KPI snapshots |
+| `Profile` | 24h | Company profiles, peer lists |
+| `Exchanges` | 7d | Stock exchange catalogues |
+
+TTLs are tunable in `appsettings.json` under the `Cache` section. Bad values (zero or out-of-range) fail startup validation. Cache keys are namespaced with a `tenant=shared` prefix today; a future BYOK milestone partitions per user without a key-shape migration. See `.planning/specs/01-product-surface.md` §3 P2 for the full design.
+
 ## ⚙️ Configuration
 
 Configuration is loaded from `appsettings.json`, an optional environment-specific `appsettings.{Environment}.json`, environment variables, and command-line arguments — in that order. The `FINNHUB_API_KEY` environment variable, if present, overrides `FinnHub:ApiKey`.

--- a/src/FinnHub.MCP.Server.Application/Caching/CacheKey.cs
+++ b/src/FinnHub.MCP.Server.Application/Caching/CacheKey.cs
@@ -1,0 +1,60 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+
+namespace FinnHub.MCP.Server.Application.Caching;
+
+/// <summary>
+/// Builds the namespaced cache key emitted by <see cref="IFinnHubCache"/> implementations.
+/// </summary>
+/// <remarks>
+/// Format: <c>finnhub:tenant={tenant}:tier={tier_lowercase}:{logicalKey}</c>.
+/// The tenant segment is the literal <c>"shared"</c> for v1; the BYOK milestone swaps it
+/// for the sha256 of the per-request API key without changing the key shape.
+/// </remarks>
+internal static partial class CacheKey
+{
+    private const int MaxLogicalKeyLength = 256;
+
+    [GeneratedRegex(@"^[a-z0-9_-]{1,64}$", RegexOptions.Compiled)]
+    private static partial Regex TenantRegex();
+
+    /// <summary>
+    /// Builds a fully-namespaced cache key.
+    /// </summary>
+    /// <param name="tenant">Per-deployment tenant slug. Must match <c>[a-z0-9_-]{1,64}</c>.</param>
+    /// <param name="tier">Mutability tier; lowercased into the key for readability.</param>
+    /// <param name="logicalKey">Caller-shaped key segment. 1–256 chars.</param>
+    /// <exception cref="ArgumentException">Either input violates the documented constraints.</exception>
+    public static string Build(string tenant, CacheTier tier, string logicalKey)
+    {
+        if (string.IsNullOrWhiteSpace(tenant) || !TenantRegex().IsMatch(tenant))
+        {
+            throw new ArgumentException(
+                "Tenant must match [a-z0-9_-]{1,64}.",
+                nameof(tenant));
+        }
+
+        if (string.IsNullOrWhiteSpace(logicalKey))
+        {
+            throw new ArgumentException(
+                "Logical key cannot be empty or whitespace.",
+                nameof(logicalKey));
+        }
+
+        if (logicalKey.Length > MaxLogicalKeyLength)
+        {
+            throw new ArgumentException(
+                $"Logical key must be at most {MaxLogicalKeyLength} chars.",
+                nameof(logicalKey));
+        }
+
+        var tierName = tier.ToString().ToLowerInvariant();
+        return $"finnhub:tenant={tenant}:tier={tierName}:{logicalKey}";
+    }
+}

--- a/src/FinnHub.MCP.Server.Application/Caching/CacheTier.cs
+++ b/src/FinnHub.MCP.Server.Application/Caching/CacheTier.cs
@@ -1,0 +1,46 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Caching;
+
+/// <summary>
+/// Mutability tier of an upstream Finnhub endpoint, used by <c>IFinnHubCache</c>
+/// to look up the appropriate TTL for a cached entry.
+/// </summary>
+/// <remarks>
+/// Ordered shortest-TTL to longest-TTL. The enum is internal labeling only —
+/// it is never serialized to the wire. Actual TTL durations live in
+/// <see cref="FinnHub.MCP.Server.Application.Options.CacheOptions"/> and are
+/// resolved via <c>CacheOptions.GetTtl(tier)</c>.
+/// </remarks>
+public enum CacheTier
+{
+    /// <summary>
+    /// Live market data (quotes, last trade). Default TTL ~10s.
+    /// </summary>
+    Quote,
+
+    /// <summary>
+    /// News articles, sentiment, and symbol search results. Default TTL ~60s.
+    /// </summary>
+    News,
+
+    /// <summary>
+    /// Reported financials, KPI snapshots, basic metrics. Default TTL ~1 hour.
+    /// </summary>
+    Financials,
+
+    /// <summary>
+    /// Company profiles, peer lists, sector classification. Default TTL ~24 hours.
+    /// </summary>
+    Profile,
+
+    /// <summary>
+    /// Stock exchange catalogues and other near-static reference data. Default TTL ~7 days.
+    /// </summary>
+    Exchanges
+}

--- a/src/FinnHub.MCP.Server.Application/Caching/IFinnHubCache.cs
+++ b/src/FinnHub.MCP.Server.Application/Caching/IFinnHubCache.cs
@@ -1,0 +1,50 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Caching;
+
+/// <summary>
+/// Tiered response cache fronting upstream Finnhub calls.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Concrete implementation lives in <c>Infrastructure</c> behind
+/// <c>Microsoft.Extensions.Caching.Hybrid.HybridCache</c>. Services call
+/// <see cref="GetOrCreateAsync{T}"/> with a logical cache key and a factory; the cache
+/// short-circuits identical requests within the tier's configured TTL and propagates
+/// upstream exceptions through the factory delegate without poisoning the slot.
+/// </para>
+/// <para>
+/// Cache keys are namespaced internally with a <c>tenant</c> segment. v1 uses the literal
+/// <c>"shared"</c> tenant per <c>.planning/specs/01-product-surface.md</c> §4 cross-cutting
+/// concerns; a future BYOK milestone flips the tenant to <c>sha256(api-key)</c> without a
+/// key-shape migration.
+/// </para>
+/// <para>
+/// The cached payload type must be JSON-serialisable by whatever serializer
+/// <c>HybridCache</c> is configured with; in this project that is
+/// <c>FinnHubJsonContext</c>'s source-generated metadata.
+/// </para>
+/// </remarks>
+public interface IFinnHubCache
+{
+    /// <summary>
+    /// Returns the cached value for <paramref name="key"/> in the supplied
+    /// <paramref name="tier"/>, invoking <paramref name="factory"/> on miss.
+    /// </summary>
+    /// <typeparam name="T">JSON-serialisable payload type.</typeparam>
+    /// <param name="key">Caller-shaped logical key. The implementation namespaces this with the tenant and tier.</param>
+    /// <param name="tier">Mutability tier controlling the TTL.</param>
+    /// <param name="factory">Invoked on cache miss to produce a fresh value. Cancellation propagates into the factory.</param>
+    /// <param name="cancellationToken">Cancels both the cache lookup and the factory invocation.</param>
+    /// <returns>The cached value on hit, or the freshly produced value on miss.</returns>
+    ValueTask<T> GetOrCreateAsync<T>(
+        string key,
+        CacheTier tier,
+        Func<CancellationToken, ValueTask<T>> factory,
+        CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Application/FinnHub.MCP.Server.Application.csproj
+++ b/src/FinnHub.MCP.Server.Application/FinnHub.MCP.Server.Application.csproj
@@ -17,5 +17,8 @@
     <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
       <_Parameter1>FinnHub.MCP.Server.Application.Tests.Unit</_Parameter1>
     </AssemblyAttribute>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>FinnHub.MCP.Server.Infrastructure</_Parameter1>
+    </AssemblyAttribute>
   </ItemGroup>
 </Project>

--- a/src/FinnHub.MCP.Server.Application/FinnHub.MCP.Server.Application.csproj
+++ b/src/FinnHub.MCP.Server.Application/FinnHub.MCP.Server.Application.csproj
@@ -13,4 +13,9 @@
   <ItemGroup Label="Packages">
     <PackageReference Include="Microsoft.Extensions.Logging" />
   </ItemGroup>
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>FinnHub.MCP.Server.Application.Tests.Unit</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/src/FinnHub.MCP.Server.Application/Options/CacheOptions.cs
+++ b/src/FinnHub.MCP.Server.Application/Options/CacheOptions.cs
@@ -1,0 +1,70 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using FinnHub.MCP.Server.Application.Caching;
+
+namespace FinnHub.MCP.Server.Application.Options;
+
+/// <summary>
+/// Per-tier TTL configuration for the response cache.
+/// </summary>
+/// <remarks>
+/// Bound from the <c>Cache</c> section of <c>appsettings.json</c> via
+/// <c>AddOptions&lt;CacheOptions&gt;().Bind(...).ValidateDataAnnotations().ValidateOnStart()</c>.
+/// Defaults match the values documented in <c>.planning/specs/01-product-surface.md</c> §3 P2
+/// so a missing <c>Cache</c> section still produces correct behaviour. Each tier carries a
+/// data-annotation <see cref="RangeAttribute"/> that enforces sensible bounds — a configured
+/// TTL of zero or a negative value fails startup validation.
+/// </remarks>
+public sealed class CacheOptions
+{
+    /// <summary>
+    /// TTL for the <see cref="CacheTier.Quote"/> tier. Default 10 seconds.
+    /// </summary>
+    [Range(typeof(TimeSpan), "00:00:01", "00:01:00")]
+    public TimeSpan QuoteTtl { get; init; } = TimeSpan.FromSeconds(10);
+
+    /// <summary>
+    /// TTL for the <see cref="CacheTier.News"/> tier. Default 60 seconds.
+    /// </summary>
+    [Range(typeof(TimeSpan), "00:00:10", "00:10:00")]
+    public TimeSpan NewsTtl { get; init; } = TimeSpan.FromSeconds(60);
+
+    /// <summary>
+    /// TTL for the <see cref="CacheTier.Financials"/> tier. Default 1 hour.
+    /// </summary>
+    [Range(typeof(TimeSpan), "00:01:00", "06:00:00")]
+    public TimeSpan FinancialsTtl { get; init; } = TimeSpan.FromHours(1);
+
+    /// <summary>
+    /// TTL for the <see cref="CacheTier.Profile"/> tier. Default 24 hours.
+    /// </summary>
+    [Range(typeof(TimeSpan), "00:10:00", "7.00:00:00")]
+    public TimeSpan ProfileTtl { get; init; } = TimeSpan.FromHours(24);
+
+    /// <summary>
+    /// TTL for the <see cref="CacheTier.Exchanges"/> tier. Default 7 days.
+    /// </summary>
+    [Range(typeof(TimeSpan), "01:00:00", "30.00:00:00")]
+    public TimeSpan ExchangesTtl { get; init; } = TimeSpan.FromDays(7);
+
+    /// <summary>
+    /// Returns the configured TTL for the supplied <paramref name="tier"/>.
+    /// </summary>
+    /// <param name="tier">The cache tier to resolve.</param>
+    /// <exception cref="ArgumentOutOfRangeException">The tier value is not a known enum member.</exception>
+    public TimeSpan GetTtl(CacheTier tier) => tier switch
+    {
+        CacheTier.Quote => this.QuoteTtl,
+        CacheTier.News => this.NewsTtl,
+        CacheTier.Financials => this.FinancialsTtl,
+        CacheTier.Profile => this.ProfileTtl,
+        CacheTier.Exchanges => this.ExchangesTtl,
+        _ => throw new ArgumentOutOfRangeException(nameof(tier), tier, "Unknown cache tier.")
+    };
+}

--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Search.Clients;
@@ -17,8 +18,18 @@ namespace FinnHub.MCP.Server.Application.Search.Services;
 /// Provides a high-level service for searching financial symbols via the configured search API client.
 /// This service handles validation, exception translation, logging, and standardized result formatting.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Routes upstream calls through <see cref="IFinnHubCache"/> at the <see cref="CacheTier.News"/> tier
+/// so identical queries within the configured TTL short-circuit the Finnhub HTTP call. Cache-key
+/// canonicalization lowercases the query and uppercases the exchange to match the upstream's
+/// case-insensitive behaviour. The per-invocation <c>QueryId</c> correlation identifier is
+/// deliberately excluded from the cache key.
+/// </para>
+/// </remarks>
 public sealed class SearchService(
     ISearchApiClient searchApiClient,
+    IFinnHubCache cache,
     ILogger<SearchService> logger)
     : ISearchService
 {
@@ -42,7 +53,13 @@ public sealed class SearchService(
 
         try
         {
-            var response = await searchApiClient.SearchSymbolAsync(query, cancellationToken);
+            var cacheKey = BuildCacheKey(query);
+
+            var response = await cache.GetOrCreateAsync(
+                cacheKey,
+                CacheTier.News,
+                async ct => await searchApiClient.SearchSymbolAsync(query, ct),
+                cancellationToken);
 
             logger.Log(LogLevel.Information, "Retrieved {ResponseTotalCount} symbols for query: {Query}",
                 response.TotalCount, query);
@@ -76,5 +93,14 @@ public sealed class SearchService(
             logger.Log(LogLevel.Error, ex, "Unexpected error occurred while searching symbols for query: {Query}", query.Query);
             throw;
         }
+    }
+
+    private static string BuildCacheKey(SearchSymbolQuery query)
+    {
+        var normQuery = query.Query.Trim().ToLowerInvariant();
+        var normExchange = string.IsNullOrWhiteSpace(query.Exchange)
+            ? "*"
+            : query.Exchange.Trim().ToUpperInvariant();
+        return $"search-symbol:q={normQuery}:ex={normExchange}:lim={query.Limit}";
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Caching/FinnHubHybridCache.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Caching/FinnHubHybridCache.cs
@@ -1,0 +1,79 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Options;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Caching;
+
+/// <summary>
+/// <see cref="IFinnHubCache"/> backed by <see cref="HybridCache"/>.
+/// </summary>
+/// <remarks>
+/// Builds the namespaced cache key via <see cref="CacheKey.Build"/>, resolves the
+/// per-tier TTL from <see cref="CacheOptions"/>, and delegates to
+/// <see cref="HybridCache"/>'s stateless <c>GetOrCreateAsync</c> overload. Hit/miss outcome is tracked via a
+/// captured flag inside the factory delegate and emitted as a single structured log
+/// line per call. Upstream factory exceptions propagate to the caller without
+/// leaving a poisoned cache slot — only successful upstream results are stored.
+/// </remarks>
+public sealed class FinnHubHybridCache(
+    HybridCache hybridCache,
+    IOptions<CacheOptions> options,
+    ILogger<FinnHubHybridCache> logger) : IFinnHubCache
+{
+    private const string SharedTenant = "shared";
+    private const int KeySuffixLength = 40;
+
+    /// <inheritdoc />
+    public async ValueTask<T> GetOrCreateAsync<T>(
+        string key,
+        CacheTier tier,
+        Func<CancellationToken, ValueTask<T>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(factory);
+
+        var prefixedKey = CacheKey.Build(SharedTenant, tier, key);
+        var ttl = options.Value.GetTtl(tier);
+        var entryOptions = new HybridCacheEntryOptions
+        {
+            Expiration = ttl,
+            LocalCacheExpiration = ttl
+        };
+
+        var wasFactoryInvoked = false;
+
+        var result = await hybridCache.GetOrCreateAsync(
+            prefixedKey,
+            async ct =>
+            {
+                wasFactoryInvoked = true;
+                return await factory(ct).ConfigureAwait(false);
+            },
+            options: entryOptions,
+            tags: null,
+            cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        var outcome = wasFactoryInvoked ? "miss" : "hit";
+        var keySuffix = prefixedKey.Length <= KeySuffixLength
+            ? prefixedKey
+            : prefixedKey[^KeySuffixLength..];
+
+        logger.LogInformation(
+            "cache {Outcome} tier={Tier} ttl_ms={TtlMs} key_suffix={KeySuffix}",
+            outcome,
+            tier,
+            (long)ttl.TotalMilliseconds,
+            keySuffix);
+
+        return result;
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -8,9 +8,12 @@
 using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Mime;
+using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Clients;
+using FinnHub.MCP.Server.Infrastructure.Caching;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
+using Microsoft.Extensions.Caching.Hybrid;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,6 +36,19 @@ public static class ServiceCollectionExtension
     /// <param name="services">The service collection to which services are added.</param>
     public static void RegisterInfrastructure(this IServiceCollection services)
     {
+        services.AddHybridCache(options =>
+        {
+            options.MaximumPayloadBytes = 1 * 1024 * 1024;
+            options.MaximumKeyLength = 1024;
+            options.DefaultEntryOptions = new HybridCacheEntryOptions
+            {
+                Expiration = TimeSpan.FromMinutes(1),
+                LocalCacheExpiration = TimeSpan.FromMinutes(1)
+            };
+        });
+
+        services.AddSingleton<IFinnHubCache, FinnHubHybridCache>();
+
         services.AddHttpClient<ISearchApiClient, FinnHubSearchApiClient>("FinnHub-Search-Client", (provider, client) =>
             {
                 var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;

--- a/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
+++ b/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
@@ -14,6 +14,7 @@
     <ProjectReference Include="..\FinnHub.MCP.Server.Application\FinnHub.MCP.Server.Application.csproj" />
   </ItemGroup>
   <ItemGroup Label="Packages">
+    <PackageReference Include="Microsoft.Extensions.Caching.Hybrid" />
     <PackageReference Include="Microsoft.Extensions.Options" />
     <PackageReference Include="Microsoft.Extensions.Logging" />
     <PackageReference Include="Microsoft.Extensions.Http" />

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -43,6 +43,7 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
     DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
     PropertyNameCaseInsensitive = true)]
 [JsonSerializable(typeof(FinnHubSearchResponse))]
+[JsonSerializable(typeof(SearchSymbolResponse))]
 [JsonSerializable(typeof(ToolView))]
 [JsonSerializable(typeof(NextAction))]
 [JsonSerializable(typeof(RateLimitInfo))]

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -65,6 +65,12 @@ builder.Services
     .ValidateDataAnnotations()
     .ValidateOnStart();
 
+builder.Services
+    .AddOptions<CacheOptions>()
+    .Bind(builder.Configuration.GetSection("Cache"))
+    .ValidateDataAnnotations()
+    .ValidateOnStart();
+
 builder.Services.RegisterInfrastructure();
 
 builder.Services.AddTransient<ISearchService, SearchService>();

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -26,5 +26,12 @@
         "Description": "Searches for best-matching symbols based on specified query."
       }
     ]
+  },
+  "Cache": {
+    "QuoteTtl": "00:00:10",
+    "NewsTtl": "00:01:00",
+    "FinancialsTtl": "01:00:00",
+    "ProfileTtl": "1.00:00:00",
+    "ExchangesTtl": "7.00:00:00"
   }
 }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
@@ -6,6 +6,7 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
+using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
@@ -32,7 +33,25 @@ public sealed class SearchServiceTests
     {
         this._searchApiClient = Substitute.For<ISearchApiClient>();
         ILogger<SearchService> logger = Substitute.For<ILogger<SearchService>>();
-        this._service = new SearchService(this._searchApiClient, logger);
+
+        // Pass-through cache substitute — invokes the factory unconditionally and returns its
+        // result. P2 T7 will replace this with a stateful FakeFinnHubCache that exercises
+        // cache-hit and cache-miss paths; for the legacy SearchService tests we only need the
+        // upstream call to flow through.
+        var cache = Substitute.For<IFinnHubCache>();
+        cache.GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<SearchSymbolResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(callInfo =>
+            {
+                var factory = callInfo.ArgAt<Func<CancellationToken, ValueTask<SearchSymbolResponse>>>(2);
+                var ct = callInfo.ArgAt<CancellationToken>(3);
+                return factory(ct);
+            });
+
+        this._service = new SearchService(this._searchApiClient, cache, logger);
     }
 
     /// <summary>

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Search/Services/SearchServiceTests.cs
@@ -6,11 +6,11 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Application.Search.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -24,6 +24,7 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Search.
 public sealed class SearchServiceTests
 {
     private readonly ISearchApiClient _searchApiClient;
+    private readonly FakeFinnHubCache _cache;
     private readonly SearchService _service;
 
     /// <summary>
@@ -33,25 +34,8 @@ public sealed class SearchServiceTests
     {
         this._searchApiClient = Substitute.For<ISearchApiClient>();
         ILogger<SearchService> logger = Substitute.For<ILogger<SearchService>>();
-
-        // Pass-through cache substitute — invokes the factory unconditionally and returns its
-        // result. P2 T7 will replace this with a stateful FakeFinnHubCache that exercises
-        // cache-hit and cache-miss paths; for the legacy SearchService tests we only need the
-        // upstream call to flow through.
-        var cache = Substitute.For<IFinnHubCache>();
-        cache.GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<SearchSymbolResponse>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(callInfo =>
-            {
-                var factory = callInfo.ArgAt<Func<CancellationToken, ValueTask<SearchSymbolResponse>>>(2);
-                var ct = callInfo.ArgAt<CancellationToken>(3);
-                return factory(ct);
-            });
-
-        this._service = new SearchService(this._searchApiClient, cache, logger);
+        this._cache = new FakeFinnHubCache();
+        this._service = new SearchService(this._searchApiClient, this._cache, logger);
     }
 
     /// <summary>
@@ -293,5 +277,112 @@ public sealed class SearchServiceTests
         Assert.True(result.Data.SearchDuration > TimeSpan.Zero);
         Assert.True(result.Data.SearchTimestamp >= startTime);
         Assert.True(result.Data.SearchTimestamp <= endTime);
+    }
+
+    /// <summary>
+    /// Verifies that two identical queries hit the upstream exactly once — the
+    /// second call short-circuits via the cache. <c>QueryId</c> differs between
+    /// the two queries to prove it is excluded from the cache key.
+    /// </summary>
+    [Fact]
+    public async Task SearchSymbolsAsync_TwoIdenticalCalls_HitUpstreamExactlyOnce()
+    {
+        // Arrange
+        var response = new SearchSymbolResponse
+        {
+            Symbols = [new StockSymbol { Symbol = "AAPL", DisplaySymbol = "AAPL", Description = "Apple", Type = "Common Stock" }]
+        };
+        this._searchApiClient
+            .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
+            .Returns(response);
+
+        var queryA = new SearchSymbolQuery { QueryId = "call-1", Query = "AAPL" };
+        var queryB = new SearchSymbolQuery { QueryId = "call-2", Query = "AAPL" };
+
+        // Act
+        var first = await this._service.SearchSymbolAsync(queryA, CancellationToken.None);
+        var second = await this._service.SearchSymbolAsync(queryB, CancellationToken.None);
+
+        // Assert
+        Assert.True(first.IsSuccess);
+        Assert.True(second.IsSuccess);
+        Assert.Equal(first.Data!.TotalCount, second.Data!.TotalCount);
+        Assert.Equal(1, this._cache.FactoryInvocationCount);
+        await this._searchApiClient.Received(1).SearchSymbolAsync(
+            Arg.Any<SearchSymbolQuery>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies that distinct queries each hit the upstream — different query
+    /// inputs produce different cache slots.
+    /// </summary>
+    [Fact]
+    public async Task SearchSymbolsAsync_DifferentInputs_HitUpstreamPerCall()
+    {
+        // Arrange
+        this._searchApiClient
+            .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
+            .Returns(callInfo => new SearchSymbolResponse
+            {
+                Symbols = [new StockSymbol
+                {
+                    Symbol = callInfo.ArgAt<SearchSymbolQuery>(0).Query,
+                    DisplaySymbol = "X",
+                    Description = "X",
+                    Type = "Common Stock"
+                }]
+            });
+
+        var queryA = new SearchSymbolQuery { QueryId = "a", Query = "AAPL" };
+        var queryB = new SearchSymbolQuery { QueryId = "b", Query = "NVDA" };
+
+        // Act
+        await this._service.SearchSymbolAsync(queryA, CancellationToken.None);
+        await this._service.SearchSymbolAsync(queryB, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(2, this._cache.FactoryInvocationCount);
+        await this._searchApiClient.Received(2).SearchSymbolAsync(
+            Arg.Any<SearchSymbolQuery>(),
+            Arg.Any<CancellationToken>());
+    }
+
+    /// <summary>
+    /// Verifies that a transient upstream failure does not poison the cache —
+    /// the next call retries the upstream and can succeed.
+    /// </summary>
+    [Fact]
+    public async Task SearchSymbolsAsync_FactoryThrows_DoesNotCacheException()
+    {
+        // Arrange
+        var query = new SearchSymbolQuery { QueryId = "t", Query = "AAPL" };
+        var successResponse = new SearchSymbolResponse
+        {
+            Symbols = [new StockSymbol { Symbol = "AAPL", DisplaySymbol = "AAPL", Description = "Apple", Type = "Common Stock" }]
+        };
+
+        var callCount = 0;
+        this._searchApiClient
+            .SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                callCount++;
+                if (callCount == 1)
+                {
+                    throw new ApiClientHttpException("boom", HttpStatusCode.ServiceUnavailable);
+                }
+                return successResponse;
+            });
+
+        // Act
+        var first = await this._service.SearchSymbolAsync(query, CancellationToken.None);
+        var second = await this._service.SearchSymbolAsync(query, CancellationToken.None);
+
+        // Assert
+        Assert.False(first.IsSuccess);
+        Assert.Equal("ServiceUnavailable", first.ErrorType);
+        Assert.True(second.IsSuccess);
+        Assert.Equal(2, callCount);
     }
 }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Caching/CacheKeyTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Caching/CacheKeyTests.cs
@@ -1,0 +1,74 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Caching;
+
+public sealed class CacheKeyTests
+{
+    [Fact]
+    public void Build_ProducesExpectedFormat()
+    {
+        var key = CacheKey.Build("shared", CacheTier.News, "search-symbol:q=aapl:ex=*:lim=10");
+
+        Assert.Equal("finnhub:tenant=shared:tier=news:search-symbol:q=aapl:ex=*:lim=10", key);
+    }
+
+    [Theory]
+    [InlineData(CacheTier.Quote, "quote")]
+    [InlineData(CacheTier.News, "news")]
+    [InlineData(CacheTier.Financials, "financials")]
+    [InlineData(CacheTier.Profile, "profile")]
+    [InlineData(CacheTier.Exchanges, "exchanges")]
+    public void Build_LowercasesTierName(CacheTier tier, string expectedSegment)
+    {
+        var key = CacheKey.Build("shared", tier, "x");
+
+        Assert.Contains($":tier={expectedSegment}:", key);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("SHARED")]
+    [InlineData("user@host")]
+    [InlineData("has space")]
+    public void Build_RejectsInvalidTenant(string tenant)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            CacheKey.Build(tenant, CacheTier.News, "x"));
+    }
+
+    [Fact]
+    public void Build_RejectsTenantOver64Chars()
+    {
+        var tenant = new string('a', 65);
+
+        Assert.Throws<ArgumentException>(() =>
+            CacheKey.Build(tenant, CacheTier.News, "x"));
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Build_RejectsEmptyLogicalKey(string logicalKey)
+    {
+        Assert.Throws<ArgumentException>(() =>
+            CacheKey.Build("shared", CacheTier.News, logicalKey));
+    }
+
+    [Fact]
+    public void Build_RejectsOversizedLogicalKey()
+    {
+        var logicalKey = new string('x', 257);
+
+        Assert.Throws<ArgumentException>(() =>
+            CacheKey.Build("shared", CacheTier.News, logicalKey));
+    }
+}

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Options/CacheOptionsTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Options/CacheOptionsTests.cs
@@ -1,0 +1,101 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Options;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Options;
+
+public sealed class CacheOptionsTests
+{
+    [Fact]
+    public void Defaults_MatchSpecValues()
+    {
+        var options = new CacheOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(10), options.QuoteTtl);
+        Assert.Equal(TimeSpan.FromSeconds(60), options.NewsTtl);
+        Assert.Equal(TimeSpan.FromHours(1), options.FinancialsTtl);
+        Assert.Equal(TimeSpan.FromHours(24), options.ProfileTtl);
+        Assert.Equal(TimeSpan.FromDays(7), options.ExchangesTtl);
+    }
+
+    [Theory]
+    [InlineData(CacheTier.Quote, 10)]
+    [InlineData(CacheTier.News, 60)]
+    [InlineData(CacheTier.Financials, 3600)]
+    [InlineData(CacheTier.Profile, 86_400)]
+    [InlineData(CacheTier.Exchanges, 604_800)]
+    public void GetTtl_ReturnsConfiguredValuePerTier(CacheTier tier, int expectedSeconds)
+    {
+        var options = new CacheOptions();
+
+        Assert.Equal(TimeSpan.FromSeconds(expectedSeconds), options.GetTtl(tier));
+    }
+
+    [Fact]
+    public void GetTtl_UnknownTier_Throws()
+    {
+        var options = new CacheOptions();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.GetTtl((CacheTier)999));
+    }
+
+    [Fact]
+    public void Validation_ZeroQuoteTtl_FailsDataAnnotations()
+    {
+        // The data-annotation [Range] is what ValidateDataAnnotations() / ValidateOnStart()
+        // consults at startup. Asserting it directly avoids wiring IOptions in tests.
+        var options = new CacheOptions { QuoteTtl = TimeSpan.Zero };
+
+        Assert.False(TryValidate(options, out var results));
+        Assert.Contains(results, r =>
+            r.MemberNames.Contains(nameof(CacheOptions.QuoteTtl)));
+    }
+
+    [Fact]
+    public void Validation_DefaultInstance_PassesDataAnnotations()
+    {
+        var options = new CacheOptions();
+
+        Assert.True(TryValidate(options, out _));
+    }
+
+    [Theory]
+    [InlineData(nameof(CacheOptions.QuoteTtl))]
+    [InlineData(nameof(CacheOptions.NewsTtl))]
+    [InlineData(nameof(CacheOptions.FinancialsTtl))]
+    [InlineData(nameof(CacheOptions.ProfileTtl))]
+    [InlineData(nameof(CacheOptions.ExchangesTtl))]
+    public void Validation_NegativeTtl_FailsForEveryTier(string memberName)
+    {
+        var options = memberName switch
+        {
+            nameof(CacheOptions.QuoteTtl) => new CacheOptions { QuoteTtl = TimeSpan.FromSeconds(-1) },
+            nameof(CacheOptions.NewsTtl) => new CacheOptions { NewsTtl = TimeSpan.FromSeconds(-1) },
+            nameof(CacheOptions.FinancialsTtl) => new CacheOptions { FinancialsTtl = TimeSpan.FromSeconds(-1) },
+            nameof(CacheOptions.ProfileTtl) => new CacheOptions { ProfileTtl = TimeSpan.FromSeconds(-1) },
+            nameof(CacheOptions.ExchangesTtl) => new CacheOptions { ExchangesTtl = TimeSpan.FromSeconds(-1) },
+            _ => throw new ArgumentOutOfRangeException(nameof(memberName))
+        };
+
+        Assert.False(TryValidate(options, out var results));
+        Assert.Contains(results, r => r.MemberNames.Contains(memberName));
+    }
+
+    private static bool TryValidate(CacheOptions options, out List<ValidationResult> results)
+    {
+        results = [];
+        return Validator.TryValidateObject(
+            options,
+            new ValidationContext(options),
+            results,
+            validateAllProperties: true);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/TestDoubles/FakeFinnHubCache.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/TestDoubles/FakeFinnHubCache.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
+
+/// <summary>
+/// In-process <see cref="IFinnHubCache"/> double for service-layer tests.
+/// </summary>
+/// <remarks>
+/// Mirrors production semantics around the boundaries that matter for the
+/// <c>SearchService</c> caching contract: identical <c>(tier, key)</c> pairs
+/// invoke the factory once; distinct pairs invoke it per-call; factory
+/// exceptions propagate unwrapped and the cache slot remains empty.
+/// TTL expiry is not modelled — tests that need expiry semantics belong in
+/// <c>FinnHubHybridCacheTests</c>.
+/// </remarks>
+internal sealed class FakeFinnHubCache : IFinnHubCache
+{
+    private readonly Dictionary<string, object?> _entries = new(StringComparer.Ordinal);
+
+    public int FactoryInvocationCount { get; private set; }
+
+    public async ValueTask<T> GetOrCreateAsync<T>(
+        string key,
+        CacheTier tier,
+        Func<CancellationToken, ValueTask<T>> factory,
+        CancellationToken cancellationToken = default)
+    {
+        var compositeKey = $"{tier}:{key}";
+
+        if (this._entries.TryGetValue(compositeKey, out var cached))
+        {
+            return (T)cached!;
+        }
+
+        this.FactoryInvocationCount++;
+        var value = await factory(cancellationToken);
+        this._entries[compositeKey] = value;
+        return value;
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Caching/FinnHubHybridCacheTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Caching/FinnHubHybridCacheTests.cs
@@ -1,0 +1,132 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Caching;
+using Microsoft.Extensions.Caching.Hybrid;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Caching;
+
+public sealed class FinnHubHybridCacheTests
+{
+    private readonly HybridCache _hybridCache;
+    private readonly ILogger<FinnHubHybridCache> _logger;
+    private readonly FinnHubHybridCache _sut;
+
+    public FinnHubHybridCacheTests()
+    {
+        var services = new ServiceCollection();
+        services.AddHybridCache();
+        this._hybridCache = services.BuildServiceProvider().GetRequiredService<HybridCache>();
+        this._logger = Substitute.For<ILogger<FinnHubHybridCache>>();
+        this._sut = new FinnHubHybridCache(
+            this._hybridCache,
+            Microsoft.Extensions.Options.Options.Create(new CacheOptions()),
+            this._logger);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_FirstCall_InvokesFactory()
+    {
+        var calls = 0;
+
+        var result = await this._sut.GetOrCreateAsync(
+            $"first-call:{Guid.NewGuid()}",
+            CacheTier.News,
+            _ =>
+            {
+                calls++;
+                return ValueTask.FromResult("payload");
+            });
+
+        Assert.Equal(1, calls);
+        Assert.Equal("payload", result);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_SecondCallWithSameKey_DoesNotInvokeFactory()
+    {
+        var key = $"same-key:{Guid.NewGuid()}";
+        var calls = 0;
+
+        async ValueTask<string> Factory(CancellationToken _)
+        {
+            calls++;
+            return await ValueTask.FromResult("payload");
+        }
+
+        await this._sut.GetOrCreateAsync(key, CacheTier.News, Factory);
+        var second = await this._sut.GetOrCreateAsync(key, CacheTier.News, Factory);
+
+        Assert.Equal(1, calls);
+        Assert.Equal("payload", second);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_DifferentKeys_InvokeFactoryPerKey()
+    {
+        var calls = 0;
+
+        async ValueTask<string> Factory(CancellationToken _)
+        {
+            calls++;
+            return await ValueTask.FromResult($"call-{calls}");
+        }
+
+        await this._sut.GetOrCreateAsync($"k-a:{Guid.NewGuid()}", CacheTier.News, Factory);
+        await this._sut.GetOrCreateAsync($"k-b:{Guid.NewGuid()}", CacheTier.News, Factory);
+
+        Assert.Equal(2, calls);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_FactoryThrows_DoesNotPoisonCache()
+    {
+        var key = $"throws:{Guid.NewGuid()}";
+        var calls = 0;
+
+        async ValueTask<string> Factory(CancellationToken _)
+        {
+            calls++;
+            if (calls == 1)
+            {
+                throw new InvalidOperationException("first call boom");
+            }
+
+            return await ValueTask.FromResult("recovered");
+        }
+
+        await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+            await this._sut.GetOrCreateAsync(key, CacheTier.News, Factory));
+
+        var second = await this._sut.GetOrCreateAsync(key, CacheTier.News, Factory);
+
+        Assert.Equal(2, calls);
+        Assert.Equal("recovered", second);
+    }
+
+    [Fact]
+    public async Task GetOrCreateAsync_EmitsMissThenHitLogs()
+    {
+        var key = $"log-shape:{Guid.NewGuid()}";
+
+        await this._sut.GetOrCreateAsync(key, CacheTier.News, _ => ValueTask.FromResult("v"));
+        await this._sut.GetOrCreateAsync(key, CacheTier.News, _ => ValueTask.FromResult("v"));
+
+        this._logger.Received(2).Log(
+            LogLevel.Information,
+            Arg.Any<EventId>(),
+            Arg.Any<object>(),
+            Arg.Any<Exception?>(),
+            Arg.Any<Func<object, Exception?, string>>());
+    }
+}


### PR DESCRIPTION
## Summary

Phase 2 of the product-surface milestone (`.planning/specs/01-product-surface.md`): lands a `HybridCache`-backed caching layer with per-endpoint mutability tiers, wires `SearchService` through it, and ships full test coverage across all three test projects.

Six conventional commits, ordered so each compiles cumulatively. After this PR, two identical `search-symbol` invocations within the configured TTL hit Finnhub exactly once.

## Commits

1. `feat: add CacheTier enum and CacheOptions with tiered TTLs` — Application-layer types. `CacheTier` enum (Quote / News / Financials / Profile / Exchanges), `CacheOptions` with per-tier `TimeSpan` properties under `[Range]` data-annotation bounds, `GetTtl(tier)` accessor switch.
2. `feat: add IFinnHubCache abstraction and CacheKey helper` — single-method interface in Application; `CacheKey` builds the namespaced shape `finnhub:tenant={tenant}:tier={tier_lowercase}:{logicalKey}` with the literal `"shared"` tenant for v1 per spec §4.
3. `feat: add HybridCache-backed IFinnHubCache implementation` — `Microsoft.Extensions.Caching.Hybrid 10.0.0` package added via `MicrosoftExtensionsVersion` pin, concrete impl in Infrastructure, DI registration via `services.AddHybridCache()` + `IFinnHubCache` singleton, `CacheOptions` binding in `Program.cs`, `appsettings.json` `Cache` section with the spec's default TTLs.
4. `refactor: route SearchService through IFinnHubCache` — wraps the existing upstream call with `cache.GetOrCreateAsync` at the `News` tier (per R5). Cache key canonicalises query (lowercase) and exchange (uppercase) and excludes `QueryId`. Explicit `[JsonSerializable(typeof(SearchSymbolResponse))]` added to the source-gen JSON context for AOT clarity.
5. `test: cover cache options, key shape, search caching, and HybridCache impl` — 37 new tests across Application + Infrastructure. Includes `FakeFinnHubCache` test double that replaces T5's pass-through substitute. `FinnHubHybridCacheTests` drives a real in-memory `HybridCache` to verify cache-hit short-circuit, factory-throw non-poisoning, and structured log emission.
6. `docs: document response caching tier configuration` — README "Response caching" subsection with the tier table and tunability note.

## Verification

- `dotnet build` — 0 warnings under `TreatWarningsAsErrors`
- `dotnet test` — 137 passing (Application 57, Infrastructure 21, Server 59); was 100 at the v1.12.0 baseline
- `dotnet format --verify-no-changes` — clean

## Risks resolved (planning R1–R6)

- **R1**: `Microsoft.Extensions.Caching.Hybrid 10.0.0` restored cleanly under the existing `MicrosoftExtensionsVersion` pin — no separate version required.
- **R2**: SDK exposes both `GetOrCreateAsync<TState, T>` and stateless `GetOrCreateAsync<T>(string, Func<CancellationToken, ValueTask<T>>, ...)`. Stateless overload matches our `IFinnHubCache` shape; no state-arg allocation.
- **R3**: Default `System.Text.Json` plumbing in SDK 10.0.0 is sufficient. Added explicit `[JsonSerializable(typeof(SearchSymbolResponse))]` for AOT clarity; no custom `IHybridCacheSerializerFactory` needed.
- **R4**: Cache key shape `search-symbol:q={lower-query}:ex={upper-exchange|*}:lim={N}`; `QueryId` excluded.
- **R5**: `News` tier (60s) for symbol search. Reevaluate when P6 lands the rest of the tool surface.
- **R6**: HybridCache propagates factory exceptions without caching them — verified end-to-end at runtime and via the `GetOrCreateAsync_FactoryThrows_DoesNotPoisonCache` test.

## Known deferral

- Cache-key partitioning currently uses the literal `tenant=shared` segment. The BYOK milestone (Spec B P3) flips this to `tenant=sha256(api-key)` without a key-shape migration. The hook is in by design.

## What this draft is waiting on

Manual STDIO smoke test against a real Finnhub key to confirm two consecutive identical `search-symbol` calls hit the upstream exactly once. Unit tests already cover the cache-hit short-circuit against an in-memory `HybridCache`; the smoke is belt-and-braces against the real SDK + real Finnhub round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)