### PR TITLE
feat(p6a): cross-link next_actions across Wave A tools + README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,29 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 ## 🚧 Available & Upcoming MCP Capabilities
 
 ### ✅ Currently Available
-- **`search-symbol`** tool — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10)
-- **`finnhub://resources/exchanges`** resource — catalog of stock exchanges (code, name, country, MIC, timezone, trading hours)
+
+**Tools (5):**
+- **`search-symbol`** — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10). On a high-confidence exact match, suggests `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, and `get-peers` as next actions.
+- **`get-peers`** — peer ticker list for a symbol, optionally grouped by `industry` (default), `subindustry`, or `sector`. Summary view caps at 10 peers, standard at 25, full returns all.
+- **`get-financials-snapshot`** — curated 10-KPI snapshot (market cap, P/E, P/B, EPS, dividend yield, 52-week high/low, 52-week return, beta, revenue per share). `view=full` adds the raw upstream metric dictionary.
+- **`get-price-summary`** — aggregated price stats over a candle range (`min`, `max`, `mean`, `return_pct`, `vol`, `latest`). Period: `7d`, `30d` (default), `90d`, `1y`. `view=full` adds the raw OHLCV arrays.
+- **`get-news-pulse`** — news pulse over the past 7 days: sentiment score (when available), top 5 headlines, article count, week-over-week delta. Gracefully degrades sentiment when the upstream `/news-sentiment` endpoint is premium-locked.
+
+Every tool returns the standard token-budgeted envelope with cross-linked `next_actions` and the most-recent observed Finnhub rate-limit headers.
+
+**Resources (2):**
+- **`finnhub://resources/exchanges`** — catalog of stock exchanges (code, name, country, MIC, timezone, trading hours)
+- **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
 ### 🔄 In Development
 - Wire `ExchangesResource` to the live Finnhub `/stock/exchange` endpoint
-- **Real-Time Quote Tool** — live prices for stocks, FX, and crypto
-- **Company Profile Tool** — company information and metrics
-- **Basic Financials Tool** — key financial metrics and ratios
+- **`get-quote`** — real-time price snapshot (current, change, percent_change, high/low/open, prev_close, timestamp)
+- **`get-company-profile`** — company information (name, ticker, country, currency, exchange, IPO, market cap, industry, sector)
 
 ### 📋 Planned
-- Earnings calendar, news & sentiment, insider trading, market status
+- Calendar tool (parameter-dispatched across earnings/IPO/economic), insider transactions, analyst recommendations
+- `search-tools` meta-tool for intent-based discovery (P7)
 - Technical indicators (RSI, MACD, moving averages)
-- Economic data and crypto market data
 - WebSocket transport for streaming Finnhub feeds
 
 ## 🚀 Getting Started
@@ -171,6 +181,38 @@ Parameters:
 - `limit` *(int, optional)* — 1–100, defaults to 10.
 - `view` *(string, optional)* — response detail level. One of `summary` (default, ~500-token ceiling), `standard` (~2000-token ceiling), `full` (no ceiling).
 - `fields` *(string[], optional)* — sparse projection over the documented response fields. Unknown field names are rejected as a validation error.
+
+### Tool: `get-peers`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker, e.g. `AAPL`. 1–20 chars, starts with A–Z.
+- `grouping` *(string, optional)* — `industry` (default), `subindustry`, or `sector`.
+- `view` *(string, optional)* — `summary` (top 10), `standard` (top 25), `full` (all).
+
+### Tool: `get-financials-snapshot`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `view` *(string, optional)* — `summary`/`standard` (10 curated KPIs), `full` (KPIs + raw upstream metric dictionary).
+
+### Tool: `get-price-summary`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `period` *(string, optional)* — `7d`, `30d` (default), `90d`, or `1y`. The `1y` window uses weekly resolution; the others use daily.
+- `view` *(string, optional)* — `summary`/`standard` (aggregated stats), `full` (stats + raw OHLCV arrays).
+
+### Tool: `get-news-pulse`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `view` *(string, optional)* — `summary`/`standard` (top 5 headlines), `full` (all headlines from the past 7 days).
+
+Sentiment fields (`sentiment_score`, `bullish_percent`, `bearish_percent`, `sentiment_source`) are populated only when the upstream `/news-sentiment` endpoint is reachable; they fall back to `null` on premium-locked keys without failing the call.
 
 ### Tool response envelope
 

--- a/src/FinnHub.MCP.Server/Tools/Financials/GetFinancialsSnapshotTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Financials/GetFinancialsSnapshotTool.cs
@@ -68,6 +68,7 @@ public sealed class GetFinancialsSnapshotTool(
             return EnvelopeFactory.FromResult(
                 result,
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol));
         }
         catch (OperationCanceledException ex)
@@ -90,6 +91,22 @@ public sealed class GetFinancialsSnapshotTool(
             stopwatch.Stop();
             logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
         }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetFinancialsSnapshotResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-peers", args, "compare this symbol's valuation to industry peers"),
+            new NextAction("get-price-summary", args, "check recent price action against these fundamentals")
+        ];
     }
 
     private static string BuildExplanation(Result<GetFinancialsSnapshotResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/News/GetNewsPulseTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/News/GetNewsPulseTool.cs
@@ -70,6 +70,7 @@ public sealed class GetNewsPulseTool(
             return EnvelopeFactory.FromResult(
                 result,
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol),
                 sentimentSource: result.Data?.SentimentSource);
         }
@@ -93,6 +94,22 @@ public sealed class GetNewsPulseTool(
             stopwatch.Stop();
             logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
         }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetNewsPulseResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || result.Data.Count == 0)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-price-summary", args, "correlate sentiment with recent price action"),
+            new NextAction("get-financials-snapshot", args, "check fundamentals against the news flow")
+        ];
     }
 
     private static string BuildExplanation(Result<GetNewsPulseResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
@@ -73,6 +73,7 @@ public sealed class GetPeersTool(
             return EnvelopeFactory.FromResult(
                 ProjectByView(result, validatedView),
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol));
         }
         catch (OperationCanceledException ex)
@@ -123,6 +124,22 @@ public sealed class GetPeersTool(
         };
 
         return new Result<GetPeersResponse>().Success(projected);
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetPeersResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || result.Data.TotalCount == 0)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-financials-snapshot", args, "compare this symbol's valuation to the peer set"),
+            new NextAction("get-news-pulse", args, "sentiment and headlines for this symbol")
+        ];
     }
 
     private static string BuildExplanation(Result<GetPeersResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/Prices/GetPriceSummaryTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Prices/GetPriceSummaryTool.cs
@@ -73,6 +73,7 @@ public sealed class GetPriceSummaryTool(
             return EnvelopeFactory.FromResult(
                 result,
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol));
         }
         catch (OperationCanceledException ex)
@@ -95,6 +96,22 @@ public sealed class GetPriceSummaryTool(
             stopwatch.Stop();
             logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
         }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetPriceSummaryResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || result.Data.CandleCount == 0)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-news-pulse", args, "find news that may explain the price action"),
+            new NextAction("get-financials-snapshot", args, "check fundamentals against recent price moves")
+        ];
     }
 
     private static string BuildExplanation(Result<GetPriceSummaryResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
@@ -144,10 +144,8 @@ public sealed class SearchSymbolTool(
 
     /// <summary>
     /// Builds server-suggested follow-up tool calls when the resolver has identified a
-    /// high-confidence canonical for the user's query (Confidence ≥ 0.95). The follow-up
-    /// tools (<c>get-company-profile</c>, <c>get-price-summary</c>, <c>get-news-pulse</c>)
-    /// are not yet registered; they land in a later phase. The envelope is forward-
-    /// compatible: clients are expected to ignore unknown tool names in <c>next_actions</c>.
+    /// high-confidence canonical (Confidence ≥ 0.95) for the user's query. Points at the
+    /// P6 Wave A research workflow: pulse, fundamentals, recent price action, peers.
     /// </summary>
     /// <remarks>
     /// The resolver's three fast-paths emit Confidence = 1.0, so structurally complete
@@ -178,9 +176,10 @@ public sealed class SearchSymbolTool(
 
         return
         [
-            new NextAction("get-company-profile", args, "fetch profile, sector, and market-cap context"),
-            new NextAction("get-price-summary", args, "summary stats for the latest range"),
-            new NextAction("get-news-pulse", args, "sentiment and top headlines")
+            new NextAction("get-news-pulse", args, "sentiment and top headlines from the past week"),
+            new NextAction("get-financials-snapshot", args, "10 curated valuation/profitability KPIs"),
+            new NextAction("get-price-summary", args, "min/max/mean/return/volatility over the last 30 days"),
+            new NextAction("get-peers", args, "industry peer list for comparison")
         ];
     }
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
@@ -73,10 +73,11 @@ public sealed class SearchSymbolToolTests
 
         var envelope = await tool.SearchSymbolAsync("AAPL");
 
-        Assert.Equal(3, envelope.NextActions.Count);
-        Assert.Equal("get-company-profile", envelope.NextActions[0].Tool);
-        Assert.Equal("get-price-summary", envelope.NextActions[1].Tool);
-        Assert.Equal("get-news-pulse", envelope.NextActions[2].Tool);
+        Assert.Equal(4, envelope.NextActions.Count);
+        Assert.Equal("get-news-pulse", envelope.NextActions[0].Tool);
+        Assert.Equal("get-financials-snapshot", envelope.NextActions[1].Tool);
+        Assert.Equal("get-price-summary", envelope.NextActions[2].Tool);
+        Assert.Equal("get-peers", envelope.NextActions[3].Tool);
         Assert.All(envelope.NextActions, a => Assert.Equal("AAPL", a.Args["symbol"]));
     }
 
@@ -89,7 +90,7 @@ public sealed class SearchSymbolToolTests
 
         var envelope = await tool.SearchSymbolAsync("microsoft");
 
-        Assert.Equal(3, envelope.NextActions.Count);
+        Assert.Equal(4, envelope.NextActions.Count);
         Assert.All(envelope.NextActions, a => Assert.Equal("MSFT", a.Args["symbol"]));
     }
 


### PR DESCRIPTION
## Summary
Closes out P6 Wave A by wiring `next_actions` across all 5 shipped tools so the consuming LLM gets workflow hints without enumerating the catalog, and updates the README to reflect the full Wave A surface.

## Cross-link graph

| From | → suggests | Why |
|---|---|---|
| `search-symbol` (high-confidence exact match) | `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, `get-peers` | The four-pillar research workflow for any resolved ticker |
| `get-peers` (has results) | `get-financials-snapshot`, `get-news-pulse` | Compare valuation / pulse for the symbol against the peer set |
| `get-financials-snapshot` (success) | `get-peers`, `get-price-summary` | Cross-check valuation against peers and momentum |
| `get-price-summary` (has candles) | `get-news-pulse`, `get-financials-snapshot` | Explain the price action via news + fundamentals |
| `get-news-pulse` (has articles) | `get-price-summary`, `get-financials-snapshot` | Did the news move the price? Are the fundamentals consistent? |

All `next_actions` pass the validated/resolved symbol through `args.symbol` so the LLM can chain without re-resolving. Dropped `get-company-profile` from `search-symbol`'s suggestions since it doesn't ship until Wave B.

## README
- Rewrote "Currently Available" to list the 5 tools and 2 resources with one-line descriptions
- Added per-tool parameter sections for the 4 Wave A tools, matching the existing `search-symbol` entry
- Updated "In Development" to reflect Wave B scope (`get-quote`, `get-company-profile`)

## Test plan
- [x] `dotnet build` — clean
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 233/233 pass. Updated `SearchSymbolToolTests` to assert the new 4-item `next_actions` list (was 3 items with the now-dropped `get-company-profile`).

## Exercises the new release pipeline
This is the first `feat:` since the gated-release CI landed (#158). After merge:
1. Open PR `main → release` to promote
2. `validate` job runs format + tests on the release branch
3. On pass, release-please opens its PR
4. Merging release-please's PR triggers the build/upload matrix