### PR TITLE
feat(p6a): add get-financials-snapshot — 10 curated KPIs

### DIFF
--- a/src/FinnHub.MCP.Server.Application/Financials/Clients/IFinancialsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Clients/IFinancialsApiClient.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+
+namespace FinnHub.MCP.Server.Application.Financials.Clients;
+
+/// <summary>
+/// Infrastructure contract for the Finnhub <c>/stock/metric</c> endpoint.
+/// </summary>
+public interface IFinancialsApiClient
+{
+    /// <summary>
+    /// Fetches the basic-financials metric snapshot for a symbol. The returned
+    /// response always carries the 10 curated KPIs; the raw dictionary is populated
+    /// only when <paramref name="query"/> has <c>IncludeRaw = true</c>.
+    /// </summary>
+    Task<GetFinancialsSnapshotResponse> GetSnapshotAsync(GetFinancialsSnapshotQuery query, CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/Financials/Features/GetFinancialsSnapshot/GetFinancialsSnapshotQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Features/GetFinancialsSnapshot/GetFinancialsSnapshotQuery.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+
+/// <summary>
+/// Query parameters for the <c>get-financials-snapshot</c> tool — a Finnhub
+/// <c>/stock/metric</c> lookup that returns a curated 10-KPI snapshot for a ticker.
+/// </summary>
+public sealed class GetFinancialsSnapshotQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Uppercase ticker symbol the snapshot is requested for.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Whether the response should carry the raw upstream metric dictionary in addition to the curated KPIs.</summary>
+    public bool IncludeRaw { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Financials/Features/GetFinancialsSnapshot/GetFinancialsSnapshotResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Features/GetFinancialsSnapshot/GetFinancialsSnapshotResponse.cs
@@ -1,0 +1,68 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+
+/// <summary>
+/// Wire response for <c>get-financials-snapshot</c>. Curated 10-KPI projection
+/// over the Finnhub <c>/stock/metric</c> payload. <see cref="Raw"/> is populated
+/// only when the tool was invoked with <c>view = "full"</c>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class GetFinancialsSnapshotResponse
+{
+    /// <summary>Ticker symbol the snapshot applies to.</summary>
+    [JsonPropertyName("symbol")]
+    public required string Symbol { get; init; }
+
+    /// <summary>Market capitalisation in USD millions.</summary>
+    [JsonPropertyName("market_cap")]
+    public double? MarketCap { get; init; }
+
+    /// <summary>Trailing twelve-month price/earnings ratio.</summary>
+    [JsonPropertyName("pe_ttm")]
+    public double? PeTtm { get; init; }
+
+    /// <summary>Annual price/book ratio.</summary>
+    [JsonPropertyName("pb_annual")]
+    public double? PbAnnual { get; init; }
+
+    /// <summary>Trailing twelve-month earnings per share.</summary>
+    [JsonPropertyName("eps_ttm")]
+    public double? EpsTtm { get; init; }
+
+    /// <summary>Indicated annual dividend yield.</summary>
+    [JsonPropertyName("dividend_yield")]
+    public double? DividendYield { get; init; }
+
+    /// <summary>52-week high price.</summary>
+    [JsonPropertyName("week52_high")]
+    public double? Week52High { get; init; }
+
+    /// <summary>52-week low price.</summary>
+    [JsonPropertyName("week52_low")]
+    public double? Week52Low { get; init; }
+
+    /// <summary>52-week price return (percent).</summary>
+    [JsonPropertyName("week52_price_return_pct")]
+    public double? Week52PriceReturnPct { get; init; }
+
+    /// <summary>Beta vs market.</summary>
+    [JsonPropertyName("beta")]
+    public double? Beta { get; init; }
+
+    /// <summary>Trailing twelve-month revenue per share.</summary>
+    [JsonPropertyName("revenue_per_share_ttm")]
+    public double? RevenuePerShareTtm { get; init; }
+
+    /// <summary>Raw upstream metric dictionary. Populated only when the tool was invoked with <c>view = "full"</c>.</summary>
+    [JsonPropertyName("raw")]
+    public IReadOnlyDictionary<string, double?>? Raw { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
@@ -1,0 +1,77 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Financials.Clients;
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Models;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.Financials.Services;
+
+/// <summary>
+/// Default <see cref="IFinancialsService"/> wrapping <see cref="IFinancialsApiClient"/>
+/// with hybrid caching and exception-to-result translation.
+/// </summary>
+public sealed class FinancialsService(
+    IFinancialsApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<FinancialsService> logger)
+    : IFinancialsService
+{
+    /// <inheritdoc />
+    public async Task<Result<GetFinancialsSnapshotResponse>> GetSnapshotAsync(
+        GetFinancialsSnapshotQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            var cacheKey = BuildCacheKey(query);
+
+            var response = await cache.GetOrCreateAsync(
+                cacheKey,
+                CacheTier.Financials,
+                async ct => await apiClient.GetSnapshotAsync(query, ct),
+                cancellationToken);
+
+            logger.LogInformation("Retrieved financials snapshot for {Symbol}", query.Symbol);
+
+            return new Result<GetFinancialsSnapshotResponse>().Success(response);
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogWarning(ex, "Premium-only financials endpoint for {Symbol}", query.Symbol);
+            return new Result<GetFinancialsSnapshotResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching financials for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
+            return new Result<GetFinancialsSnapshotResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "Financials request timed out for {Symbol}", query.Symbol);
+            return new Result<GetFinancialsSnapshotResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize financials response for {Symbol}", query.Symbol);
+            return new Result<GetFinancialsSnapshotResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected financials failure for {Symbol}", query.Symbol);
+            return new Result<GetFinancialsSnapshotResponse>().Failure("Financials lookup failed unexpectedly");
+        }
+    }
+
+    private static string BuildCacheKey(GetFinancialsSnapshotQuery query) =>
+        $"financials:s={query.Symbol.ToUpperInvariant()}:raw={query.IncludeRaw}";
+}

--- a/src/FinnHub.MCP.Server.Application/Financials/Services/IFinancialsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Services/IFinancialsService.cs
@@ -1,0 +1,25 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Application.Financials.Services;
+
+/// <summary>
+/// Application-level entry point for financials-snapshot lookups. Translates
+/// infrastructure exceptions into typed <see cref="Result{T}"/> shapes.
+/// </summary>
+public interface IFinancialsService
+{
+    /// <summary>
+    /// Executes a financials snapshot lookup and returns a categorised result.
+    /// </summary>
+    Task<Result<GetFinancialsSnapshotResponse>> GetSnapshotAsync(
+        GetFinancialsSnapshotQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
@@ -1,0 +1,155 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Financials.Clients;
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Financials;
+
+/// <summary>
+/// HTTP client for the Finnhub <c>/stock/metric</c> endpoint. Projects the upstream
+/// metric dictionary into the curated <see cref="GetFinancialsSnapshotResponse"/>
+/// KPIs and optionally retains the raw dictionary.
+/// </summary>
+public sealed class FinnHubFinancialsApiClient : IFinancialsApiClient
+{
+    private const string EndpointName = "financials-metric";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubFinancialsApiClient> _logger;
+
+    /// <summary>Initialises a new <see cref="FinnHubFinancialsApiClient"/>.</summary>
+    public FinnHubFinancialsApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubFinancialsApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GetFinancialsSnapshotResponse> GetSnapshotAsync(
+        GetFinancialsSnapshotQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var endpoint = this._options.EndPoints.FirstOrDefault(e => e is { IsActive: true, Name: EndpointName })?.Url
+                       ?? throw new ArgumentException("Financials metric endpoint is not configured or inactive");
+
+        var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(query.Symbol)}&metric=all";
+
+        this._logger.LogInformation("Requesting financials from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub financials failed: {Uri}", requestUri);
+            throw new ApiClientHttpException($"HTTP request to FinnHub financials failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Financials request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"Financials request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("Financials request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"Financials request cancelled: {requestUri}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        FinnHubFinancialsResponse? dto;
+        try
+        {
+            dto = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.FinnHubFinancialsResponse, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize financials response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize financials response: {requestUri}",
+                innerException: ex);
+        }
+
+        return Project(query, dto?.Metric);
+    }
+
+    private static GetFinancialsSnapshotResponse Project(GetFinancialsSnapshotQuery query, Dictionary<string, double?>? metric)
+    {
+        double? Get(string key) =>
+            metric is not null && metric.TryGetValue(key, out var value) ? value : null;
+
+        return new GetFinancialsSnapshotResponse
+        {
+            Symbol = query.Symbol,
+            MarketCap = Get("marketCapitalization"),
+            PeTtm = Get("peTTM"),
+            PbAnnual = Get("pbAnnual"),
+            EpsTtm = Get("epsTTM"),
+            DividendYield = Get("dividendYieldIndicatedAnnual"),
+            Week52High = Get("52WeekHigh"),
+            Week52Low = Get("52WeekLow"),
+            Week52PriceReturnPct = Get("52WeekPriceReturnDaily"),
+            Beta = Get("beta"),
+            RevenuePerShareTtm = Get("revenuePerShareTTM"),
+            Raw = query.IncludeRaw && metric is not null
+                ? new Dictionary<string, double?>(metric)
+                : null
+        };
+    }
+
+    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            this._logger.LogWarning("Premium-locked financials endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        this._logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "Financials API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException($"FinnHub financials returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubFinancialsResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubFinancialsResponse.cs
@@ -1,0 +1,33 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>
+/// Wire DTO for the Finnhub <c>/stock/metric</c> endpoint. The upstream payload
+/// nests a flat metric dictionary under a <c>metric</c> property; the dictionary
+/// has dozens of keys, all numeric or string-formatted dates. We project only
+/// the numeric subset and let the client map specific keys to typed KPIs.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubFinancialsResponse
+{
+    /// <summary>Symbol echoed by Finnhub.</summary>
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; init; }
+
+    /// <summary>Metric type requested (e.g. <c>all</c>).</summary>
+    [JsonPropertyName("metricType")]
+    public string? MetricType { get; init; }
+
+    /// <summary>Flat dictionary of metric names to numeric values.</summary>
+    [JsonPropertyName("metric")]
+    public Dictionary<string, double?>? Metric { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -9,12 +9,15 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Financials.Clients;
+using FinnHub.MCP.Server.Application.Financials.Services;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Services;
 using FinnHub.MCP.Server.Application.RateLimiting;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Caching;
+using FinnHub.MCP.Server.Infrastructure.Clients.Financials;
 using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
 using FinnHub.MCP.Server.Infrastructure.RateLimiting;
@@ -72,6 +75,14 @@ public static class ServiceCollectionExtension
             .AddHttpMessageHandler<RateLimitHeaderHandler>()
             .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubPeersApiClient>>()))
             .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubPeersApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<IFinancialsService, FinancialsService>();
+        services.AddHttpClient<IFinancialsApiClient, FinnHubFinancialsApiClient>("FinnHub-Financials-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubFinancialsApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubFinancialsApiClient>>()))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -7,6 +7,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
@@ -54,4 +55,7 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 [JsonSerializable(typeof(GetPeersResponse))]
 [JsonSerializable(typeof(ToolResponseEnvelope<GetPeersResponse>))]
 [JsonSerializable(typeof(string[]))]
+[JsonSerializable(typeof(FinnHubFinancialsResponse))]
+[JsonSerializable(typeof(GetFinancialsSnapshotResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetFinancialsSnapshotResponse>))]
 public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -250,5 +250,58 @@ public static class Constants
                 Approx tokens: summary ~80, standard ~200, full ~400.
                 """;
         }
+
+        /// <summary>
+        /// Constants for the <c>get-financials-snapshot</c> tool — curated 10-KPI snapshot.
+        /// </summary>
+        public static class FinancialsSnapshot
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-financials-snapshot";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get Financials Snapshot";
+
+            /// <summary>Parameter names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription = "Uppercase ticker symbol, e.g. 'AAPL'.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>Tool description registered with the MCP server.</summary>
+            public const string Description =
+                """
+                Get a curated 10-KPI financial snapshot for a symbol — market cap, P/E, P/B, EPS, dividend yield,
+                52-week high/low, 52-week price return, beta, and revenue per share.
+
+                ## Example:
+                - symbol='AAPL'
+
+                ## Response Fields (10 curated KPIs, all nullable):
+                - symbol (string)
+                - market_cap (double): market capitalisation in USD millions
+                - pe_ttm (double): trailing twelve-month P/E
+                - pb_annual (double): annual price/book
+                - eps_ttm (double): trailing twelve-month EPS
+                - dividend_yield (double): indicated annual dividend yield
+                - week52_high, week52_low (double)
+                - week52_price_return_pct (double): 52-week price return
+                - beta (double)
+                - revenue_per_share_ttm (double)
+                - raw (object, optional): full upstream metric dictionary, populated only when view = "full"
+
+                Approx tokens: summary ~200, standard ~200, full ~3000.
+                """;
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -16,6 +16,7 @@ using FinnHub.MCP.Server.Infrastructure.Extensions;
 using FinnHub.MCP.Server.Middleware;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
+using FinnHub.MCP.Server.Tools.Financials;
 using FinnHub.MCP.Server.Tools.Peers;
 using FinnHub.MCP.Server.Tools.Search;
 using Microsoft.AspNetCore.Mvc;
@@ -97,6 +98,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 })
 .WithWrappedTools<SearchSymbolTool>()
 .WithWrappedTools<GetPeersTool>()
+.WithWrappedTools<GetFinancialsSnapshotTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>();
 

--- a/src/FinnHub.MCP.Server/Tools/Financials/FinancialsInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Financials/FinancialsInputValidator.cs
@@ -1,0 +1,55 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Tools.Financials;
+
+/// <summary>
+/// Validation helpers for the <c>get-financials-snapshot</c> tool parameters.
+/// </summary>
+internal static partial class FinancialsInputValidator
+{
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be empty.", nameof(symbol));
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Financials/GetFinancialsSnapshotTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Financials/GetFinancialsSnapshotTool.cs
@@ -1,0 +1,106 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Financials.Services;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Financials;
+
+/// <summary>
+/// MCP tool exposing the Finnhub <c>/stock/metric</c> endpoint as a curated 10-KPI snapshot.
+/// </summary>
+[McpServerToolType]
+public sealed class GetFinancialsSnapshotTool(
+    IFinancialsService financialsService,
+    ILogger<GetFinancialsSnapshotTool> logger)
+{
+    /// <summary>
+    /// Returns a curated 10-KPI snapshot for a symbol. <c>view = "full"</c> additionally
+    /// includes the raw upstream metric dictionary on the <c>raw</c> field.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.FinancialsSnapshot.Name,
+        Title = Constants.Tools.FinancialsSnapshot.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.FinancialsSnapshot.Description)]
+    public async Task<ToolResponseEnvelope<GetFinancialsSnapshotResponse>> GetFinancialsSnapshotAsync(
+        [Description(Constants.Tools.FinancialsSnapshot.Parameters.SymbolDescription)]
+        string symbol,
+        [Description(Constants.Tools.FinancialsSnapshot.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.FinancialsSnapshot.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedSymbol = FinancialsInputValidator.ValidateSymbol(symbol);
+            var validatedView = FinancialsInputValidator.ValidateView(view);
+
+            var query = new GetFinancialsSnapshotQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Symbol = validatedSymbol,
+                IncludeRaw = validatedView == ToolView.Full
+            };
+
+            var result = await financialsService.GetSnapshotAsync(query, cancellationToken);
+
+            logger.LogInformation(
+                "Financials snapshot completed for {Symbol} in {ElapsedMs}ms",
+                validatedSymbol, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.FromResult(
+                result,
+                validatedView,
+                explanation: BuildExplanation(result, validatedSymbol));
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static string BuildExplanation(Result<GetFinancialsSnapshotResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return $"No financials snapshot available for '{symbol}'.";
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Financials snapshot for '{symbol}' (10 curated KPIs).");
+    }
+}

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -31,6 +31,13 @@
         "IsActive": true,
         "group": "stock",
         "Description": "Returns peer ticker list for a symbol with optional grouping."
+      },
+      {
+        "Name": "financials-metric",
+        "Url": "/stock/metric",
+        "IsActive": true,
+        "group": "stock",
+        "Description": "Returns basic-financials metric snapshot for a symbol."
       }
     ]
   },

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Financials/Services/FinancialsServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Financials/Services/FinancialsServiceTests.cs
@@ -1,0 +1,84 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Financials.Clients;
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Financials.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Financials.Services;
+
+public sealed class FinancialsServiceTests
+{
+    private readonly IFinancialsApiClient _apiClient = Substitute.For<IFinancialsApiClient>();
+    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FinancialsService _sut;
+
+    public FinancialsServiceTests()
+    {
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<GetFinancialsSnapshotResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetFinancialsSnapshotResponse>>>()(CancellationToken.None));
+
+        this._sut = new FinancialsService(this._apiClient, this._cache, NullLogger<FinancialsService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetSnapshotAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_HappyPath_ReturnsSuccess()
+    {
+        var query = new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSnapshotAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetFinancialsSnapshotResponse { Symbol = "AAPL", MarketCap = 3000000.0 });
+
+        var result = await this._sut.GetSnapshotAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("AAPL", result.Data!.Symbol);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_PremiumRequired_MapsCorrectly()
+    {
+        var query = new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSnapshotAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/api/v1/stock/metric"));
+
+        var result = await this._sut.GetSnapshotAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PremiumRequired", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_HttpError_MapsToServiceUnavailable()
+    {
+        var query = new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSnapshotAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientHttpException("boom", HttpStatusCode.BadGateway));
+
+        var result = await this._sut.GetSnapshotAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ServiceUnavailable", result.ErrorType);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
@@ -1,0 +1,122 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Financials;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Financials;
+
+public sealed class FinnHubFinancialsApiClientTests : IDisposable
+{
+    private const string SamplePayload = """
+                                         {
+                                           "symbol": "AAPL",
+                                           "metricType": "all",
+                                           "metric": {
+                                             "marketCapitalization": 3000000.0,
+                                             "peTTM": 28.4,
+                                             "pbAnnual": 45.2,
+                                             "epsTTM": 6.13,
+                                             "dividendYieldIndicatedAnnual": 0.5,
+                                             "52WeekHigh": 199.6,
+                                             "52WeekLow": 164.1,
+                                             "52WeekPriceReturnDaily": 12.1,
+                                             "beta": 1.28,
+                                             "revenuePerShareTTM": 24.7,
+                                             "extraField": 99.0
+                                           }
+                                         }
+                                         """;
+
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubFinancialsApiClient _sut;
+
+    public FinnHubFinancialsApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints = [new FinnHubEndPoint { Name = "financials-metric", Url = "stock/metric", IsActive = true }]
+        });
+
+        this._sut = new FinnHubFinancialsApiClient(
+            this._httpClient,
+            options,
+            NullLogger<FinnHubFinancialsApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_ProjectsCuratedKpis()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.Equal("AAPL", result.Symbol);
+        Assert.Equal(3000000.0, result.MarketCap);
+        Assert.Equal(28.4, result.PeTtm);
+        Assert.Equal(199.6, result.Week52High);
+        Assert.Equal(1.28, result.Beta);
+        Assert.Null(result.Raw);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_IncludeRaw_PopulatesRawDictionary()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL", IncludeRaw = true },
+            CancellationToken.None);
+
+        Assert.NotNull(result.Raw);
+        Assert.True(result.Raw!.ContainsKey("extraField"));
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_MissingMetric_ReturnsNullKpis()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{\"symbol\":\"UNK\",\"metricType\":\"all\",\"metric\":null}");
+
+        var result = await this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "UNK" },
+            CancellationToken.None);
+
+        Assert.Null(result.MarketCap);
+        Assert.Null(result.Beta);
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/GetFinancialsSnapshotToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/GetFinancialsSnapshotToolTests.cs
@@ -1,0 +1,70 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
+using FinnHub.MCP.Server.Application.Financials.Services;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Financials;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Financials;
+
+public sealed class GetFinancialsSnapshotToolTests
+{
+    private readonly IFinancialsService _service = Substitute.For<IFinancialsService>();
+    private readonly GetFinancialsSnapshotTool _sut;
+
+    public GetFinancialsSnapshotToolTests()
+    {
+        this._sut = new GetFinancialsSnapshotTool(this._service, NullLogger<GetFinancialsSnapshotTool>.Instance);
+    }
+
+    [Fact]
+    public async Task GetFinancialsSnapshotAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetFinancialsSnapshotAsync("!!!"));
+    }
+
+    [Fact]
+    public async Task GetFinancialsSnapshotAsync_LowercaseSymbol_Normalises()
+    {
+        this._service
+            .GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetFinancialsSnapshotResponse>().Success(
+                new GetFinancialsSnapshotResponse { Symbol = "AAPL" }));
+
+        await this._sut.GetFinancialsSnapshotAsync("aapl");
+
+        await this._service.Received(1).GetSnapshotAsync(
+            Arg.Is<GetFinancialsSnapshotQuery>(q => q.Symbol == "AAPL" && !q.IncludeRaw),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetFinancialsSnapshotAsync_FullView_SetsIncludeRaw()
+    {
+        this._service
+            .GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetFinancialsSnapshotResponse>().Success(
+                new GetFinancialsSnapshotResponse { Symbol = "AAPL" }));
+
+        await this._sut.GetFinancialsSnapshotAsync("AAPL", view: "full");
+
+        await this._service.Received(1).GetSnapshotAsync(
+            Arg.Is<GetFinancialsSnapshotQuery>(q => q.IncludeRaw),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetFinancialsSnapshotAsync_InvalidView_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._sut.GetFinancialsSnapshotAsync("AAPL", view: "nonsense"));
+    }
+}


### PR DESCRIPTION
## Summary
Second of four P6 Wave A aggregation tools (after PR #152). Mirrors the get-peers template across all 3 layers.

## Tool: get-financials-snapshot
- Maps to Finnhub `/stock/metric?metric=all`
- Projects the upstream metric dictionary into a curated 10-KPI shape: `market_cap`, `pe_ttm`, `pb_annual`, `eps_ttm`, `dividend_yield`, `week52_high`/`low`, `week52_price_return_pct`, `beta`, `revenue_per_share_ttm`
- `view=full` additionally populates the `raw` field with the entire upstream dictionary
- Financials-tier cache (1h TTL)
- Wired through `ToolInvocationMiddleware` so participates in P1 envelope-budget + P4 rate-limit threading
- 403 from Finnhub fails fast as `PremiumRequired` per P5

## Spec
[`.planning/specs/01-product-surface.md` §3 P6](https://github.com/SalZaki/finnhub-mcp/blob/main/.planning/specs/01-product-surface.md)

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 204/204 pass (was 192; +12 new across 3 layers)
  - Service: cache passthrough, success/premium/http mapping
  - Client: projects all 10 KPIs from sample payload, IncludeRaw populates raw dict, missing-metric returns null KPIs, 403 → PremiumRequired
  - Tool: invalid symbol/view rejected, lowercase normalised, view=full sets IncludeRaw=true