### PR TITLE
release: promote main to release for v1.19.0

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,15 +2,13 @@ name: Build and Test
 
 on:
   push:
-    branches: [main, develop]
+    branches: [main, develop, release]
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'assets/**'
   pull_request:
     branches: [main, develop]
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'assets/**'
   workflow_dispatch:
@@ -57,7 +55,7 @@ jobs:
         run: dotnet restore ./finnhub-mcp.sln
 
       - name: 🏗️ Build solution
-        run: dotnet build -p:CurrentYear=$(date +'%Y') --no-restore --configuration Release
+        run: dotnet build -p:CurrentYear="$(date +'%Y')" --no-restore --configuration Release
 
   test:
     name: 🧪 Unit Tests & 📊 Coverage
@@ -103,13 +101,13 @@ jobs:
 
           # Find all coverage files and copy them
           counter=1
-          for file in $(find ./TestResults -name "coverage.cobertura.xml"); do
+          while IFS= read -r file; do
             # Extract a unique identifier from the path
             dir_name=$(dirname "$file" | sed 's|.*/||')
             cp "$file" "./Coverage/coverage-${counter}-${dir_name}.cobertura.xml"
             echo "Copied $file to ./Coverage/coverage-${counter}-${dir_name}.cobertura.xml"
             ((counter++))
-          done
+          done < <(find ./TestResults -name "coverage.cobertura.xml")
 
           # Copy test results file
           find ./TestResults -name "*.trx" -exec cp {} ./Coverage/ \;

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -142,14 +142,6 @@ jobs:
           flags: unit-tests
           name: codecov-test-results-finnhub-mcp
 
-      - name: 📊 Publish test results
-        uses: dorny/test-reporter@v1
-        if: always()
-        with:
-          name: .NET Tests
-          path: ./TestResults/*.trx
-          reporter: dotnet-trx
-
       - name: 📁 Upload test results
         uses: actions/upload-artifact@v4
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,8 +19,35 @@ permissions:
   issues: write
 
 jobs:
+  validate:
+    name: ✅ Validate Release Branch
+    if: ${{ github.ref_name == 'release' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 📦 Restore
+        shell: bash
+        run: dotnet restore ./finnhub-mcp.sln
+
+      - name: 🎨 Format check
+        shell: bash
+        run: dotnet format ./finnhub-mcp.sln --verify-no-changes --no-restore
+
+      - name: 🧪 Test
+        shell: bash
+        run: dotnet test ./finnhub-mcp.sln --configuration Release --no-restore
+
   release:
     name: 📦 Create GitHub Release
+    needs: validate
     if: ${{ github.ref_name == 'release' }}
     runs-on: ubuntu-latest
     outputs:
@@ -40,33 +67,10 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
-  validate:
-    name: ✅ Validate Release
-    needs: release
-    if: ${{ needs.release.outputs.release_created == 'true' }}
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: 📥 Checkout
-        uses: actions/checkout@v4
-
-      - name: 🧰 Setup .NET
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '10.0.x'
-
-      - name: 📦 Restore
-        shell: bash
-        run: dotnet restore ./finnhub-mcp.sln
-
-      - name: 🧪 Test
-        shell: bash
-        run: dotnet test ./finnhub-mcp.sln --configuration Release --no-restore
-
   build:
     name: 🔧 Build & Upload Artifacts
-    needs: [release, validate]
-    if: ${{ needs.release.outputs.release_created }}
+    needs: release
+    if: ${{ needs.release.outputs.release_created == 'true' }}
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,13 +3,15 @@
 on:
   push:
     branches:
-      - main
       - release
     paths-ignore:
-      - '.github/**'
       - 'docs/**'
       - 'assets/**'
   workflow_dispatch:
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: write
@@ -19,6 +21,7 @@ permissions:
 jobs:
   release:
     name: 📦 Create GitHub Release
+    if: ${{ github.ref_name == 'release' }}
     runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
@@ -37,9 +40,32 @@ jobs:
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  validate:
+    name: ✅ Validate Release
+    needs: release
+    if: ${{ needs.release.outputs.release_created == 'true' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+
+      - name: 🧰 Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: 📦 Restore
+        shell: bash
+        run: dotnet restore ./finnhub-mcp.sln
+
+      - name: 🧪 Test
+        shell: bash
+        run: dotnet test ./finnhub-mcp.sln --configuration Release --no-restore
+
   build:
     name: 🔧 Build & Upload Artifacts
-    needs: release
+    needs: [release, validate]
     if: ${{ needs.release.outputs.release_created }}
     strategy:
       fail-fast: true
@@ -96,18 +122,18 @@ jobs:
       - name: 📦 Publish
         shell: bash
         run: |
-          VERSION_CLEAN=${{ needs.release.outputs.tag_name }}
+          VERSION_CLEAN="${{ needs.release.outputs.tag_name }}"
           VERSION_CLEAN=${VERSION_CLEAN#v}
           echo "Publishing version: $VERSION_CLEAN"
 
           dotnet publish src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj \
             -c Release \
-            -r ${{ matrix.runtime }} \
+            -r "${{ matrix.runtime }}" \
             --self-contained true \
             --no-restore \
-            -p:Version=$VERSION_CLEAN \
-            -p:AssemblyVersion=$VERSION_CLEAN \
-            -p:FileVersion=$VERSION_CLEAN \
+            -p:Version="$VERSION_CLEAN" \
+            -p:AssemblyVersion="$VERSION_CLEAN" \
+            -p:FileVersion="$VERSION_CLEAN" \
             -p:DebugType=None \
             -p:DebugSymbols=false \
             -p:PublishSingleFile=true \
@@ -123,10 +149,12 @@ jobs:
 
       - name: 🧼 Prepare Artifact
         shell: bash
+        env:
+          RUNTIME: ${{ matrix.runtime }}
         run: |
           cd ./publish
 
-          if [[ "${{ matrix.runtime }}" == win-* ]]; then
+          if [[ "$RUNTIME" == win-* ]]; then
             # Windows: Look for .exe files
             EXEC=$(find . -name "*.exe" -type f | head -1)
             if [ -z "$EXEC" ]; then
@@ -173,6 +201,8 @@ jobs:
 
       - name: ✅ Verify Artifact
         shell: bash
+        env:
+          RUNTIME: ${{ matrix.runtime }}
         run: |
           cd ./publish
           if [ ! -f "${{ matrix.artifact_name }}" ]; then
@@ -185,7 +215,7 @@ jobs:
           echo "✅ Artifact size: $SIZE bytes"
 
           # Verify it's executable (Unix only)
-          if [[ "${{ matrix.runtime }}" != win-* ]] && [ ! -x "${{ matrix.artifact_name }}" ]; then
+          if [[ "$RUNTIME" != win-* ]] && [ ! -x "${{ matrix.artifact_name }}" ]; then
             echo "❌ Artifact is not executable"
             exit 1
           fi
@@ -204,15 +234,19 @@ jobs:
         if: always()
         shell: bash
         run: |
-          echo "## Build Summary for ${{ matrix.runtime }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **OS**: ${{ matrix.os }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Runtime**: ${{ matrix.runtime }}" >> $GITHUB_STEP_SUMMARY
-          echo "- **Artifact**: ${{ matrix.artifact_name }}" >> $GITHUB_STEP_SUMMARY
+          {
+            echo "## Build Summary for ${{ matrix.runtime }}"
+            echo "- **OS**: ${{ matrix.os }}"
+            echo "- **Runtime**: ${{ matrix.runtime }}"
+            echo "- **Artifact**: ${{ matrix.artifact_name }}"
+          } >> "$GITHUB_STEP_SUMMARY"
 
           if [ -f "./publish/${{ matrix.artifact_name }}" ]; then
             SIZE=$(stat -c%s "./publish/${{ matrix.artifact_name }}" 2>/dev/null || stat -f%z "./publish/${{ matrix.artifact_name }}" 2>/dev/null || echo "unknown")
-            echo "- **Size**: $SIZE bytes" >> $GITHUB_STEP_SUMMARY
-            echo "- **Status**: ✅ Success" >> $GITHUB_STEP_SUMMARY
+            {
+              echo "- **Size**: $SIZE bytes"
+              echo "- **Status**: ✅ Success"
+            } >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- **Status**: ❌ Failed" >> $GITHUB_STEP_SUMMARY
+            echo "- **Status**: ❌ Failed" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/README.md
+++ b/README.md
@@ -35,19 +35,29 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 ## 🚧 Available & Upcoming MCP Capabilities
 
 ### ✅ Currently Available
-- **`search-symbol`** tool — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10)
-- **`finnhub://resources/exchanges`** resource — catalog of stock exchanges (code, name, country, MIC, timezone, trading hours)
+
+**Tools (5):**
+- **`search-symbol`** — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10). On a high-confidence exact match, suggests `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, and `get-peers` as next actions.
+- **`get-peers`** — peer ticker list for a symbol, optionally grouped by `industry` (default), `subindustry`, or `sector`. Summary view caps at 10 peers, standard at 25, full returns all.
+- **`get-financials-snapshot`** — curated 10-KPI snapshot (market cap, P/E, P/B, EPS, dividend yield, 52-week high/low, 52-week return, beta, revenue per share). `view=full` adds the raw upstream metric dictionary.
+- **`get-price-summary`** — aggregated price stats over a candle range (`min`, `max`, `mean`, `return_pct`, `vol`, `latest`). Period: `7d`, `30d` (default), `90d`, `1y`. `view=full` adds the raw OHLCV arrays.
+- **`get-news-pulse`** — news pulse over the past 7 days: sentiment score (when available), top 5 headlines, article count, week-over-week delta. Gracefully degrades sentiment when the upstream `/news-sentiment` endpoint is premium-locked.
+
+Every tool returns the standard token-budgeted envelope with cross-linked `next_actions` and the most-recent observed Finnhub rate-limit headers.
+
+**Resources (2):**
+- **`finnhub://resources/exchanges`** — catalog of stock exchanges (code, name, country, MIC, timezone, trading hours)
+- **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
 ### 🔄 In Development
 - Wire `ExchangesResource` to the live Finnhub `/stock/exchange` endpoint
-- **Real-Time Quote Tool** — live prices for stocks, FX, and crypto
-- **Company Profile Tool** — company information and metrics
-- **Basic Financials Tool** — key financial metrics and ratios
+- **`get-quote`** — real-time price snapshot (current, change, percent_change, high/low/open, prev_close, timestamp)
+- **`get-company-profile`** — company information (name, ticker, country, currency, exchange, IPO, market cap, industry, sector)
 
 ### 📋 Planned
-- Earnings calendar, news & sentiment, insider trading, market status
+- Calendar tool (parameter-dispatched across earnings/IPO/economic), insider transactions, analyst recommendations
+- `search-tools` meta-tool for intent-based discovery (P7)
 - Technical indicators (RSI, MACD, moving averages)
-- Economic data and crypto market data
 - WebSocket transport for streaming Finnhub feeds
 
 ## 🚀 Getting Started
@@ -171,6 +181,38 @@ Parameters:
 - `limit` *(int, optional)* — 1–100, defaults to 10.
 - `view` *(string, optional)* — response detail level. One of `summary` (default, ~500-token ceiling), `standard` (~2000-token ceiling), `full` (no ceiling).
 - `fields` *(string[], optional)* — sparse projection over the documented response fields. Unknown field names are rejected as a validation error.
+
+### Tool: `get-peers`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker, e.g. `AAPL`. 1–20 chars, starts with A–Z.
+- `grouping` *(string, optional)* — `industry` (default), `subindustry`, or `sector`.
+- `view` *(string, optional)* — `summary` (top 10), `standard` (top 25), `full` (all).
+
+### Tool: `get-financials-snapshot`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `view` *(string, optional)* — `summary`/`standard` (10 curated KPIs), `full` (KPIs + raw upstream metric dictionary).
+
+### Tool: `get-price-summary`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `period` *(string, optional)* — `7d`, `30d` (default), `90d`, or `1y`. The `1y` window uses weekly resolution; the others use daily.
+- `view` *(string, optional)* — `summary`/`standard` (aggregated stats), `full` (stats + raw OHLCV arrays).
+
+### Tool: `get-news-pulse`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `view` *(string, optional)* — `summary`/`standard` (top 5 headlines), `full` (all headlines from the past 7 days).
+
+Sentiment fields (`sentiment_score`, `bullish_percent`, `bearish_percent`, `sentiment_source`) are populated only when the upstream `/news-sentiment` endpoint is reachable; they fall back to `null` on premium-locked keys without failing the call.
 
 ### Tool response envelope
 

--- a/src/FinnHub.MCP.Server/Tools/Financials/GetFinancialsSnapshotTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Financials/GetFinancialsSnapshotTool.cs
@@ -68,6 +68,7 @@ public sealed class GetFinancialsSnapshotTool(
             return EnvelopeFactory.FromResult(
                 result,
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol));
         }
         catch (OperationCanceledException ex)
@@ -90,6 +91,22 @@ public sealed class GetFinancialsSnapshotTool(
             stopwatch.Stop();
             logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
         }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetFinancialsSnapshotResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-peers", args, "compare this symbol's valuation to industry peers"),
+            new NextAction("get-price-summary", args, "check recent price action against these fundamentals")
+        ];
     }
 
     private static string BuildExplanation(Result<GetFinancialsSnapshotResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/News/GetNewsPulseTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/News/GetNewsPulseTool.cs
@@ -70,6 +70,7 @@ public sealed class GetNewsPulseTool(
             return EnvelopeFactory.FromResult(
                 result,
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol),
                 sentimentSource: result.Data?.SentimentSource);
         }
@@ -93,6 +94,22 @@ public sealed class GetNewsPulseTool(
             stopwatch.Stop();
             logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
         }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetNewsPulseResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || result.Data.Count == 0)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-price-summary", args, "correlate sentiment with recent price action"),
+            new NextAction("get-financials-snapshot", args, "check fundamentals against the news flow")
+        ];
     }
 
     private static string BuildExplanation(Result<GetNewsPulseResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
@@ -73,6 +73,7 @@ public sealed class GetPeersTool(
             return EnvelopeFactory.FromResult(
                 ProjectByView(result, validatedView),
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol));
         }
         catch (OperationCanceledException ex)
@@ -123,6 +124,22 @@ public sealed class GetPeersTool(
         };
 
         return new Result<GetPeersResponse>().Success(projected);
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetPeersResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || result.Data.TotalCount == 0)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-financials-snapshot", args, "compare this symbol's valuation to the peer set"),
+            new NextAction("get-news-pulse", args, "sentiment and headlines for this symbol")
+        ];
     }
 
     private static string BuildExplanation(Result<GetPeersResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/Prices/GetPriceSummaryTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Prices/GetPriceSummaryTool.cs
@@ -73,6 +73,7 @@ public sealed class GetPriceSummaryTool(
             return EnvelopeFactory.FromResult(
                 result,
                 validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
                 explanation: BuildExplanation(result, validatedSymbol));
         }
         catch (OperationCanceledException ex)
@@ -95,6 +96,22 @@ public sealed class GetPriceSummaryTool(
             stopwatch.Stop();
             logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
         }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetPriceSummaryResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || result.Data.CandleCount == 0)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-news-pulse", args, "find news that may explain the price action"),
+            new NextAction("get-financials-snapshot", args, "check fundamentals against recent price moves")
+        ];
     }
 
     private static string BuildExplanation(Result<GetPriceSummaryResponse> result, string symbol)

--- a/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
@@ -144,10 +144,8 @@ public sealed class SearchSymbolTool(
 
     /// <summary>
     /// Builds server-suggested follow-up tool calls when the resolver has identified a
-    /// high-confidence canonical for the user's query (Confidence ≥ 0.95). The follow-up
-    /// tools (<c>get-company-profile</c>, <c>get-price-summary</c>, <c>get-news-pulse</c>)
-    /// are not yet registered; they land in a later phase. The envelope is forward-
-    /// compatible: clients are expected to ignore unknown tool names in <c>next_actions</c>.
+    /// high-confidence canonical (Confidence ≥ 0.95) for the user's query. Points at the
+    /// P6 Wave A research workflow: pulse, fundamentals, recent price action, peers.
     /// </summary>
     /// <remarks>
     /// The resolver's three fast-paths emit Confidence = 1.0, so structurally complete
@@ -178,9 +176,10 @@ public sealed class SearchSymbolTool(
 
         return
         [
-            new NextAction("get-company-profile", args, "fetch profile, sector, and market-cap context"),
-            new NextAction("get-price-summary", args, "summary stats for the latest range"),
-            new NextAction("get-news-pulse", args, "sentiment and top headlines")
+            new NextAction("get-news-pulse", args, "sentiment and top headlines from the past week"),
+            new NextAction("get-financials-snapshot", args, "10 curated valuation/profitability KPIs"),
+            new NextAction("get-price-summary", args, "min/max/mean/return/volatility over the last 30 days"),
+            new NextAction("get-peers", args, "industry peer list for comparison")
         ];
     }
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
@@ -73,10 +73,11 @@ public sealed class SearchSymbolToolTests
 
         var envelope = await tool.SearchSymbolAsync("AAPL");
 
-        Assert.Equal(3, envelope.NextActions.Count);
-        Assert.Equal("get-company-profile", envelope.NextActions[0].Tool);
-        Assert.Equal("get-price-summary", envelope.NextActions[1].Tool);
-        Assert.Equal("get-news-pulse", envelope.NextActions[2].Tool);
+        Assert.Equal(4, envelope.NextActions.Count);
+        Assert.Equal("get-news-pulse", envelope.NextActions[0].Tool);
+        Assert.Equal("get-financials-snapshot", envelope.NextActions[1].Tool);
+        Assert.Equal("get-price-summary", envelope.NextActions[2].Tool);
+        Assert.Equal("get-peers", envelope.NextActions[3].Tool);
         Assert.All(envelope.NextActions, a => Assert.Equal("AAPL", a.Args["symbol"]));
     }
 
@@ -89,7 +90,7 @@ public sealed class SearchSymbolToolTests
 
         var envelope = await tool.SearchSymbolAsync("microsoft");
 
-        Assert.Equal(3, envelope.NextActions.Count);
+        Assert.Equal(4, envelope.NextActions.Count);
         Assert.All(envelope.NextActions, a => Assert.Equal("MSFT", a.Args["symbol"]));
     }
 


### PR DESCRIPTION
## Summary
First promotion under the gated-release model introduced in #158. Bundles all of main's work since v1.18.0 onto the release branch so release-please can open its release PR.

## What's being promoted

| Commit | Type | Description |
|---|---|---|
| `5538cae` | merge | #159 — feat(p6a): cross-link next_actions across Wave A tools and document in README |
| `dedb7dd` | feat | Cross-linked `next_actions` across all 5 Wave A tools; README rewrite for Currently Available |
| `a95f026` | merge | #158 — ci: gate releases through release branch |
| `c630a10` | ci | Removed `dorny/test-reporter` (root of recurring PR CI flakes) |
| `618a923` | ci | Validate runs before release-please so failed tests don't create orphan releases |
| `ff516aa` | ci | Gated the release workflow through the release branch |

## Expected outcome
On merge, `release.yml` triggers on the `release` branch push:
1. `validate` runs `dotnet format --verify-no-changes` + `dotnet test --configuration Release`
2. If validate passes, release-please opens a release PR (expecting v1.19.0 from the `feat(p6a)` commit; the `ci:` commits don't bump per the release-please config)
3. Merging release-please's PR triggers the build matrix → artifact upload

## Risks / first-run gotchas
- This is the **first time** the new pipeline runs end-to-end. If the validate job has a config issue, it'll surface here.
- If validate fails, nothing ships — fix forward and re-promote.
- After release-please's PR is opened, that PR also targets `release` (not `main`) — different from the previous flow.