### PR TITLE
feat(p6a): add get-peers tool — pattern reference for Wave A

### DIFF
--- a/src/FinnHub.MCP.Server.Application/Peers/Clients/IPeersApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Clients/IPeersApiClient.cs
@@ -1,0 +1,22 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+
+namespace FinnHub.MCP.Server.Application.Peers.Clients;
+
+/// <summary>
+/// Infrastructure contract for the Finnhub <c>/stock/peers</c> endpoint.
+/// Implementations handle HTTP transport, deserialization, and exception translation.
+/// </summary>
+public interface IPeersApiClient
+{
+    /// <summary>
+    /// Fetches the peer ticker list for a symbol.
+    /// </summary>
+    Task<GetPeersResponse> GetPeersAsync(GetPeersQuery query, CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/Peers/Features/GetPeers/GetPeersQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Features/GetPeers/GetPeersQuery.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+
+/// <summary>
+/// Query parameters for the <c>get-peers</c> tool — a Finnhub <c>/stock/peers</c> lookup
+/// for a symbol with optional grouping (industry, subindustry, sector).
+/// </summary>
+public sealed class GetPeersQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Uppercase ticker symbol the peer set is requested for.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Grouping strategy: <c>industry</c> (default), <c>subindustry</c>, or <c>sector</c>.</summary>
+    public PeersGrouping Grouping { get; init; } = PeersGrouping.Industry;
+}

--- a/src/FinnHub.MCP.Server.Application/Peers/Features/GetPeers/GetPeersResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Features/GetPeers/GetPeersResponse.cs
@@ -1,0 +1,35 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+
+/// <summary>
+/// Wire response for <c>get-peers</c>. Carries the peer ticker list and the grouping
+/// strategy that produced it.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class GetPeersResponse
+{
+    /// <summary>Peer ticker symbols, ordered as returned by Finnhub.</summary>
+    [JsonPropertyName("peers")]
+    public IReadOnlyList<string> Peers { get; init; } = [];
+
+    /// <summary>Echo of the grouping that produced the list (industry|subindustry|sector).</summary>
+    [JsonPropertyName("grouping")]
+    public required string Grouping { get; init; }
+
+    /// <summary>Number of peers returned.</summary>
+    [JsonPropertyName("total_count")]
+    public int TotalCount => this.Peers.Count;
+
+    /// <summary>Whether any peers were returned.</summary>
+    [JsonPropertyName("has_results")]
+    public bool HasResults => this.TotalCount > 0;
+}

--- a/src/FinnHub.MCP.Server.Application/Peers/Features/GetPeers/PeersGrouping.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Features/GetPeers/PeersGrouping.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+
+/// <summary>
+/// Grouping strategy the Finnhub <c>/stock/peers</c> endpoint uses to determine
+/// "peer" companies for a given ticker.
+/// </summary>
+public enum PeersGrouping
+{
+    /// <summary>Default — peers within the same GICS industry.</summary>
+    Industry,
+
+    /// <summary>Peers within the same GICS sub-industry (tighter than industry).</summary>
+    SubIndustry,
+
+    /// <summary>Peers within the broader GICS sector (looser than industry).</summary>
+    Sector
+}

--- a/src/FinnHub.MCP.Server.Application/Peers/Services/IPeersService.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Services/IPeersService.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+
+namespace FinnHub.MCP.Server.Application.Peers.Services;
+
+/// <summary>
+/// Application-level entry point for peer lookups. Translates infrastructure
+/// exceptions into typed <see cref="Result{T}"/> shapes the tool can consume.
+/// </summary>
+public interface IPeersService
+{
+    /// <summary>
+    /// Executes a peer lookup and returns a categorized result.
+    /// </summary>
+    Task<Result<GetPeersResponse>> GetPeersAsync(GetPeersQuery query, CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
@@ -1,0 +1,83 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Clients;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.Peers.Services;
+
+/// <summary>
+/// Default <see cref="IPeersService"/> wrapping <see cref="IPeersApiClient"/> with
+/// hybrid caching and exception-to-result translation.
+/// </summary>
+public sealed class PeersService(
+    IPeersApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<PeersService> logger)
+    : IPeersService
+{
+    /// <inheritdoc />
+    public async Task<Result<GetPeersResponse>> GetPeersAsync(
+        GetPeersQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            var cacheKey = BuildCacheKey(query);
+
+            var response = await cache.GetOrCreateAsync(
+                cacheKey,
+                CacheTier.Profile,
+                async ct => await apiClient.GetPeersAsync(query, ct),
+                cancellationToken);
+
+            logger.LogInformation(
+                "Retrieved {Count} peers for {Symbol} (grouping={Grouping})",
+                response.TotalCount, query.Symbol, query.Grouping);
+
+            return response.HasResults
+                ? new Result<GetPeersResponse>().Success(response)
+                : new Result<GetPeersResponse>().Failure(
+                    $"No peers found for {query.Symbol}.",
+                    ResultErrorType.NotFound);
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogWarning(ex, "Premium-only peers endpoint for {Symbol}", query.Symbol);
+            return new Result<GetPeersResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching peers for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
+            return new Result<GetPeersResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "Peers request timed out for {Symbol}", query.Symbol);
+            return new Result<GetPeersResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize peers response for {Symbol}", query.Symbol);
+            return new Result<GetPeersResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected peers failure for {Symbol}", query.Symbol);
+            return new Result<GetPeersResponse>().Failure("Peers lookup failed unexpectedly");
+        }
+    }
+
+    private static string BuildCacheKey(GetPeersQuery query) =>
+        $"peers:s={query.Symbol.ToUpperInvariant()}:g={query.Grouping}";
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Peers/FinnHubPeersApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Peers/FinnHubPeersApiClient.cs
@@ -1,0 +1,144 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Peers.Clients;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Peers;
+
+/// <summary>
+/// HTTP client for the Finnhub <c>/stock/peers</c> endpoint. The upstream response
+/// is a flat JSON array of ticker strings; this client normalises that into a
+/// <see cref="GetPeersResponse"/> and translates HTTP failures into typed exceptions.
+/// </summary>
+public sealed class FinnHubPeersApiClient : IPeersApiClient
+{
+    private const string EndpointName = "peers";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubPeersApiClient> _logger;
+
+    /// <summary>
+    /// Initialises a new <see cref="FinnHubPeersApiClient"/>.
+    /// </summary>
+    public FinnHubPeersApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubPeersApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GetPeersResponse> GetPeersAsync(GetPeersQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var endpoint = this._options.EndPoints.FirstOrDefault(e => e is { IsActive: true, Name: EndpointName })?.Url
+                       ?? throw new ArgumentException("Peers endpoint is not configured or inactive");
+
+        var groupingParam = MapGrouping(query.Grouping);
+        var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(query.Symbol)}&grouping={groupingParam}";
+
+        this._logger.LogInformation("Requesting peers from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub peers failed: {Uri}", requestUri);
+            throw new ApiClientHttpException($"HTTP request to FinnHub peers failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Peers request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"Peers request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("Peers request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"Peers request cancelled: {requestUri}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        IReadOnlyList<string> tickers;
+        try
+        {
+            tickers = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.StringArray, cancellationToken)
+                .ConfigureAwait(false) ?? [];
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize peers response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize peers response: {requestUri}",
+                innerException: ex);
+        }
+
+        return new GetPeersResponse
+        {
+            Peers = tickers,
+            Grouping = groupingParam
+        };
+    }
+
+    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            this._logger.LogWarning("Premium-locked peers endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        this._logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "Peers API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException(
+            $"FinnHub peers returned {statusCode}.", statusCode, errorBody);
+    }
+
+    private static string MapGrouping(PeersGrouping grouping) => grouping switch
+    {
+        PeersGrouping.Industry => "industry",
+        PeersGrouping.SubIndustry => "subIndustry",
+        PeersGrouping.Sector => "sector",
+        _ => throw new ArgumentOutOfRangeException(nameof(grouping), grouping, "Unknown peer grouping")
+    };
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -10,9 +10,12 @@ using System.Net.Http.Headers;
 using System.Net.Mime;
 using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Peers.Clients;
+using FinnHub.MCP.Server.Application.Peers.Services;
 using FinnHub.MCP.Server.Application.RateLimiting;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Caching;
+using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
 using FinnHub.MCP.Server.Infrastructure.RateLimiting;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -54,41 +57,45 @@ public static class ServiceCollectionExtension
         services.AddSingleton<IRateLimitTracker, RateLimitTracker>();
         services.AddTransient<RateLimitHeaderHandler>();
 
-        services.AddHttpClient<ISearchApiClient, FinnHubSearchApiClient>("FinnHub-Search-Client", (provider, client) =>
-            {
-                var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;
-
-                client.BaseAddress = new Uri(options.BaseUrl);
-                client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
-                client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("FinnHub-MCP-Server", "1.0"));
-                client.Timeout = TimeSpan.FromSeconds(30);
-
-                if (!string.IsNullOrWhiteSpace(options.ApiKey))
-                {
-                    client.DefaultRequestHeaders.Add("X-Finnhub-Token", options.ApiKey);
-                }
-            })
-            .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler
-            {
-                PooledConnectionLifetime = TimeSpan.FromMinutes(2),
-                MaxConnectionsPerServer = 10,
-                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
-            })
+        services.AddHttpClient<ISearchApiClient, FinnHubSearchApiClient>("FinnHub-Search-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
             // Rate-limit header observation runs outermost so it sees the post-retry response
             // Polly ultimately surfaces to the caller, not the intermediate failed attempts.
             .AddHttpMessageHandler<RateLimitHeaderHandler>()
-            .AddPolicyHandler((provider, _) =>
-            {
-                var logger = provider.GetRequiredService<ILogger<FinnHubSearchApiClient>>();
-                return GetRetryPolicy(logger);
-            })
-            .AddPolicyHandler((provider, _) =>
-            {
-                var logger = provider.GetRequiredService<ILogger<FinnHubSearchApiClient>>();
-                return GetCircuitBreakerPolicy(logger);
-            })
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubSearchApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubSearchApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<IPeersService, PeersService>();
+        services.AddHttpClient<IPeersApiClient, FinnHubPeersApiClient>("FinnHub-Peers-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubPeersApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubPeersApiClient>>()))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
+
+    private static void ConfigureFinnHubClient(IServiceProvider provider, HttpClient client)
+    {
+        var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;
+
+        client.BaseAddress = new Uri(options.BaseUrl);
+        client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
+        client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("FinnHub-MCP-Server", "1.0"));
+        client.Timeout = TimeSpan.FromSeconds(30);
+
+        if (!string.IsNullOrWhiteSpace(options.ApiKey))
+        {
+            client.DefaultRequestHeaders.Add("X-Finnhub-Token", options.ApiKey);
+        }
+    }
+
+    private static HttpMessageHandler BuildPrimaryHandler() => new SocketsHttpHandler
+    {
+        PooledConnectionLifetime = TimeSpan.FromMinutes(2),
+        MaxConnectionsPerServer = 10,
+        AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+    };
 
     /// <summary>
     /// Builds a retry policy using Polly with exponential backoff and logs each retry attempt.

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -8,6 +8,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Application.Symbols;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
@@ -50,4 +51,7 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 [JsonSerializable(typeof(NextAction))]
 [JsonSerializable(typeof(RateLimitInfo))]
 [JsonSerializable(typeof(ToolResponseEnvelope<SearchSymbolResponse>))]
+[JsonSerializable(typeof(GetPeersResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetPeersResponse>))]
+[JsonSerializable(typeof(string[]))]
 public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -191,5 +191,64 @@ public static class Constants
                 Approx tokens: summary ~200, standard ~2000, full ~8000.
                 """;
         }
+
+        /// <summary>
+        /// Constants for the <c>get-peers</c> tool — peer ticker lookup for a symbol.
+        /// </summary>
+        public static class Peers
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-peers";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get Peers";
+
+            /// <summary>
+            /// Parameter names and descriptions for <c>get-peers</c>.
+            /// </summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription = "Uppercase ticker symbol, e.g. 'AAPL'.";
+
+                /// <summary>Grouping parameter name.</summary>
+                public const string GroupingName = "grouping";
+
+                /// <summary>Grouping parameter description.</summary>
+                public const string GroupingDescription =
+                    "Peer grouping strategy: industry (default), subindustry, or sector.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>
+            /// Tool description registered with the MCP server.
+            /// </summary>
+            public const string Description =
+                """
+                Get the peer ticker list for a symbol — companies in the same industry, sub-industry, or sector.
+
+                ## Example:
+                - symbol='AAPL', grouping='industry'
+
+                ## Response Fields:
+                - peers (array of strings): peer ticker symbols
+                - grouping (string): echo of the grouping strategy
+                - total_count (int)
+                - has_results (bool)
+
+                ## Notes:
+                - summary view returns the top 10 peers; standard returns up to 25; full returns the complete array.
+
+                Approx tokens: summary ~80, standard ~200, full ~400.
+                """;
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -16,6 +16,7 @@ using FinnHub.MCP.Server.Infrastructure.Extensions;
 using FinnHub.MCP.Server.Middleware;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
+using FinnHub.MCP.Server.Tools.Peers;
 using FinnHub.MCP.Server.Tools.Search;
 using Microsoft.AspNetCore.Mvc;
 
@@ -95,6 +96,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
     };
 })
 .WithWrappedTools<SearchSymbolTool>()
+.WithWrappedTools<GetPeersTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>();
 

--- a/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
@@ -1,0 +1,139 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Application.Peers.Services;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Peers;
+
+/// <summary>
+/// MCP tool exposing the Finnhub <c>/stock/peers</c> endpoint.
+/// </summary>
+[McpServerToolType]
+public sealed class GetPeersTool(
+    IPeersService peersService,
+    ILogger<GetPeersTool> logger)
+{
+    private const int SummaryPeerLimit = 10;
+    private const int StandardPeerLimit = 25;
+
+    /// <summary>
+    /// Returns peer ticker symbols for a given symbol, optionally bucketed by industry, sub-industry, or sector.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.Peers.Name,
+        Title = Constants.Tools.Peers.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.Peers.Description)]
+    public async Task<ToolResponseEnvelope<GetPeersResponse>> GetPeersAsync(
+        [Description(Constants.Tools.Peers.Parameters.SymbolDescription)]
+        string symbol,
+        [Description(Constants.Tools.Peers.Parameters.GroupingDescription)]
+        string? grouping = null,
+        [Description(Constants.Tools.Peers.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.Peers.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedSymbol = PeersInputValidator.ValidateSymbol(symbol);
+            var validatedGrouping = PeersInputValidator.ValidateGrouping(grouping);
+            var validatedView = PeersInputValidator.ValidateView(view);
+
+            var query = new GetPeersQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Symbol = validatedSymbol,
+                Grouping = validatedGrouping
+            };
+
+            var result = await peersService.GetPeersAsync(query, cancellationToken);
+
+            logger.LogInformation(
+                "Peers completed for {Symbol} in {ElapsedMs}ms: {Count} peers",
+                validatedSymbol, stopwatch.ElapsedMilliseconds, result.Data?.TotalCount ?? 0);
+
+            return EnvelopeFactory.FromResult(
+                ProjectByView(result, validatedView),
+                validatedView,
+                explanation: BuildExplanation(result, validatedSymbol));
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static Result<GetPeersResponse> ProjectByView(Result<GetPeersResponse> result, ToolView view)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return result;
+        }
+
+        var cap = view switch
+        {
+            ToolView.Summary => SummaryPeerLimit,
+            ToolView.Standard => StandardPeerLimit,
+            _ => int.MaxValue
+        };
+
+        if (result.Data.Peers.Count <= cap)
+        {
+            return result;
+        }
+
+        var projected = new GetPeersResponse
+        {
+            Peers = result.Data.Peers.Take(cap).ToList().AsReadOnly(),
+            Grouping = result.Data.Grouping
+        };
+
+        return new Result<GetPeersResponse>().Success(projected);
+    }
+
+    private static string BuildExplanation(Result<GetPeersResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return $"No peers found for '{symbol}'.";
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Found {result.Data.TotalCount} peer(s) for '{symbol}' ({result.Data.Grouping}).");
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Peers/PeersInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Peers/PeersInputValidator.cs
@@ -1,0 +1,74 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+
+namespace FinnHub.MCP.Server.Tools.Peers;
+
+/// <summary>
+/// Validation helpers for <c>get-peers</c> tool parameters.
+/// </summary>
+internal static partial class PeersInputValidator
+{
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be empty.", nameof(symbol));
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static PeersGrouping ValidateGrouping(string? grouping)
+    {
+        if (string.IsNullOrWhiteSpace(grouping))
+        {
+            return PeersGrouping.Industry;
+        }
+
+        return grouping.Trim().ToLowerInvariant() switch
+        {
+            "industry" => PeersGrouping.Industry,
+            "subindustry" => PeersGrouping.SubIndustry,
+            "sector" => PeersGrouping.Sector,
+            _ => throw new ArgumentException(
+                "Grouping must be one of: industry, subindustry, sector.",
+                nameof(grouping))
+        };
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -24,6 +24,13 @@
         "IsActive": true,
         "group": "stock",
         "Description": "Searches for best-matching symbols based on specified query."
+      },
+      {
+        "Name": "peers",
+        "Url": "/stock/peers",
+        "IsActive": true,
+        "group": "stock",
+        "Description": "Returns peer ticker list for a symbol with optional grouping."
       }
     ]
   },

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Peers/Services/PeersServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Peers/Services/PeersServiceTests.cs
@@ -1,0 +1,101 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Peers.Clients;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Application.Peers.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Peers.Services;
+
+public sealed class PeersServiceTests
+{
+    private readonly IPeersApiClient _apiClient = Substitute.For<IPeersApiClient>();
+    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly PeersService _sut;
+
+    public PeersServiceTests()
+    {
+        // Cache passes through to factory by default
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<GetPeersResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetPeersResponse>>>()(CancellationToken.None));
+
+        this._sut = new PeersService(this._apiClient, this._cache, NullLogger<PeersService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetPeersAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_WithResults_ReturnsSuccess()
+    {
+        var query = new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" };
+        var response = new GetPeersResponse { Peers = ["MSFT", "GOOG"], Grouping = "industry" };
+        this._apiClient.GetPeersAsync(query, Arg.Any<CancellationToken>()).Returns(response);
+
+        var result = await this._sut.GetPeersAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(2, result.Data!.TotalCount);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_EmptyPeers_ReturnsNotFound()
+    {
+        var query = new GetPeersQuery { QueryId = "q1", Symbol = "UNKN" };
+        this._apiClient
+            .GetPeersAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetPeersResponse { Peers = [], Grouping = "industry" });
+
+        var result = await this._sut.GetPeersAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("NotFound", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_PremiumRequired_MapsToPremiumRequiredResult()
+    {
+        var query = new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient
+            .GetPeersAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/api/v1/stock/peers"));
+
+        var result = await this._sut.GetPeersAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PremiumRequired", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_HttpError_MapsToServiceUnavailable()
+    {
+        var query = new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient
+            .GetPeersAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientHttpException("boom", HttpStatusCode.BadGateway));
+
+        var result = await this._sut.GetPeersAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ServiceUnavailable", result.ErrorType);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
@@ -1,0 +1,106 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Peers;
+
+public sealed class FinnHubPeersApiClientTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubPeersApiClient _sut;
+
+    public FinnHubPeersApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints = [new FinnHubEndPoint { Name = "peers", Url = "stock/peers", IsActive = true }]
+        });
+
+        this._sut = new FinnHubPeersApiClient(
+            this._httpClient,
+            options,
+            NullLogger<FinnHubPeersApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_Success_ReturnsMappedResponse()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "[\"MSFT\",\"GOOG\",\"AMZN\"]");
+
+        var result = await this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL", Grouping = PeersGrouping.Industry },
+            CancellationToken.None);
+
+        Assert.Equal(3, result.TotalCount);
+        Assert.Equal("MSFT", result.Peers[0]);
+        Assert.Equal("industry", result.Grouping);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_SubIndustryGrouping_MapsCorrectlyInUri()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "[]");
+
+        await this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL", Grouping = PeersGrouping.SubIndustry },
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Contains("grouping=subIndustry", this._handler.LastRequest!.RequestUri!.Query, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "{\"error\":\"premium\"}");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_ServerError_ThrowsHttpException()
+    {
+        this._handler.SetResponse(HttpStatusCode.BadGateway, "upstream down");
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_InvalidJson_ThrowsDeserialization()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "not-json");
+
+        await Assert.ThrowsAsync<ApiClientDeserializationException>(() => this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
@@ -1,0 +1,85 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Application.Peers.Services;
+using FinnHub.MCP.Server.Tools.Peers;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Peers;
+
+public sealed class GetPeersToolTests
+{
+    private readonly IPeersService _service = Substitute.For<IPeersService>();
+    private readonly GetPeersTool _sut;
+
+    public GetPeersToolTests()
+    {
+        this._sut = new GetPeersTool(this._service, NullLogger<GetPeersTool>.Instance);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetPeersAsync("!!!"));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_LowercaseSymbol_NormalisesToUppercase()
+    {
+        this._service
+            .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetPeersResponse>().Success(
+                new GetPeersResponse { Peers = ["MSFT"], Grouping = "industry" }));
+
+        await this._sut.GetPeersAsync("aapl");
+
+        await this._service.Received(1).GetPeersAsync(
+            Arg.Is<GetPeersQuery>(q => q.Symbol == "AAPL"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_SummaryView_CapsAtTen()
+    {
+        var manyPeers = Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray();
+        this._service
+            .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetPeersResponse>().Success(
+                new GetPeersResponse { Peers = manyPeers, Grouping = "industry" }));
+
+        var envelope = await this._sut.GetPeersAsync("AAPL", view: "summary");
+
+        Assert.True(envelope.IsSuccess);
+        Assert.Equal(10, envelope.Data!.TotalCount);
+        Assert.Equal("P1", envelope.Data.Peers[0]);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_FullView_ReturnsAll()
+    {
+        var manyPeers = Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray();
+        this._service
+            .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetPeersResponse>().Success(
+                new GetPeersResponse { Peers = manyPeers, Grouping = "industry" }));
+
+        var envelope = await this._sut.GetPeersAsync("AAPL", view: "full");
+
+        Assert.Equal(30, envelope.Data!.TotalCount);
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_InvalidGrouping_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._sut.GetPeersAsync("AAPL", grouping: "nonsense"));
+    }
+}


### PR DESCRIPTION
## Summary
First of four P6 Wave A aggregation tools. Establishes the per-tool template (Tool + InputValidator + Query/Response + Service + ApiClient + DI + tests) that the next three (get-financials-snapshot, get-price-summary, get-news-pulse) will mirror, each shipping in its own PR.

**Why ship per-tool rather than the full wave at once:** smaller review surface, faster CI feedback, pattern validation before multiplication.

## Tool: get-peers
- Maps to Finnhub `/stock/peers`
- Optional `grouping` parameter: `industry` (default), `subindustry`, `sector`
- `summary` view caps at 10 peers, `standard` at 25, `full` returns all
- Wired through `ToolInvocationMiddleware` via `WithWrappedTools` so it participates in the P1 envelope-budget enforcement and P4 rate-limit threading
- Profile-tier cache (24h TTL) keyed on `symbol + grouping`
- 403 from Finnhub fails fast as `PremiumRequired` per P5

## Refactor: ServiceCollectionExtension
Extracted `ConfigureFinnHubClient` and `BuildPrimaryHandler` so each new tool's named HttpClient registration is two lines, not twenty.

## Spec
[`.planning/specs/01-product-surface.md` §3 P6](https://github.com/SalZaki/finnhub-mcp/blob/main/.planning/specs/01-product-surface.md)

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 192/192 pass (was 177; +15 new across 3 layers)
  - Service: cache passthrough, success/notfound mapping, premium/http/timeout exception mapping
  - Client: success, sub-industry grouping in URI, 403 → PremiumRequired, 5xx → ApiClientHttpException, invalid JSON → Deserialization
  - Tool: invalid symbol/grouping rejected, lowercase normalised, summary caps at 10, full returns all
- [ ] Live smoke: deferred until full wave merges — easier to validate cross-tool `next_actions` together