### PR TITLE
fix: stop --urls 8080 collision and .env env-var clobbering in stdio dev flow

### DIFF
--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -21,15 +21,17 @@ var assembly = Assembly.GetEntryAssembly();
 var applicationName = assembly?.GetCustomAttribute<AssemblyTitleAttribute>()?.Title ?? $"finnhub-mcp-server-{Guid.NewGuid()}";
 var version = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion.Split('+')[0] ?? "1.0.0";
 
-if (!args.Contains("--urls"))
+var isStdio = args.Contains("--stdio");
+
+// STDIO transport never binds HTTP — skip the default --urls injection so two
+// concurrent stdio instances don't fight over port 8080.
+if (!isStdio && !args.Contains("--urls"))
 {
     args = args
         .Append("--urls")
         .Append($"http://localhost:{8080}/")
         .ToArray();
 }
-
-var isStdio = args.Contains("--stdio");
 
 var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 {

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -41,7 +41,11 @@ var builder = WebApplication.CreateBuilder(new WebApplicationOptions
 
 if (builder.Environment.IsDevelopment())
 {
-    Env.TraversePath().Load();
+    // Defer to launcher-supplied env vars (Claude Code -e flags, container env, k8s
+    // secrets). The .env file only fills gaps for locals that haven't been set —
+    // never overrides them. Without this, a stale .env in the workspace can
+    // silently override a freshly-rotated API key passed by the launcher.
+    new LoadOptions(setEnvVars: true, clobberExistingVars: false, onlyExactPath: false).Load();
 }
 
 var exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule?.FileName;


### PR DESCRIPTION
## Summary

Two one-line dev-experience fixes flagged after the P2 smoke session today.

## Commits

1. **`fix: skip --urls injection in stdio mode`** — `Program.cs` was always injecting `--urls http://localhost:8080/` before computing `isStdio`, so two concurrent stdio runs fought over port 8080. Compute `isStdio` first, then only inject when not in stdio mode. Note: Kestrel still binds a default port in stdio mode because the app is built as a `WebApplication`; fully skipping Kestrel is a larger refactor outside this PR's scope.

2. **`fix: stop .env from clobbering launcher-supplied env vars`** — `DotNetEnv 3.x` defaults to `ClobberExistingVars = true`, so a workspace-local `.env` silently overrode the `FINNHUB_API_KEY` env var Claude Code passed via `-e`. Switch to `LoadOptions(setEnvVars: true, clobberExistingVars: false, onlyExactPath: false).Load()`. Standard env hierarchy: launcher > .env > defaults.

## Verification

- `dotnet build` — 0 warnings under `TreatWarningsAsErrors`
- `dotnet test` — 137 passing (no test changes; both fixes are behavioural)
- `dotnet format --verify-no-changes` — clean
- Manual port-collision smoke: with port 8080 occupied by a sentinel listener, stdio launch no longer errors with "Address already in use" (Kestrel still binds a default port, but not 8080).
- No-clobber: build verifies the `LoadOptions` API is used correctly; behaviour is documented by DotNetEnv 3.1.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)