### PR TITLE
ci: gate releases through release branch

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,15 +2,13 @@ name: Build and Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, release]
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'assets/**'
   pull_request:
     branches: [main, develop]
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'assets/**'
   workflow_dispatch:
@@ -57,7 +55,7 @@ jobs:
         run: dotnet restore ./finnhub-mcp.sln
 
       - name: 🏗️ Build solution
-        run: dotnet build -p:CurrentYear=$(date +'%Y') --no-restore --configuration Release
+        run: dotnet build -p:CurrentYear="$(date +'%Y')" --no-restore --configuration Release
 
   test:
     name: 🧪 Unit Tests & 📊 Coverage
@@ -103,13 +101,13 @@ jobs:
 
           # Find all coverage files and copy them
           counter=1
-          for file in $(find ./TestResults -name "coverage.cobertura.xml"); do
+          while IFS= read -r file; do
             # Extract a unique identifier from the path
             dir_name=$(dirname "$file" | sed 's|.*/||')
             cp "$file" "./Coverage/coverage-${counter}-${dir_name}.cobertura.xml"
             echo "Copied $file to ./Coverage/coverage-${counter}-${dir_name}.cobertura.xml"
             ((counter++))
-          done
+          done < <(find ./TestResults -name "coverage.cobertura.xml")
 
           # Copy test results file
           find ./TestResults -name "*.trx" -exec cp {} ./Coverage/ \;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -142,14 +142,6 @@ jobs:
           flags: unit-tests
           name: codecov-test-results-finnhub-mcp
 
-      - name: 📊 Publish test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: .NET Tests
-          path: ./TestResults/*.trx
-          reporter: dotnet-trx
-
       - name: 📁 Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,35 @@ permissions:
   issues: write
 
 jobs:
+  validate:
+    name: ✅ Validate Release Branch
+    if: ${{ github.ref_name == 'release' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 📦 Restore
+        shell: bash
+        run: dotnet restore ./finnhub-mcp.sln
+
+      - name: 🎨 Format check
+        shell: bash
+        run: dotnet format ./finnhub-mcp.sln --verify-no-changes --no-restore
+
+      - name: 🧪 Test
+        shell: bash
+        run: dotnet test ./finnhub-mcp.sln --configuration Release --no-restore
+
   release:
     name: 📦 Create GitHub Release
+    needs: validate
     if: ${{ github.ref_name == 'release' }}
     runs-on: ubuntu-latest
     outputs:
@@ -40,33 +67,10 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  validate:
-    name: ✅ Validate Release
-    needs: release
-    if: ${{ needs.release.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v4
-
-      - name: 🧰 Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: 📦 Restore
-        shell: bash
-        run: dotnet restore ./finnhub-mcp.sln
-
-      - name: 🧪 Test
-        shell: bash
-        run: dotnet test ./finnhub-mcp.sln --configuration Release --no-restore
-
   build:
     name: 🔧 Build & Upload Artifacts
-    needs: [release, validate]
-    if: ${{ needs.release.outputs.release_created }}
+    needs: release
+    if: ${{ needs.release.outputs.release_created == 'true' }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,15 @@
 on:
   push:
     branches:
-      - main
       - release
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'assets/**'
   workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -19,6 +21,7 @@ permissions:
 jobs:
   release:
     name: 📦 Create GitHub Release
+    if: ${{ github.ref_name == 'release' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -37,9 +40,32 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  validate:
+    name: ✅ Validate Release
+    needs: release
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 📦 Restore
+        shell: bash
+        run: dotnet restore ./finnhub-mcp.sln
+
+      - name: 🧪 Test
+        shell: bash
+        run: dotnet test ./finnhub-mcp.sln --configuration Release --no-restore
+
   build:
     name: 🔧 Build & Upload Artifacts
-    needs: release
+    needs: [release, validate]
     if: ${{ needs.release.outputs.release_created }}
     strategy:
       fail-fast: true
@@ -96,18 +122,18 @@ jobs:
       - name: 📦 Publish
         shell: bash
         run: |
-          VERSION_CLEAN=${{ needs.release.outputs.tag_name }}
+          VERSION_CLEAN="${{ needs.release.outputs.tag_name }}"
           VERSION_CLEAN=${VERSION_CLEAN#v}
           echo "Publishing version: $VERSION_CLEAN"
 
           dotnet publish src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj \
             -c Release \
-            -r ${{ matrix.runtime }} \
+            -r "${{ matrix.runtime }}" \
             --self-contained true \
             --no-restore \
-            -p:Version=$VERSION_CLEAN \
-            -p:AssemblyVersion=$VERSION_CLEAN \
-            -p:FileVersion=$VERSION_CLEAN \
+            -p:Version="$VERSION_CLEAN" \
+            -p:AssemblyVersion="$VERSION_CLEAN" \
+            -p:FileVersion="$VERSION_CLEAN" \
             -p:DebugType=None \
             -p:DebugSymbols=false \
             -p:PublishSingleFile=true \
@@ -123,10 +149,12 @@ jobs:
 
       - name: 🧼 Prepare Artifact
         shell: bash
+        env:
+          RUNTIME: ${{ matrix.runtime }}
         run: |
           cd ./publish
 
-          if [[ "${{ matrix.runtime }}" == win-* ]]; then
+          if [[ "$RUNTIME" == win-* ]]; then
             # Windows: Look for .exe files
             EXEC=$(find . -name "*.exe" -type f | head -1)
             if [ -z "$EXEC" ]; then
@@ -173,6 +201,8 @@ jobs:
 
       - name: ✅ Verify Artifact
         shell: bash
+        env:
+          RUNTIME: ${{ matrix.runtime }}
         run: |
           cd ./publish
           if [ ! -f "${{ matrix.artifact_name }}" ]; then
@@ -185,7 +215,7 @@ jobs:
           echo "✅ Artifact size: $SIZE bytes"
 
           # Verify it's executable (Unix only)
-          if [[ "${{ matrix.runtime }}" != win-* ]] && [ ! -x "${{ matrix.artifact_name }}" ]; then
+          if [[ "$RUNTIME" != win-* ]] && [ ! -x "${{ matrix.artifact_name }}" ]; then
             echo "❌ Artifact is not executable"
             exit 1
           fi
@@ -204,15 +234,19 @@ jobs:
         if: always()
         shell: bash
         run: |
-          echo "## Build Summary for ${{ matrix.runtime }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **OS**: ${{ matrix.os }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Runtime**: ${{ matrix.runtime }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Artifact**: ${{ matrix.artifact_name }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Build Summary for ${{ matrix.runtime }}"
+            echo "- **OS**: ${{ matrix.os }}"
+            echo "- **Runtime**: ${{ matrix.runtime }}"
+            echo "- **Artifact**: ${{ matrix.artifact_name }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f "./publish/${{ matrix.artifact_name }}" ]; then
             SIZE=$(stat -c%s "./publish/${{ matrix.artifact_name }}" 2>/dev/null || stat -f%z "./publish/${{ matrix.artifact_name }}" 2>/dev/null || echo "unknown")
-            echo "- **Size**: $SIZE bytes" >> $GITHUB_STEP_SUMMARY
-            echo "- **Status**: ✅ Success" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "- **Size**: $SIZE bytes"
+              echo "- **Status**: ✅ Success"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- **Status**: ❌ Failed" >> $GITHUB_STEP_SUMMARY
+            echo "- **Status**: ❌ Failed" >> "$GITHUB_STEP_SUMMARY"
           fi


### PR DESCRIPTION
## Summary
- Gate all releases through the `release` branch — release-please and artifact builds no longer fire on `main` pushes.
- **Validate runs BEFORE release-please**: failed tests prevent the tag and GitHub release from being created at all (no orphan releases).
- Add `dotnet format --verify-no-changes` to the release-path validate to match PR CI surface.
- Run Build & Test on the `release` branch in addition to `main`/`develop`.
- Remove `dorny/test-reporter@v1` — root cause of recent PR CI flakes (`HttpError: Bad credentials`); the test job's pass/fail and Codecov's `test-results-action` already cover the signal.
- Concurrency control on the release workflow (`cancel-in-progress: false`) so simultaneous runs queue.
- Shell hardening throughout (POSIX-safe quoting, env-var indirection for `${{ matrix.* }}` before bash conditionals, `{ ... } >> $GITHUB_STEP_SUMMARY` grouping).

## New job graph

```
push to release
       │
       ▼
   ✅ validate          (format + tests; gate)
       │
       ▼
   📦 release           (release-please creates tag + GH release IF validate passed)
       │
       ▼
   🔧 build (matrix)    (uploads artifacts to the release; only when release_created=true)
```

A test failure now stops at `validate` — no tag, no GH release, no orphan state. Recovery is "fix and re-push to release."

## ⚠️ Migration steps required when this merges

This PR changes where releases come from. Operator action is required to keep ships flowing.

### 1. Bootstrap the `release` branch
The new workflow only triggers on pushes to `release`. The branch must exist on the remote first.
```bash
git fetch origin
git push origin origin/main:refs/heads/release
```

### 2. Close any stale release-please PR on `main`
After this PR merges, release-please will no longer act on `main`. Any open `release-please--branches--main` PR is dead — close it without merging. release-please will open a fresh PR targeting `release` on the next push.

### 3. Ship a release going forward
For each release:
```bash
# 1. Open a PR from main → release (gathers feat commits into one release)
gh pr create --base release --head main --title "release: promote main to release"

# 2. Merge it. validate runs, then release-please opens its release PR on release.
# 3. Merge release-please's PR. Tag + GH release + artifacts ship.
```

### 4. Recommended: protect the `release` branch
Settings → Branches → Add rule → `release` → Require PR + status checks. Otherwise anyone with push access can `git push origin release` and trigger a release.

## Open follow-ups (not in this PR)
- **Auto-promote workflow** (optional): a small workflow on push-to-main that opens the `main → release` PR automatically. Keeps the merge gate but removes the manual `gh pr create` step. Skipped here because the design intent (manual gate) is the value — easy to add later.
- **Branch protection on `release`**: repo-settings change, can't be in this PR.
- **Replace dorny with a more reliable PR check** (optional): the dotnet test step already shows pass/fail; not adding a replacement.

## Validation
- `actionlint .github/workflows/*.yml` — clean
- `git diff --check` — clean
- New job graph reviewed: `validate` blocks `release` blocks `build`; failed validate aborts before tag creation.