### PR TITLE
ci: target release branch from release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          # The repo's GitHub default branch is `main`, but releases are gated
+          # through `release`. Without this override, release-please opens its
+          # release PR against `main` — bypassing the validate gate.
+          target-branch: release
 
   build:
     name: 🔧 Build & Upload Artifacts


### PR DESCRIPTION
## Summary
Fixes a first-run gap in the gated-release pipeline introduced in #158. release-please was opening its release PR against \`main\` instead of \`release\`, bypassing the validate gate entirely.

## Why
\`googleapis/release-please-action@v4\` defaults to the repo's GitHub default branch (set to \`main\` here). The workflow itself runs on push to \`release\`, but without \`target-branch\` it tells release-please to operate on whatever the repo default is. Result: validate ran on \`release\` (correct), then release-please opened PR #161 against \`main\` (wrong).

PR #161 is now an orphan — should be closed without merging once this fix lands.

## What
One line in \`.github/workflows/release.yml\`:

\`\`\`yaml
- name: 🔖 Release Please
  uses: googleapis/release-please-action@v4
  with:
    token: \${{ secrets.GITHUB_TOKEN }}
    config-file: .release-please-config.json
    manifest-file: .release-please-manifest.json
    target-branch: release   # ← added
\`\`\`

## Post-merge steps
1. Close PR #161 without merging (orphan from the misconfigured first run)
2. Promote main → release again
3. release-please re-runs with the correct target, opens a new PR \`release-please--branches--release → release\`
4. Merge that → tag + build matrix triggers correctly

## Validation
- \`actionlint .github/workflows/release.yml\` — clean
- Logically: \`target-branch: release\` is the only sane value once releases are gated through the release branch