### PR TITLE
release: promote main to release (with release-please target fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,6 +66,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          # The repo's GitHub default branch is `main`, but releases are gated
+          # through `release`. Without this override, release-please opens its
+          # release PR against `main` — bypassing the validate gate.
+          target-branch: release
 
   build:
     name: 🔧 Build & Upload Artifacts


### PR DESCRIPTION
Second promotion under the gated pipeline. Includes the target-branch fix from #162.

When this merges:
1. `dotnet.yml` + `release.yml` validate run on release branch
2. release-please (now with `target-branch: release`) opens its release PR against `release` — not `main` as it did on the first attempt
3. Merging that release PR triggers the build matrix → v1.19.0 artifacts ship

Commits being promoted:
- `9db7de8` ci: target release branch from release-please (#162 merge)

(All earlier work from PR #160 is already on release.)