### PR TITLE
feat(p6a): add get-price-summary — aggregated price stats

### DIFF
--- a/src/FinnHub.MCP.Server.Application/Prices/Clients/IPricesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Clients/IPricesApiClient.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+
+namespace FinnHub.MCP.Server.Application.Prices.Clients;
+
+/// <summary>
+/// Infrastructure contract for the Finnhub <c>/stock/candle</c> endpoint.
+/// </summary>
+public interface IPricesApiClient
+{
+    /// <summary>
+    /// Fetches the candle range for a symbol and aggregates it server-side
+    /// into the curated summary stats. <see cref="GetPriceSummaryResponse.Candles"/>
+    /// is populated only when <paramref name="query"/> has <c>IncludeCandles = true</c>.
+    /// </summary>
+    Task<GetPriceSummaryResponse> GetSummaryAsync(GetPriceSummaryQuery query, CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/Prices/Features/GetPriceSummary/GetPriceSummaryQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Features/GetPriceSummary/GetPriceSummaryQuery.cs
@@ -1,0 +1,27 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+
+/// <summary>
+/// Query parameters for the <c>get-price-summary</c> tool — a Finnhub
+/// <c>/stock/candle</c> lookup that aggregates the candle range into curated stats.
+/// </summary>
+public sealed class GetPriceSummaryQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Uppercase ticker symbol the summary is requested for.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Lookback window (default 30 days).</summary>
+    public PricePeriod Period { get; init; } = PricePeriod.ThirtyDays;
+
+    /// <summary>Whether the response should carry the raw OHLCV arrays in addition to the summary stats.</summary>
+    public bool IncludeCandles { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Prices/Features/GetPriceSummary/GetPriceSummaryResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Features/GetPriceSummary/GetPriceSummaryResponse.cs
@@ -1,0 +1,101 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+
+/// <summary>
+/// Wire response for <c>get-price-summary</c>. Server-side aggregation over the
+/// upstream candle range. <see cref="Candles"/> is populated only when the tool
+/// was invoked with <c>view = "full"</c>.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class GetPriceSummaryResponse
+{
+    /// <summary>Ticker symbol the summary applies to.</summary>
+    [JsonPropertyName("symbol")]
+    public required string Symbol { get; init; }
+
+    /// <summary>Lookback window the summary covers, e.g. <c>30d</c>, <c>1y</c>.</summary>
+    [JsonPropertyName("period")]
+    public required string Period { get; init; }
+
+    /// <summary>Finnhub resolution code, e.g. <c>D</c>, <c>W</c>.</summary>
+    [JsonPropertyName("resolution")]
+    public required string Resolution { get; init; }
+
+    /// <summary>Minimum low across the range, or <c>null</c> if no candles were returned.</summary>
+    [JsonPropertyName("min")]
+    public double? Min { get; init; }
+
+    /// <summary>Maximum high across the range, or <c>null</c> if no candles were returned.</summary>
+    [JsonPropertyName("max")]
+    public double? Max { get; init; }
+
+    /// <summary>Arithmetic mean of closing prices, or <c>null</c> if no candles were returned.</summary>
+    [JsonPropertyName("mean")]
+    public double? Mean { get; init; }
+
+    /// <summary>Total return (percent) from the first close to the last close.</summary>
+    [JsonPropertyName("return_pct")]
+    public double? ReturnPct { get; init; }
+
+    /// <summary>Population standard deviation of closing prices (volatility proxy).</summary>
+    [JsonPropertyName("vol")]
+    public double? Vol { get; init; }
+
+    /// <summary>Most-recent close and its UTC timestamp.</summary>
+    [JsonPropertyName("latest")]
+    public PriceLatest? Latest { get; init; }
+
+    /// <summary>Number of candles aggregated.</summary>
+    [JsonPropertyName("candle_count")]
+    public int CandleCount { get; init; }
+
+    /// <summary>Raw OHLCV arrays. Populated only when the tool was invoked with <c>view = "full"</c>.</summary>
+    [JsonPropertyName("candles")]
+    public PriceCandles? Candles { get; init; }
+}
+
+/// <summary>Most-recent candle's close and timestamp.</summary>
+/// <param name="Close">Closing price.</param>
+/// <param name="TimestampUtc">UTC timestamp of the candle.</param>
+[ExcludeFromCodeCoverage]
+public sealed record PriceLatest(
+    [property: JsonPropertyName("close")] double Close,
+    [property: JsonPropertyName("timestamp_utc")] DateTimeOffset TimestampUtc);
+
+/// <summary>Raw OHLCV arrays, returned only for <c>view = "full"</c>.</summary>
+[ExcludeFromCodeCoverage]
+public sealed class PriceCandles
+{
+    /// <summary>Open prices.</summary>
+    [JsonPropertyName("o")]
+    public required IReadOnlyList<double> Open { get; init; }
+
+    /// <summary>High prices.</summary>
+    [JsonPropertyName("h")]
+    public required IReadOnlyList<double> High { get; init; }
+
+    /// <summary>Low prices.</summary>
+    [JsonPropertyName("l")]
+    public required IReadOnlyList<double> Low { get; init; }
+
+    /// <summary>Close prices.</summary>
+    [JsonPropertyName("c")]
+    public required IReadOnlyList<double> Close { get; init; }
+
+    /// <summary>Volume.</summary>
+    [JsonPropertyName("v")]
+    public required IReadOnlyList<long> Volume { get; init; }
+
+    /// <summary>Unix-epoch (seconds) timestamps.</summary>
+    [JsonPropertyName("t")]
+    public required IReadOnlyList<long> Timestamps { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Prices/Features/GetPriceSummary/PricePeriod.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Features/GetPriceSummary/PricePeriod.cs
@@ -1,0 +1,27 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+
+/// <summary>
+/// Lookback windows the <c>get-price-summary</c> tool supports. Each value resolves to
+/// a Finnhub <c>resolution</c> and a from/to epoch pair under the hood.
+/// </summary>
+public enum PricePeriod
+{
+    /// <summary>7 calendar days at daily resolution.</summary>
+    SevenDays,
+
+    /// <summary>30 calendar days at daily resolution (default).</summary>
+    ThirtyDays,
+
+    /// <summary>90 calendar days at daily resolution.</summary>
+    NinetyDays,
+
+    /// <summary>365 calendar days at weekly resolution.</summary>
+    OneYear
+}

--- a/src/FinnHub.MCP.Server.Application/Prices/Services/IPricesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Services/IPricesService.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+
+namespace FinnHub.MCP.Server.Application.Prices.Services;
+
+/// <summary>
+/// Application-level entry point for price-summary lookups.
+/// </summary>
+public interface IPricesService
+{
+    /// <summary>
+    /// Executes a price summary lookup and returns a categorised result.
+    /// </summary>
+    Task<Result<GetPriceSummaryResponse>> GetSummaryAsync(
+        GetPriceSummaryQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
@@ -1,0 +1,83 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Prices.Clients;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.Prices.Services;
+
+/// <summary>
+/// Default <see cref="IPricesService"/> wrapping <see cref="IPricesApiClient"/> with
+/// hybrid caching and exception-to-result translation.
+/// </summary>
+public sealed class PricesService(
+    IPricesApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<PricesService> logger)
+    : IPricesService
+{
+    /// <inheritdoc />
+    public async Task<Result<GetPriceSummaryResponse>> GetSummaryAsync(
+        GetPriceSummaryQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            var cacheKey = BuildCacheKey(query);
+
+            var response = await cache.GetOrCreateAsync(
+                cacheKey,
+                CacheTier.Quote,
+                async ct => await apiClient.GetSummaryAsync(query, ct),
+                cancellationToken);
+
+            logger.LogInformation(
+                "Retrieved price summary for {Symbol} period={Period} candles={Count}",
+                query.Symbol, query.Period, response.CandleCount);
+
+            return response.CandleCount > 0
+                ? new Result<GetPriceSummaryResponse>().Success(response)
+                : new Result<GetPriceSummaryResponse>().Failure(
+                    $"No price data for {query.Symbol} over {query.Period}.",
+                    ResultErrorType.NotFound);
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogWarning(ex, "Premium-only candle endpoint for {Symbol}", query.Symbol);
+            return new Result<GetPriceSummaryResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching candles for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
+            return new Result<GetPriceSummaryResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "Candle request timed out for {Symbol}", query.Symbol);
+            return new Result<GetPriceSummaryResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize candle response for {Symbol}", query.Symbol);
+            return new Result<GetPriceSummaryResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected candle failure for {Symbol}", query.Symbol);
+            return new Result<GetPriceSummaryResponse>().Failure("Price summary failed unexpectedly");
+        }
+    }
+
+    private static string BuildCacheKey(GetPriceSummaryQuery query) =>
+        $"price-summary:s={query.Symbol.ToUpperInvariant()}:p={query.Period}:c={query.IncludeCandles}";
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Prices/FinnHubPricesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Prices/FinnHubPricesApiClient.cs
@@ -1,0 +1,220 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Prices.Clients;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Prices;
+
+/// <summary>
+/// HTTP client for the Finnhub <c>/stock/candle</c> endpoint. Aggregates the
+/// returned OHLCV arrays into curated summary stats.
+/// </summary>
+public sealed class FinnHubPricesApiClient : IPricesApiClient
+{
+    private const string EndpointName = "candle";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubPricesApiClient> _logger;
+
+    /// <summary>Initialises a new <see cref="FinnHubPricesApiClient"/>.</summary>
+    public FinnHubPricesApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubPricesApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GetPriceSummaryResponse> GetSummaryAsync(
+        GetPriceSummaryQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var endpoint = this._options.EndPoints.FirstOrDefault(e => e is { IsActive: true, Name: EndpointName })?.Url
+                       ?? throw new ArgumentException("Candle endpoint is not configured or inactive");
+
+        var (resolution, from, to, periodLabel) = ResolvePeriod(query.Period);
+
+        var requestUri = string.Create(
+            CultureInfo.InvariantCulture,
+            $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(query.Symbol)}&resolution={resolution}&from={from}&to={to}");
+
+        this._logger.LogInformation("Requesting candles from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub candle failed: {Uri}", requestUri);
+            throw new ApiClientHttpException($"HTTP request to FinnHub candle failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Candle request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"Candle request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("Candle request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"Candle request cancelled: {requestUri}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        FinnHubCandleResponse? dto;
+        try
+        {
+            dto = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.FinnHubCandleResponse, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize candle response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize candle response: {requestUri}",
+                innerException: ex);
+        }
+
+        return Aggregate(query, resolution, periodLabel, dto);
+    }
+
+    private static GetPriceSummaryResponse Aggregate(
+        GetPriceSummaryQuery query,
+        string resolution,
+        string periodLabel,
+        FinnHubCandleResponse? dto)
+    {
+        var noData = dto is null
+                     || string.Equals(dto.Status, "no_data", StringComparison.Ordinal)
+                     || dto.Close is null
+                     || dto.Close.Length == 0;
+
+        if (noData)
+        {
+            return new GetPriceSummaryResponse
+            {
+                Symbol = query.Symbol,
+                Period = periodLabel,
+                Resolution = resolution,
+                CandleCount = 0
+            };
+        }
+
+        var close = dto!.Close!;
+        var high = dto.High ?? [];
+        var low = dto.Low ?? [];
+        var timestamps = dto.Timestamps ?? [];
+
+        var min = low.Length > 0 ? low.Min() : close.Min();
+        var max = high.Length > 0 ? high.Max() : close.Max();
+        var mean = close.Average();
+        var returnPct = (close[^1] - close[0]) / close[0] * 100.0;
+        var vol = StandardDeviation(close);
+        var latestTs = timestamps.Length > 0 ? timestamps[^1] : 0;
+
+        return new GetPriceSummaryResponse
+        {
+            Symbol = query.Symbol,
+            Period = periodLabel,
+            Resolution = resolution,
+            Min = min,
+            Max = max,
+            Mean = mean,
+            ReturnPct = returnPct,
+            Vol = vol,
+            CandleCount = close.Length,
+            Latest = new PriceLatest(close[^1], DateTimeOffset.FromUnixTimeSeconds(latestTs)),
+            Candles = query.IncludeCandles
+                ? new PriceCandles
+                {
+                    Open = dto.Open ?? [],
+                    High = high,
+                    Low = low,
+                    Close = close,
+                    Volume = dto.Volume ?? [],
+                    Timestamps = timestamps
+                }
+                : null
+        };
+    }
+
+    private static double StandardDeviation(double[] values)
+    {
+        if (values.Length < 2)
+        {
+            return 0d;
+        }
+
+        var mean = values.Average();
+        var sumOfSquares = values.Sum(v => (v - mean) * (v - mean));
+        return Math.Sqrt(sumOfSquares / values.Length);
+    }
+
+    private static (string Resolution, long From, long To, string Label) ResolvePeriod(PricePeriod period)
+    {
+        var now = DateTimeOffset.UtcNow;
+        return period switch
+        {
+            PricePeriod.SevenDays => ("D", now.AddDays(-7).ToUnixTimeSeconds(), now.ToUnixTimeSeconds(), "7d"),
+            PricePeriod.ThirtyDays => ("D", now.AddDays(-30).ToUnixTimeSeconds(), now.ToUnixTimeSeconds(), "30d"),
+            PricePeriod.NinetyDays => ("D", now.AddDays(-90).ToUnixTimeSeconds(), now.ToUnixTimeSeconds(), "90d"),
+            PricePeriod.OneYear => ("W", now.AddDays(-365).ToUnixTimeSeconds(), now.ToUnixTimeSeconds(), "1y"),
+            _ => throw new ArgumentOutOfRangeException(nameof(period), period, "Unknown period")
+        };
+    }
+
+    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            this._logger.LogWarning("Premium-locked candle endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        this._logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "Candle API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException($"FinnHub candle returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubCandleResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubCandleResponse.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>
+/// Wire DTO for the Finnhub <c>/stock/candle</c> endpoint. Status field <c>s</c>
+/// is <c>"ok"</c> on success or <c>"no_data"</c> when the range yielded no candles.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubCandleResponse
+{
+    /// <summary>Open prices.</summary>
+    [JsonPropertyName("o")]
+    public double[]? Open { get; init; }
+
+    /// <summary>High prices.</summary>
+    [JsonPropertyName("h")]
+    public double[]? High { get; init; }
+
+    /// <summary>Low prices.</summary>
+    [JsonPropertyName("l")]
+    public double[]? Low { get; init; }
+
+    /// <summary>Close prices.</summary>
+    [JsonPropertyName("c")]
+    public double[]? Close { get; init; }
+
+    /// <summary>Volume.</summary>
+    [JsonPropertyName("v")]
+    public long[]? Volume { get; init; }
+
+    /// <summary>Unix-epoch (seconds) timestamps.</summary>
+    [JsonPropertyName("t")]
+    public long[]? Timestamps { get; init; }
+
+    /// <summary>Status code: <c>ok</c> or <c>no_data</c>.</summary>
+    [JsonPropertyName("s")]
+    public string? Status { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -14,11 +14,14 @@ using FinnHub.MCP.Server.Application.Financials.Services;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Services;
+using FinnHub.MCP.Server.Application.Prices.Clients;
+using FinnHub.MCP.Server.Application.Prices.Services;
 using FinnHub.MCP.Server.Application.RateLimiting;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Caching;
 using FinnHub.MCP.Server.Infrastructure.Clients.Financials;
 using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
+using FinnHub.MCP.Server.Infrastructure.Clients.Prices;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
 using FinnHub.MCP.Server.Infrastructure.RateLimiting;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -83,6 +86,14 @@ public static class ServiceCollectionExtension
             .AddHttpMessageHandler<RateLimitHeaderHandler>()
             .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubFinancialsApiClient>>()))
             .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubFinancialsApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<IPricesService, PricesService>();
+        services.AddHttpClient<IPricesApiClient, FinnHubPricesApiClient>("FinnHub-Prices-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubPricesApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubPricesApiClient>>()))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -10,6 +10,7 @@ using System.Text.Json.Serialization;
 using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Application.Symbols;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
@@ -58,4 +59,7 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 [JsonSerializable(typeof(FinnHubFinancialsResponse))]
 [JsonSerializable(typeof(GetFinancialsSnapshotResponse))]
 [JsonSerializable(typeof(ToolResponseEnvelope<GetFinancialsSnapshotResponse>))]
+[JsonSerializable(typeof(FinnHubCandleResponse))]
+[JsonSerializable(typeof(GetPriceSummaryResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetPriceSummaryResponse>))]
 public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -303,5 +303,64 @@ public static class Constants
                 Approx tokens: summary ~200, standard ~200, full ~3000.
                 """;
         }
+
+        /// <summary>Constants for the <c>get-price-summary</c> tool — aggregated price stats over a candle range.</summary>
+        public static class PriceSummary
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-price-summary";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get Price Summary";
+
+            /// <summary>Parameter names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription = "Uppercase ticker symbol, e.g. 'AAPL'.";
+
+                /// <summary>Period parameter name.</summary>
+                public const string PeriodName = "period";
+
+                /// <summary>Period parameter description.</summary>
+                public const string PeriodDescription =
+                    "Lookback window: 7d, 30d (default), 90d, or 1y.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>Tool description registered with the MCP server.</summary>
+            public const string Description =
+                """
+                Aggregate the price candle range for a symbol into curated summary stats —
+                min, max, mean, total return %, volatility (population stdev of closes), and the most-recent close.
+
+                ## Example:
+                - symbol='AAPL', period='30d'
+
+                ## Response Fields:
+                - symbol (string)
+                - period (string): echo of the requested window
+                - resolution (string): Finnhub resolution code (D|W)
+                - min, max, mean (double): from low/high/close arrays
+                - return_pct (double): (last_close - first_close) / first_close * 100
+                - vol (double): population stdev of closing prices
+                - latest (object): { close, timestamp_utc }
+                - candle_count (int)
+                - candles (object, optional): full OHLCV arrays, populated only when view = "full"
+
+                ## Notes:
+                - 1y period uses weekly resolution to stay within token budget; 7d/30d/90d use daily.
+
+                Approx tokens: summary ~120, standard ~120, full varies with period (~600 at 30d, ~2000 at 1y).
+                """;
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -18,6 +18,7 @@ using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
 using FinnHub.MCP.Server.Tools.Financials;
 using FinnHub.MCP.Server.Tools.Peers;
+using FinnHub.MCP.Server.Tools.Prices;
 using FinnHub.MCP.Server.Tools.Search;
 using Microsoft.AspNetCore.Mvc;
 
@@ -99,6 +100,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithWrappedTools<SearchSymbolTool>()
 .WithWrappedTools<GetPeersTool>()
 .WithWrappedTools<GetFinancialsSnapshotTool>()
+.WithWrappedTools<GetPriceSummaryTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>();
 

--- a/src/FinnHub.MCP.Server/Tools/Prices/GetPriceSummaryTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Prices/GetPriceSummaryTool.cs
@@ -1,0 +1,111 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Application.Prices.Services;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Prices;
+
+/// <summary>
+/// MCP tool exposing the Finnhub <c>/stock/candle</c> endpoint as a curated
+/// price summary (min/max/mean/return/vol/latest) rather than a raw OHLCV dump.
+/// </summary>
+[McpServerToolType]
+public sealed class GetPriceSummaryTool(
+    IPricesService pricesService,
+    ILogger<GetPriceSummaryTool> logger)
+{
+    /// <summary>
+    /// Returns aggregated price stats for a symbol over the requested period.
+    /// <c>view = "full"</c> additionally includes the raw OHLCV arrays.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.PriceSummary.Name,
+        Title = Constants.Tools.PriceSummary.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.PriceSummary.Description)]
+    public async Task<ToolResponseEnvelope<GetPriceSummaryResponse>> GetPriceSummaryAsync(
+        [Description(Constants.Tools.PriceSummary.Parameters.SymbolDescription)]
+        string symbol,
+        [Description(Constants.Tools.PriceSummary.Parameters.PeriodDescription)]
+        string? period = null,
+        [Description(Constants.Tools.PriceSummary.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.PriceSummary.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedSymbol = PricesInputValidator.ValidateSymbol(symbol);
+            var validatedPeriod = PricesInputValidator.ValidatePeriod(period);
+            var validatedView = PricesInputValidator.ValidateView(view);
+
+            var query = new GetPriceSummaryQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Symbol = validatedSymbol,
+                Period = validatedPeriod,
+                IncludeCandles = validatedView == ToolView.Full
+            };
+
+            var result = await pricesService.GetSummaryAsync(query, cancellationToken);
+
+            logger.LogInformation(
+                "Price summary completed for {Symbol} period={Period} in {ElapsedMs}ms",
+                validatedSymbol, validatedPeriod, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.FromResult(
+                result,
+                validatedView,
+                explanation: BuildExplanation(result, validatedSymbol));
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static string BuildExplanation(Result<GetPriceSummaryResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return $"No price data for '{symbol}'.";
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Price summary for '{symbol}' over {result.Data.Period} ({result.Data.CandleCount} candles).");
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Prices/PricesInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Prices/PricesInputValidator.cs
@@ -1,0 +1,73 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+
+namespace FinnHub.MCP.Server.Tools.Prices;
+
+/// <summary>Validation helpers for the <c>get-price-summary</c> tool parameters.</summary>
+internal static partial class PricesInputValidator
+{
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be empty.", nameof(symbol));
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static PricePeriod ValidatePeriod(string? period)
+    {
+        if (string.IsNullOrWhiteSpace(period))
+        {
+            return PricePeriod.ThirtyDays;
+        }
+
+        return period.Trim().ToLowerInvariant() switch
+        {
+            "7d" => PricePeriod.SevenDays,
+            "30d" => PricePeriod.ThirtyDays,
+            "90d" => PricePeriod.NinetyDays,
+            "1y" => PricePeriod.OneYear,
+            _ => throw new ArgumentException(
+                "Period must be one of: 7d, 30d, 90d, 1y.",
+                nameof(period))
+        };
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -38,6 +38,13 @@
         "IsActive": true,
         "group": "stock",
         "Description": "Returns basic-financials metric snapshot for a symbol."
+      },
+      {
+        "Name": "candle",
+        "Url": "/stock/candle",
+        "IsActive": true,
+        "group": "stock",
+        "Description": "Returns OHLCV candles for a symbol over the given period and resolution."
       }
     ]
   },

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Prices/Services/PricesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Prices/Services/PricesServiceTests.cs
@@ -1,0 +1,109 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Prices.Clients;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Application.Prices.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Prices.Services;
+
+public sealed class PricesServiceTests
+{
+    private readonly IPricesApiClient _apiClient = Substitute.For<IPricesApiClient>();
+    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly PricesService _sut;
+
+    public PricesServiceTests()
+    {
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<GetPriceSummaryResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetPriceSummaryResponse>>>()(CancellationToken.None));
+
+        this._sut = new PricesService(this._apiClient, this._cache, NullLogger<PricesService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetSummaryAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_WithCandles_ReturnsSuccess()
+    {
+        var query = new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSummaryAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetPriceSummaryResponse
+            {
+                Symbol = "AAPL",
+                Period = "30d",
+                Resolution = "D",
+                CandleCount = 21
+            });
+
+        var result = await this._sut.GetSummaryAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(21, result.Data!.CandleCount);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_NoCandles_ReturnsNotFound()
+    {
+        var query = new GetPriceSummaryQuery { QueryId = "q1", Symbol = "UNKN" };
+        this._apiClient.GetSummaryAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetPriceSummaryResponse
+            {
+                Symbol = "UNKN",
+                Period = "30d",
+                Resolution = "D",
+                CandleCount = 0
+            });
+
+        var result = await this._sut.GetSummaryAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("NotFound", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_PremiumRequired_MapsCorrectly()
+    {
+        var query = new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSummaryAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/api/v1/stock/candle"));
+
+        var result = await this._sut.GetSummaryAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PremiumRequired", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_HttpError_MapsToServiceUnavailable()
+    {
+        var query = new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSummaryAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientHttpException("boom", HttpStatusCode.BadGateway));
+
+        var result = await this._sut.GetSummaryAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ServiceUnavailable", result.ErrorType);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
@@ -1,0 +1,131 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Infrastructure.Clients.Prices;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Prices;
+
+public sealed class FinnHubPricesApiClientTests : IDisposable
+{
+    private const string SamplePayload = """
+                                         {
+                                           "c": [100.0, 102.0, 105.0, 108.0, 110.0],
+                                           "h": [101.0, 103.0, 106.0, 109.0, 111.0],
+                                           "l": [99.0, 101.0, 104.0, 107.0, 109.0],
+                                           "o": [99.5, 101.5, 104.5, 107.5, 109.5],
+                                           "v": [10000, 12000, 11000, 13000, 14000],
+                                           "t": [1700000000, 1700086400, 1700172800, 1700259200, 1700345600],
+                                           "s": "ok"
+                                         }
+                                         """;
+
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubPricesApiClient _sut;
+
+    public FinnHubPricesApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints = [new FinnHubEndPoint { Name = "candle", Url = "stock/candle", IsActive = true }]
+        });
+
+        this._sut = new FinnHubPricesApiClient(
+            this._httpClient,
+            options,
+            NullLogger<FinnHubPricesApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_AggregatesStats()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.Equal(5, result.CandleCount);
+        Assert.Equal(99.0, result.Min);
+        Assert.Equal(111.0, result.Max);
+        Assert.Equal(105.0, result.Mean);
+        Assert.Equal(10.0, result.ReturnPct);
+        Assert.NotNull(result.Latest);
+        Assert.Equal(110.0, result.Latest!.Close);
+        Assert.Null(result.Candles);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_IncludeCandles_PopulatesCandles()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL", IncludeCandles = true },
+            CancellationToken.None);
+
+        Assert.NotNull(result.Candles);
+        Assert.Equal(5, result.Candles!.Close.Count);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_NoData_ReturnsZeroCandles()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{\"s\":\"no_data\"}");
+
+        var result = await this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "UNK" },
+            CancellationToken.None);
+
+        Assert.Equal(0, result.CandleCount);
+        Assert.Null(result.Min);
+        Assert.Null(result.Mean);
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_OneYearPeriod_UsesWeeklyResolution()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{\"s\":\"no_data\"}");
+
+        var result = await this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL", Period = PricePeriod.OneYear },
+            CancellationToken.None);
+
+        Assert.Equal("W", result.Resolution);
+        Assert.Equal("1y", result.Period);
+        Assert.Contains("resolution=W", this._handler.LastRequest!.RequestUri!.Query, StringComparison.Ordinal);
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/GetPriceSummaryToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/GetPriceSummaryToolTests.cs
@@ -1,0 +1,70 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Application.Prices.Services;
+using FinnHub.MCP.Server.Tools.Prices;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Prices;
+
+public sealed class GetPriceSummaryToolTests
+{
+    private readonly IPricesService _service = Substitute.For<IPricesService>();
+    private readonly GetPriceSummaryTool _sut;
+
+    public GetPriceSummaryToolTests()
+    {
+        this._sut = new GetPriceSummaryTool(this._service, NullLogger<GetPriceSummaryTool>.Instance);
+    }
+
+    [Fact]
+    public async Task GetPriceSummaryAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetPriceSummaryAsync("!!!"));
+    }
+
+    [Fact]
+    public async Task GetPriceSummaryAsync_InvalidPeriod_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._sut.GetPriceSummaryAsync("AAPL", period: "5h"));
+    }
+
+    [Fact]
+    public async Task GetPriceSummaryAsync_FullView_SetsIncludeCandles()
+    {
+        this._service
+            .GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetPriceSummaryResponse>().Success(
+                new GetPriceSummaryResponse { Symbol = "AAPL", Period = "30d", Resolution = "D", CandleCount = 1 }));
+
+        await this._sut.GetPriceSummaryAsync("AAPL", view: "full");
+
+        await this._service.Received(1).GetSummaryAsync(
+            Arg.Is<GetPriceSummaryQuery>(q => q.IncludeCandles),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetPriceSummaryAsync_NinetyDaysPeriod_PassesThrough()
+    {
+        this._service
+            .GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetPriceSummaryResponse>().Success(
+                new GetPriceSummaryResponse { Symbol = "AAPL", Period = "90d", Resolution = "D", CandleCount = 1 }));
+
+        await this._sut.GetPriceSummaryAsync("AAPL", period: "90d");
+
+        await this._service.Received(1).GetSummaryAsync(
+            Arg.Is<GetPriceSummaryQuery>(q => q.Period == PricePeriod.NinetyDays),
+            Arg.Any<CancellationToken>());
+    }
+}


### PR DESCRIPTION
## Summary
Third of four P6 Wave A aggregation tools (after #152, #153). Mirrors the per-tool template.

## Tool: get-price-summary
- Maps to Finnhub `/stock/candle`
- Period values (5 supported): `7d`, `30d` (default), `90d` at daily resolution; `1y` at weekly resolution
- Server-side aggregation: `min`, `max`, `mean`, `return_pct`, `vol` (population stdev of closes), `latest` close+timestamp, `candle_count`
- `view = "full"` additionally populates the `candles` field with raw OHLCV arrays
- Quote-tier cache (10s TTL) — candles are intra-day mutable
- Wired through `ToolInvocationMiddleware` so participates in P1 envelope-budget + P4 rate-limit threading
- 403 fails fast as `PremiumRequired` per P5 (relevant — candles endpoint is premium on most Finnhub plans)

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 218/218 pass (was 204; +14 new across 3 layers)
  - Service: cache passthrough, success/notfound/premium/http mapping
  - Client: stat aggregation correct on sample payload, IncludeCandles populates raw, no_data returns zero, 403 → PremiumRequired, 1y uses W resolution
  - Tool: invalid symbol/period rejected, view=full sets IncludeCandles=true, period passthrough