### PR TITLE
feat(p6a): add get-news-pulse — completes P6 Wave A

### DIFF
--- a/src/FinnHub.MCP.Server.Application/News/Clients/INewsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Clients/INewsApiClient.cs
@@ -1,0 +1,27 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+
+namespace FinnHub.MCP.Server.Application.News.Clients;
+
+/// <summary>
+/// Infrastructure contract for Finnhub's news endpoints. Two separate methods so the
+/// service layer can fan them out (and gracefully degrade sentiment when premium-locked).
+/// </summary>
+public interface INewsApiClient
+{
+    /// <summary>Fetches company news articles for a symbol between the supplied UTC dates (inclusive).</summary>
+    Task<IReadOnlyList<CompanyNewsArticle>> GetCompanyNewsAsync(
+        string symbol,
+        DateOnly from,
+        DateOnly to,
+        CancellationToken cancellationToken);
+
+    /// <summary>Fetches the composite news-sentiment snapshot for a symbol. Throws <c>ApiClientPremiumRequiredException</c> on 403.</summary>
+    Task<NewsSentiment> GetSentimentAsync(string symbol, CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/CompanyNewsArticle.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/CompanyNewsArticle.cs
@@ -1,0 +1,21 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+
+/// <summary>
+/// Intermediate shape returned by the client for an individual <c>/company-news</c> article.
+/// </summary>
+/// <param name="Headline">Article headline.</param>
+/// <param name="Url">Public URL.</param>
+/// <param name="Source">Publisher name.</param>
+/// <param name="DatetimeUtc">UTC publication timestamp.</param>
+public sealed record CompanyNewsArticle(
+    string Headline,
+    string Url,
+    string Source,
+    DateTimeOffset DatetimeUtc);

--- a/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/GetNewsPulseQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/GetNewsPulseQuery.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+
+/// <summary>
+/// Query parameters for the <c>get-news-pulse</c> tool — aggregated news sentiment
+/// and headline pulse over the past 7 days, with a delta vs the prior 7 days.
+/// </summary>
+public sealed class GetNewsPulseQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Uppercase ticker symbol the pulse is requested for.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Whether the response should carry the full headline list rather than the top 5.</summary>
+    public bool IncludeAllHeadlines { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/GetNewsPulseResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/GetNewsPulseResponse.cs
@@ -1,0 +1,68 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+
+/// <summary>
+/// Wire response for <c>get-news-pulse</c>. Aggregates the company-news headline
+/// volume for the current and prior 7-day windows and (when available) the
+/// upstream sentiment scores.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class GetNewsPulseResponse
+{
+    /// <summary>Ticker symbol the pulse applies to.</summary>
+    [JsonPropertyName("symbol")]
+    public required string Symbol { get; init; }
+
+    /// <summary>Lookback window — always <c>7d</c> in v1.</summary>
+    [JsonPropertyName("period")]
+    public string Period { get; init; } = "7d";
+
+    /// <summary>Composite sentiment score from Finnhub's <c>news-sentiment</c> endpoint, or <c>null</c> when the endpoint is premium-locked.</summary>
+    [JsonPropertyName("sentiment_score")]
+    public double? SentimentScore { get; init; }
+
+    /// <summary>Bullish percent from upstream sentiment, or <c>null</c> when unavailable.</summary>
+    [JsonPropertyName("bullish_percent")]
+    public double? BullishPercent { get; init; }
+
+    /// <summary>Bearish percent from upstream sentiment, or <c>null</c> when unavailable.</summary>
+    [JsonPropertyName("bearish_percent")]
+    public double? BearishPercent { get; init; }
+
+    /// <summary>Where the sentiment numbers came from: <c>finnhub</c> when present, <c>null</c> when the endpoint was unavailable.</summary>
+    [JsonPropertyName("sentiment_source")]
+    public string? SentimentSource { get; init; }
+
+    /// <summary>Top headlines from the current 7-day window (default 5; full list when <c>view = "full"</c>), ordered newest first.</summary>
+    [JsonPropertyName("top_headlines")]
+    public IReadOnlyList<NewsHeadline> TopHeadlines { get; init; } = [];
+
+    /// <summary>Article count over the current 7-day window.</summary>
+    [JsonPropertyName("count")]
+    public int Count { get; init; }
+
+    /// <summary>Article-count difference vs the prior 7-day window (positive = more articles this week).</summary>
+    [JsonPropertyName("delta_vs_prev_week")]
+    public int DeltaVsPrevWeek { get; init; }
+}
+
+/// <summary>Curated wire shape for an individual news headline.</summary>
+/// <param name="Headline">Article headline.</param>
+/// <param name="Url">Public URL of the article.</param>
+/// <param name="Source">Publisher name.</param>
+/// <param name="DatetimeUtc">UTC publication timestamp.</param>
+[ExcludeFromCodeCoverage]
+public sealed record NewsHeadline(
+    [property: JsonPropertyName("headline")] string Headline,
+    [property: JsonPropertyName("url")] string Url,
+    [property: JsonPropertyName("source")] string Source,
+    [property: JsonPropertyName("datetime_utc")] DateTimeOffset DatetimeUtc);

--- a/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/NewsSentiment.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Features/GetNewsPulse/NewsSentiment.cs
@@ -1,0 +1,19 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+
+/// <summary>
+/// Intermediate shape returned by the client for the <c>/news-sentiment</c> endpoint.
+/// </summary>
+/// <param name="CompanyNewsScore">Composite sentiment score.</param>
+/// <param name="BullishPercent">Share of news scored as bullish (0..1).</param>
+/// <param name="BearishPercent">Share of news scored as bearish (0..1).</param>
+public sealed record NewsSentiment(
+    double? CompanyNewsScore,
+    double? BullishPercent,
+    double? BearishPercent);

--- a/src/FinnHub.MCP.Server.Application/News/Services/INewsService.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Services/INewsService.cs
@@ -1,0 +1,25 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+
+namespace FinnHub.MCP.Server.Application.News.Services;
+
+/// <summary>
+/// Application-level entry point for the news-pulse aggregation. Orchestrates
+/// the sentiment + current-week + prior-week calls into a single result.
+/// </summary>
+public interface INewsService
+{
+    /// <summary>
+    /// Executes the news-pulse aggregation and returns a categorised result.
+    /// </summary>
+    Task<Result<GetNewsPulseResponse>> GetPulseAsync(
+        GetNewsPulseQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
@@ -1,0 +1,131 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.News.Clients;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.News.Services;
+
+/// <summary>
+/// Default <see cref="INewsService"/>. Orchestrates the three upstream calls
+/// (news-sentiment + current week company-news + prior week company-news) and
+/// gracefully degrades sentiment when the upstream endpoint is premium-locked.
+/// </summary>
+public sealed class NewsService(
+    INewsApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<NewsService> logger)
+    : INewsService
+{
+    private const int DefaultTopHeadlines = 5;
+
+    /// <inheritdoc />
+    public async Task<Result<GetNewsPulseResponse>> GetPulseAsync(
+        GetNewsPulseQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var weekAgo = today.AddDays(-7);
+        var twoWeeksAgo = today.AddDays(-14);
+
+        try
+        {
+            // Sentiment is optional (premium-gated). Catch and degrade gracefully.
+            var sentiment = await this.TryFetchSentimentAsync(query.Symbol, cancellationToken);
+
+            var currentWeekKey = $"news-pulse:s={query.Symbol.ToUpperInvariant()}:w=current";
+            var prevWeekKey = $"news-pulse:s={query.Symbol.ToUpperInvariant()}:w=prev";
+
+            var currentWeekTask = cache.GetOrCreateAsync(
+                currentWeekKey,
+                CacheTier.News,
+                async ct => await apiClient.GetCompanyNewsAsync(query.Symbol, weekAgo, today, ct),
+                cancellationToken);
+
+            var prevWeekTask = cache.GetOrCreateAsync(
+                prevWeekKey,
+                CacheTier.News,
+                async ct => await apiClient.GetCompanyNewsAsync(query.Symbol, twoWeeksAgo, weekAgo, ct),
+                cancellationToken);
+
+            var currentWeek = await currentWeekTask;
+            var prevWeek = await prevWeekTask;
+
+            var topHeadlines = currentWeek
+                .OrderByDescending(a => a.DatetimeUtc)
+                .Take(query.IncludeAllHeadlines ? int.MaxValue : DefaultTopHeadlines)
+                .Select(a => new NewsHeadline(a.Headline, a.Url, a.Source, a.DatetimeUtc))
+                .ToList()
+                .AsReadOnly();
+
+            var response = new GetNewsPulseResponse
+            {
+                Symbol = query.Symbol,
+                SentimentScore = sentiment?.CompanyNewsScore,
+                BullishPercent = sentiment?.BullishPercent,
+                BearishPercent = sentiment?.BearishPercent,
+                SentimentSource = sentiment is null ? null : "finnhub",
+                TopHeadlines = topHeadlines,
+                Count = currentWeek.Count,
+                DeltaVsPrevWeek = currentWeek.Count - prevWeek.Count
+            };
+
+            logger.LogInformation(
+                "News pulse for {Symbol}: current={Cur} prev={Prev} sentiment={SentimentSource}",
+                query.Symbol, response.Count, prevWeek.Count, response.SentimentSource ?? "none");
+
+            return response.Count == 0
+                ? new Result<GetNewsPulseResponse>().Failure(
+                    $"No news found for {query.Symbol} in the past week.",
+                    ResultErrorType.NotFound)
+                : new Result<GetNewsPulseResponse>().Success(response);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching news for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
+            return new Result<GetNewsPulseResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "News request timed out for {Symbol}", query.Symbol);
+            return new Result<GetNewsPulseResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize news response for {Symbol}", query.Symbol);
+            return new Result<GetNewsPulseResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected news failure for {Symbol}", query.Symbol);
+            return new Result<GetNewsPulseResponse>().Failure("News pulse failed unexpectedly");
+        }
+    }
+
+    private async Task<NewsSentiment?> TryFetchSentimentAsync(string symbol, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await cache.GetOrCreateAsync(
+                $"news-sentiment:s={symbol.ToUpperInvariant()}",
+                CacheTier.News,
+                async ct => await apiClient.GetSentimentAsync(symbol, ct),
+                cancellationToken);
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogInformation(ex, "Sentiment endpoint premium-locked for {Symbol}; degrading", symbol);
+            return null;
+        }
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/News/FinnHubNewsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/News/FinnHubNewsApiClient.cs
@@ -1,0 +1,184 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.News.Clients;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.News;
+
+/// <summary>
+/// HTTP client for Finnhub's news endpoints (<c>/news-sentiment</c> and <c>/company-news</c>).
+/// </summary>
+public sealed class FinnHubNewsApiClient : INewsApiClient
+{
+    private const string CompanyNewsEndpoint = "company-news";
+    private const string SentimentEndpoint = "news-sentiment";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubNewsApiClient> _logger;
+
+    /// <summary>Initialises a new <see cref="FinnHubNewsApiClient"/>.</summary>
+    public FinnHubNewsApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubNewsApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<CompanyNewsArticle>> GetCompanyNewsAsync(
+        string symbol,
+        DateOnly from,
+        DateOnly to,
+        CancellationToken cancellationToken)
+    {
+        var endpoint = this.ResolveEndpoint(CompanyNewsEndpoint);
+        var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(symbol)}" +
+                         $"&from={from:yyyy-MM-dd}&to={to:yyyy-MM-dd}";
+
+        await using var stream = await this.GetStreamAsync(requestUri, cancellationToken).ConfigureAwait(false);
+
+        FinnHubCompanyNewsArticle[]? articles;
+        try
+        {
+            articles = await JsonSerializer
+                .DeserializeAsync(stream, FinnHubJsonContext.Default.FinnHubCompanyNewsArticleArray, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize company-news response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize company-news response: {requestUri}",
+                innerException: ex);
+        }
+
+        return articles is null
+            ? []
+            : articles
+                .Where(a => !string.IsNullOrEmpty(a.Headline))
+                .Select(a => new CompanyNewsArticle(
+                    a.Headline ?? string.Empty,
+                    a.Url ?? string.Empty,
+                    a.Source ?? string.Empty,
+                    DateTimeOffset.FromUnixTimeSeconds(a.Datetime)))
+                .ToList()
+                .AsReadOnly();
+    }
+
+    /// <inheritdoc />
+    public async Task<NewsSentiment> GetSentimentAsync(string symbol, CancellationToken cancellationToken)
+    {
+        var endpoint = this.ResolveEndpoint(SentimentEndpoint);
+        var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(symbol)}";
+
+        await using var stream = await this.GetStreamAsync(requestUri, cancellationToken).ConfigureAwait(false);
+
+        FinnHubNewsSentimentResponse? dto;
+        try
+        {
+            dto = await JsonSerializer
+                .DeserializeAsync(stream, FinnHubJsonContext.Default.FinnHubNewsSentimentResponse, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize sentiment response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize sentiment response: {requestUri}",
+                innerException: ex);
+        }
+
+        return new NewsSentiment(
+            dto?.CompanyNewsScore,
+            dto?.Sentiment?.BullishPercent,
+            dto?.Sentiment?.BearishPercent);
+    }
+
+    private string ResolveEndpoint(string name) =>
+        this._options.EndPoints.FirstOrDefault(e => e.IsActive && string.Equals(e.Name, name, StringComparison.Ordinal))?.Url
+        ?? throw new ArgumentException(string.Create(CultureInfo.InvariantCulture, $"Endpoint '{name}' is not configured or inactive"));
+
+    private async Task<Stream> GetStreamAsync(string requestUri, CancellationToken cancellationToken)
+    {
+        this._logger.LogInformation("Requesting news from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub news failed: {Uri}", requestUri);
+            throw new ApiClientHttpException($"HTTP request to FinnHub news failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "News request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"News request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("News request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"News request cancelled: {requestUri}");
+        }
+
+        var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await HandleErrorAsync(response, contentStream, cancellationToken, this._logger).ConfigureAwait(false);
+        }
+
+        return contentStream;
+    }
+
+    private static async Task HandleErrorAsync(
+        HttpResponseMessage response,
+        Stream contentStream,
+        CancellationToken ct,
+        ILogger logger)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            logger.LogWarning("Premium-locked news endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "News API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException($"FinnHub news returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubCompanyNewsArticle.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubCompanyNewsArticle.cs
@@ -1,0 +1,32 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>Wire DTO for a single article in the Finnhub <c>/company-news</c> array response.</summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubCompanyNewsArticle
+{
+    /// <summary>Article headline.</summary>
+    [JsonPropertyName("headline")]
+    public string? Headline { get; init; }
+
+    /// <summary>Public URL of the article.</summary>
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+
+    /// <summary>Publisher name.</summary>
+    [JsonPropertyName("source")]
+    public string? Source { get; init; }
+
+    /// <summary>Unix-epoch (seconds) publication time.</summary>
+    [JsonPropertyName("datetime")]
+    public long Datetime { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubNewsSentimentResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubNewsSentimentResponse.cs
@@ -1,0 +1,41 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>Wire DTO for the Finnhub <c>/news-sentiment</c> endpoint (premium).</summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubNewsSentimentResponse
+{
+    /// <summary>Symbol echoed by Finnhub.</summary>
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; init; }
+
+    /// <summary>Composite company news sentiment score.</summary>
+    [JsonPropertyName("companyNewsScore")]
+    public double? CompanyNewsScore { get; init; }
+
+    /// <summary>Nested sentiment breakdown.</summary>
+    [JsonPropertyName("sentiment")]
+    public FinnHubNewsSentimentBreakdown? Sentiment { get; init; }
+}
+
+/// <summary>Bullish/bearish breakdown nested under <c>sentiment</c>.</summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubNewsSentimentBreakdown
+{
+    /// <summary>Share of news scored as bullish (0..1).</summary>
+    [JsonPropertyName("bullishPercent")]
+    public double? BullishPercent { get; init; }
+
+    /// <summary>Share of news scored as bearish (0..1).</summary>
+    [JsonPropertyName("bearishPercent")]
+    public double? BearishPercent { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -11,6 +11,8 @@ using System.Net.Mime;
 using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Financials.Clients;
 using FinnHub.MCP.Server.Application.Financials.Services;
+using FinnHub.MCP.Server.Application.News.Clients;
+using FinnHub.MCP.Server.Application.News.Services;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Services;
@@ -20,6 +22,7 @@ using FinnHub.MCP.Server.Application.RateLimiting;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Caching;
 using FinnHub.MCP.Server.Infrastructure.Clients.Financials;
+using FinnHub.MCP.Server.Infrastructure.Clients.News;
 using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
 using FinnHub.MCP.Server.Infrastructure.Clients.Prices;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
@@ -94,6 +97,14 @@ public static class ServiceCollectionExtension
             .AddHttpMessageHandler<RateLimitHeaderHandler>()
             .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubPricesApiClient>>()))
             .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubPricesApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<INewsService, NewsService>();
+        services.AddHttpClient<INewsApiClient, FinnHubNewsApiClient>("FinnHub-News-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubNewsApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubNewsApiClient>>()))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -9,6 +9,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
 using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
@@ -62,4 +63,8 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 [JsonSerializable(typeof(FinnHubCandleResponse))]
 [JsonSerializable(typeof(GetPriceSummaryResponse))]
 [JsonSerializable(typeof(ToolResponseEnvelope<GetPriceSummaryResponse>))]
+[JsonSerializable(typeof(FinnHubNewsSentimentResponse))]
+[JsonSerializable(typeof(FinnHubCompanyNewsArticle[]))]
+[JsonSerializable(typeof(GetNewsPulseResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetNewsPulseResponse>))]
 public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -362,5 +362,56 @@ public static class Constants
                 Approx tokens: summary ~120, standard ~120, full varies with period (~600 at 30d, ~2000 at 1y).
                 """;
         }
+
+        /// <summary>Constants for the <c>get-news-pulse</c> tool — aggregated news sentiment and headlines.</summary>
+        public static class NewsPulse
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-news-pulse";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get News Pulse";
+
+            /// <summary>Parameter names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription = "Uppercase ticker symbol, e.g. 'AAPL'.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>Tool description registered with the MCP server.</summary>
+            public const string Description =
+                """
+                Get an aggregated news pulse for a symbol over the past 7 days — sentiment scores
+                (when the upstream sentiment endpoint is available), top 5 headlines, total article
+                count, and the article-count delta vs the prior 7-day window.
+
+                ## Example:
+                - symbol='AAPL'
+
+                ## Response Fields:
+                - symbol (string)
+                - period (string): always "7d" in v1
+                - sentiment_score, bullish_percent, bearish_percent (double, nullable):
+                  populated only when the upstream /news-sentiment endpoint is reachable.
+                  Falls back to null gracefully on premium-locked keys.
+                - sentiment_source (string, nullable): "finnhub" when sentiment is present, null otherwise.
+                - top_headlines (array of objects): top 5 most-recent (or all if view="full"); each
+                  { headline, url, source, datetime_utc }.
+                - count (int): article count over the current 7-day window.
+                - delta_vs_prev_week (int): current count minus prior-week count.
+
+                Approx tokens: summary ~400, standard ~400, full varies with article count.
+                """;
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -17,6 +17,7 @@ using FinnHub.MCP.Server.Middleware;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
 using FinnHub.MCP.Server.Tools.Financials;
+using FinnHub.MCP.Server.Tools.News;
 using FinnHub.MCP.Server.Tools.Peers;
 using FinnHub.MCP.Server.Tools.Prices;
 using FinnHub.MCP.Server.Tools.Search;
@@ -101,6 +102,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithWrappedTools<GetPeersTool>()
 .WithWrappedTools<GetFinancialsSnapshotTool>()
 .WithWrappedTools<GetPriceSummaryTool>()
+.WithWrappedTools<GetNewsPulseTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>();
 

--- a/src/FinnHub.MCP.Server/Tools/News/GetNewsPulseTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/News/GetNewsPulseTool.cs
@@ -1,0 +1,115 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+using FinnHub.MCP.Server.Application.News.Services;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.News;
+
+/// <summary>
+/// MCP tool exposing an aggregated news pulse for a symbol — sentiment (when
+/// available), top headlines, and a delta vs the prior 7 days.
+/// </summary>
+[McpServerToolType]
+public sealed class GetNewsPulseTool(
+    INewsService newsService,
+    ILogger<GetNewsPulseTool> logger)
+{
+    /// <summary>
+    /// Returns the news pulse for a symbol — sentiment score, top headlines, and
+    /// article-count delta vs the prior 7-day window. <c>view = "full"</c>
+    /// returns the complete headline list rather than the top 5.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.NewsPulse.Name,
+        Title = Constants.Tools.NewsPulse.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.NewsPulse.Description)]
+    public async Task<ToolResponseEnvelope<GetNewsPulseResponse>> GetNewsPulseAsync(
+        [Description(Constants.Tools.NewsPulse.Parameters.SymbolDescription)]
+        string symbol,
+        [Description(Constants.Tools.NewsPulse.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.NewsPulse.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedSymbol = NewsInputValidator.ValidateSymbol(symbol);
+            var validatedView = NewsInputValidator.ValidateView(view);
+
+            var query = new GetNewsPulseQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Symbol = validatedSymbol,
+                IncludeAllHeadlines = validatedView == ToolView.Full
+            };
+
+            var result = await newsService.GetPulseAsync(query, cancellationToken);
+
+            logger.LogInformation(
+                "News pulse completed for {Symbol} in {ElapsedMs}ms",
+                validatedSymbol, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.FromResult(
+                result,
+                validatedView,
+                explanation: BuildExplanation(result, validatedSymbol),
+                sentimentSource: result.Data?.SentimentSource);
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static string BuildExplanation(Result<GetNewsPulseResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return $"No news pulse available for '{symbol}'.";
+        }
+
+        var deltaWord = result.Data.DeltaVsPrevWeek switch
+        {
+            > 0 => $"+{result.Data.DeltaVsPrevWeek}",
+            _ => result.Data.DeltaVsPrevWeek.ToString(CultureInfo.InvariantCulture)
+        };
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"News pulse for '{symbol}': {result.Data.Count} articles in past 7d ({deltaWord} vs prior week).");
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/News/NewsInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/News/NewsInputValidator.cs
@@ -1,0 +1,53 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Tools.News;
+
+/// <summary>Validation helpers for the <c>get-news-pulse</c> tool parameters.</summary>
+internal static partial class NewsInputValidator
+{
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be empty.", nameof(symbol));
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -45,6 +45,20 @@
         "IsActive": true,
         "group": "stock",
         "Description": "Returns OHLCV candles for a symbol over the given period and resolution."
+      },
+      {
+        "Name": "company-news",
+        "Url": "/company-news",
+        "IsActive": true,
+        "group": "news",
+        "Description": "Returns company news articles for a symbol over a UTC date range."
+      },
+      {
+        "Name": "news-sentiment",
+        "Url": "/news-sentiment",
+        "IsActive": true,
+        "group": "news",
+        "Description": "Returns composite news sentiment snapshot for a symbol (premium)."
       }
     ]
   },

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
@@ -1,0 +1,152 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.News.Clients;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+using FinnHub.MCP.Server.Application.News.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.News.Services;
+
+public sealed class NewsServiceTests
+{
+    private readonly INewsApiClient _apiClient = Substitute.For<INewsApiClient>();
+    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly NewsService _sut;
+
+    public NewsServiceTests()
+    {
+        // Cache delegates passthrough for both list and sentiment payloads.
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<IReadOnlyList<CompanyNewsArticle>>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<IReadOnlyList<CompanyNewsArticle>>>>()(CancellationToken.None));
+
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<NewsSentiment>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<NewsSentiment>>>()(CancellationToken.None));
+
+        this._sut = new NewsService(this._apiClient, this._cache, NullLogger<NewsService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetPulseAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetPulseAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetPulseAsync_WithSentimentAndArticles_ReturnsFullResponse()
+    {
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .Returns(new NewsSentiment(0.8, 0.7, 0.1));
+        var now = DateTimeOffset.UtcNow;
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ =>
+            {
+                return (IReadOnlyList<CompanyNewsArticle>)
+                [
+                    new CompanyNewsArticle("h1", "u1", "src", now),
+                    new CompanyNewsArticle("h2", "u2", "src", now.AddHours(-1))
+                ];
+            });
+
+        var result = await this._sut.GetPulseAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(0.8, result.Data!.SentimentScore);
+        Assert.Equal("finnhub", result.Data.SentimentSource);
+        Assert.Equal(2, result.Data.Count);
+        Assert.Equal(0, result.Data.DeltaVsPrevWeek);
+        Assert.Equal(2, result.Data.TopHeadlines.Count);
+    }
+
+    [Fact]
+    public async Task GetPulseAsync_PremiumSentiment_DegradesGracefully()
+    {
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/api/v1/news-sentiment"));
+
+        var now = DateTimeOffset.UtcNow;
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IReadOnlyList<CompanyNewsArticle>)[new CompanyNewsArticle("h1", "u1", "src", now)]);
+
+        var result = await this._sut.GetPulseAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Null(result.Data!.SentimentScore);
+        Assert.Null(result.Data.SentimentSource);
+        Assert.Equal(1, result.Data.Count);
+    }
+
+    [Fact]
+    public async Task GetPulseAsync_NoArticles_ReturnsNotFound()
+    {
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "UNKN" };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .Returns(new NewsSentiment(null, null, null));
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IReadOnlyList<CompanyNewsArticle>)[]);
+
+        var result = await this._sut.GetPulseAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("NotFound", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetPulseAsync_TopHeadlinesCappedAtFive()
+    {
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .Returns(new NewsSentiment(null, null, null));
+        var now = DateTimeOffset.UtcNow;
+        var many = Enumerable.Range(0, 10)
+            .Select(i => new CompanyNewsArticle($"h{i}", $"u{i}", "src", now.AddMinutes(-i)))
+            .ToList();
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IReadOnlyList<CompanyNewsArticle>)many);
+
+        var result = await this._sut.GetPulseAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(5, result.Data!.TopHeadlines.Count);
+        Assert.Equal("h0", result.Data.TopHeadlines[0].Headline);
+    }
+
+    [Fact]
+    public async Task GetPulseAsync_IncludeAllHeadlines_ReturnsAll()
+    {
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "AAPL", IncludeAllHeadlines = true };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .Returns(new NewsSentiment(null, null, null));
+        var now = DateTimeOffset.UtcNow;
+        var many = Enumerable.Range(0, 8)
+            .Select(i => new CompanyNewsArticle($"h{i}", $"u{i}", "src", now.AddMinutes(-i)))
+            .ToList();
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IReadOnlyList<CompanyNewsArticle>)many);
+
+        var result = await this._sut.GetPulseAsync(query);
+
+        Assert.Equal(8, result.Data!.TopHeadlines.Count);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
@@ -1,0 +1,133 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.News;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.News;
+
+public sealed class FinnHubNewsApiClientTests : IDisposable
+{
+    private const string SentimentPayload = """
+                                            {
+                                              "symbol": "AAPL",
+                                              "companyNewsScore": 0.84,
+                                              "sentiment": { "bullishPercent": 0.85, "bearishPercent": 0.15 }
+                                            }
+                                            """;
+
+    private const string CompanyNewsPayload = """
+                                              [
+                                                { "headline": "h1", "url": "u1", "source": "s1", "datetime": 1700000000 },
+                                                { "headline": "h2", "url": "u2", "source": "s2", "datetime": 1700086400 }
+                                              ]
+                                              """;
+
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubNewsApiClient _sut;
+
+    public FinnHubNewsApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints =
+            [
+                new FinnHubEndPoint { Name = "company-news", Url = "company-news", IsActive = true },
+                new FinnHubEndPoint { Name = "news-sentiment", Url = "news-sentiment", IsActive = true }
+            ]
+        });
+
+        this._sut = new FinnHubNewsApiClient(this._httpClient, options, NullLogger<FinnHubNewsApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetSentimentAsync_Success_ParsesBreakdown()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SentimentPayload);
+
+        var result = await this._sut.GetSentimentAsync("AAPL", CancellationToken.None);
+
+        Assert.Equal(0.84, result.CompanyNewsScore);
+        Assert.Equal(0.85, result.BullishPercent);
+        Assert.Equal(0.15, result.BearishPercent);
+    }
+
+    [Fact]
+    public async Task GetSentimentAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() =>
+            this._sut.GetSentimentAsync("AAPL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetCompanyNewsAsync_Success_MapsArticles()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, CompanyNewsPayload);
+
+        var result = await this._sut.GetCompanyNewsAsync(
+            "AAPL",
+            new DateOnly(2026, 5, 1),
+            new DateOnly(2026, 5, 7),
+            CancellationToken.None);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("h1", result[0].Headline);
+        Assert.Equal("u1", result[0].Url);
+        Assert.Contains("from=2026-05-01", this._handler.LastRequest!.RequestUri!.Query, StringComparison.Ordinal);
+        Assert.Contains("to=2026-05-07", this._handler.LastRequest!.RequestUri!.Query, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task GetCompanyNewsAsync_Empty_ReturnsEmptyList()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "[]");
+
+        var result = await this._sut.GetCompanyNewsAsync(
+            "UNK",
+            new DateOnly(2026, 5, 1),
+            new DateOnly(2026, 5, 7),
+            CancellationToken.None);
+
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task GetCompanyNewsAsync_BlankHeadline_Filtered()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK,
+            "[{\"headline\":\"\",\"url\":\"u\",\"source\":\"s\",\"datetime\":1700000000},{\"headline\":\"h2\",\"url\":\"u2\",\"source\":\"s2\",\"datetime\":1700000000}]");
+
+        var result = await this._sut.GetCompanyNewsAsync(
+            "AAPL",
+            new DateOnly(2026, 5, 1),
+            new DateOnly(2026, 5, 7),
+            CancellationToken.None);
+
+        Assert.Single(result);
+        Assert.Equal("h2", result[0].Headline);
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/GetNewsPulseToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/GetNewsPulseToolTests.cs
@@ -1,0 +1,70 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+using FinnHub.MCP.Server.Application.News.Services;
+using FinnHub.MCP.Server.Tools.News;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.News;
+
+public sealed class GetNewsPulseToolTests
+{
+    private readonly INewsService _service = Substitute.For<INewsService>();
+    private readonly GetNewsPulseTool _sut;
+
+    public GetNewsPulseToolTests()
+    {
+        this._sut = new GetNewsPulseTool(this._service, NullLogger<GetNewsPulseTool>.Instance);
+    }
+
+    [Fact]
+    public async Task GetNewsPulseAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetNewsPulseAsync("!!!"));
+    }
+
+    [Fact]
+    public async Task GetNewsPulseAsync_LowercaseSymbol_Normalises()
+    {
+        this._service
+            .GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetNewsPulseResponse>().Success(
+                new GetNewsPulseResponse { Symbol = "AAPL", Count = 1, SentimentSource = "finnhub" }));
+
+        await this._sut.GetNewsPulseAsync("aapl");
+
+        await this._service.Received(1).GetPulseAsync(
+            Arg.Is<GetNewsPulseQuery>(q => q.Symbol == "AAPL" && !q.IncludeAllHeadlines),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNewsPulseAsync_FullView_SetsIncludeAllHeadlines()
+    {
+        this._service
+            .GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetNewsPulseResponse>().Success(
+                new GetNewsPulseResponse { Symbol = "AAPL", Count = 1 }));
+
+        await this._sut.GetNewsPulseAsync("AAPL", view: "full");
+
+        await this._service.Received(1).GetPulseAsync(
+            Arg.Is<GetNewsPulseQuery>(q => q.IncludeAllHeadlines),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetNewsPulseAsync_InvalidView_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._sut.GetNewsPulseAsync("AAPL", view: "nonsense"));
+    }
+}


### PR DESCRIPTION
## Summary
Fourth and final tool in P6 Wave A (after #152 get-peers, #153 get-financials-snapshot, #155 get-price-summary). Most complex of the wave — orchestrates three upstream calls and gracefully degrades sentiment when the upstream sentiment endpoint is premium-locked.

## Tool: get-news-pulse
- Maps to two Finnhub endpoints:
  - `/news-sentiment` (premium): composite sentiment, bullish/bearish percent
  - `/company-news` x2: current 7-day window + prior 7-day window for the `delta_vs_prev_week` stat
- **Sentiment degradation per P5**: when `/news-sentiment` returns 403, `ApiClientPremiumRequiredException` is caught in the service and `sentiment_source` is set to `null` — the response still ships with headlines and counts
- Top 5 headlines by datetime desc on default views; `view=full` returns the full list
- News-tier cache (1m TTL) per P2; the two company-news calls share cache slots across invocations
- `NotFound` when the current week yields zero articles

## Spec
[`.planning/specs/01-product-surface.md` §3 P6](https://github.com/SalZaki/finnhub-mcp/blob/main/.planning/specs/01-product-surface.md)

## P6 Wave A status — complete after merge
- [x] #152 `get-peers`
- [x] #153 `get-financials-snapshot`
- [x] #155 `get-price-summary`
- [ ] this PR — `get-news-pulse`

Brings the active tool surface to 5 (search-symbol + Wave A four). Wave B (`get-quote` + `get-company-profile`) is next.

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 233/233 pass (was 218; +15 new)
  - Service: full happy path, premium-sentiment degradation, no-articles → NotFound, top-5 cap, IncludeAllHeadlines passthrough
  - Client: sentiment parsing, premium 403, company-news mapping with date range in query string, empty list, blank-headline filtering
  - Tool: invalid symbol/view rejected, lowercase normalised, view=full sets IncludeAllHeadlines

## Follow-ups (not in this PR)
- Cross-link `next_actions` across the 5 tools (search-symbol → get-peers/get-news-pulse/etc, get-financials-snapshot → get-peers/get-recommendations)
- README "Currently Available" update — defer until all of Wave B/C/D lands so README reflects the full picture