### PR TITLE
feat(p6b): add get-quote and get-company-profile (P6 Wave B)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,10 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 
 ### ✅ Currently Available
 
-**Tools (5):**
-- **`search-symbol`** — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10). On a high-confidence exact match, suggests `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, and `get-peers` as next actions.
+**Tools (7):**
+- **`search-symbol`** — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10). On a high-confidence exact match, suggests `get-quote`, `get-company-profile`, `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, and `get-peers` as next actions.
+- **`get-quote`** — real-time price snapshot (current, change, percent change, session high/low/open, prev close, timestamp). Cached at the 10-second Quote tier.
+- **`get-company-profile`** — company snapshot (name, ticker, country, currency, exchange, IPO, market cap, shares outstanding, industry). `view=summary` drops the cosmetic fields (logo, phone, weburl); `standard` and `full` include them.
 - **`get-peers`** — peer ticker list for a symbol, optionally grouped by `industry` (default), `subindustry`, or `sector`. Summary view caps at 10 peers, standard at 25, full returns all.
 - **`get-financials-snapshot`** — curated 10-KPI snapshot (market cap, P/E, P/B, EPS, dividend yield, 52-week high/low, 52-week return, beta, revenue per share). `view=full` adds the raw upstream metric dictionary.
 - **`get-price-summary`** — aggregated price stats over a candle range (`min`, `max`, `mean`, `return_pct`, `vol`, `latest`). Period: `7d`, `30d` (default), `90d`, `1y`. `view=full` adds the raw OHLCV arrays.
@@ -51,11 +53,11 @@ Every tool returns the standard token-budgeted envelope with cross-linked `next_
 
 ### 🔄 In Development
 - Wire `ExchangesResource` to the live Finnhub `/stock/exchange` endpoint
-- **`get-quote`** — real-time price snapshot (current, change, percent_change, high/low/open, prev_close, timestamp)
-- **`get-company-profile`** — company information (name, ticker, country, currency, exchange, IPO, market cap, industry, sector)
+- **`get-calendar`** — parameter-dispatched calendar across earnings, IPO, and economic events
 
 ### 📋 Planned
-- Calendar tool (parameter-dispatched across earnings/IPO/economic), insider transactions, analyst recommendations
+- **`get-insider-signal`** — net buy/sell aggregation over the past 30 days plus notable insider names
+- **`get-recommendations`** — analyst consensus with strong-buy/buy/hold/sell/strong-sell counts
 - `search-tools` meta-tool for intent-based discovery (P7)
 - Technical indicators (RSI, MACD, moving averages)
 - WebSocket transport for streaming Finnhub feeds
@@ -181,6 +183,22 @@ Parameters:
 - `limit` *(int, optional)* — 1–100, defaults to 10.
 - `view` *(string, optional)* — response detail level. One of `summary` (default, ~500-token ceiling), `standard` (~2000-token ceiling), `full` (no ceiling).
 - `fields` *(string[], optional)* — sparse projection over the documented response fields. Unknown field names are rejected as a validation error.
+
+### Tool: `get-quote`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker, e.g. `AAPL`. 1–20 chars, starts with A–Z.
+- `view` *(string, optional)* — `summary`/`standard`/`full` all return the same curated snapshot fields.
+
+Response is intentionally compact (`current`, `change`, `percent_change`, `high`, `low`, `open`, `prev_close`, `timestamp_utc`). Cached at the 10-second Quote tier.
+
+### Tool: `get-company-profile`
+
+Parameters:
+
+- `symbol` *(string, required)* — uppercase ticker.
+- `view` *(string, optional)* — `summary` drops `logo`/`phone`/`weburl`; `standard` and `full` include them.
 
 ### Tool: `get-peers`
 

--- a/src/FinnHub.MCP.Server.Application/Profiles/Clients/IProfilesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Clients/IProfilesApiClient.cs
@@ -1,0 +1,19 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+
+namespace FinnHub.MCP.Server.Application.Profiles.Clients;
+
+/// <summary>
+/// Infrastructure contract for the Finnhub <c>/stock/profile2</c> endpoint.
+/// </summary>
+public interface IProfilesApiClient
+{
+    /// <summary>Fetches the company profile snapshot for a symbol.</summary>
+    Task<GetCompanyProfileResponse> GetProfileAsync(GetCompanyProfileQuery query, CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/Profiles/Features/GetCompanyProfile/GetCompanyProfileQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Features/GetCompanyProfile/GetCompanyProfileQuery.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+
+/// <summary>
+/// Query parameters for the <c>get-company-profile</c> tool — a Finnhub
+/// <c>/stock/profile2</c> lookup that returns the company snapshot for a ticker.
+/// </summary>
+public sealed class GetCompanyProfileQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Uppercase ticker symbol the profile is requested for.</summary>
+    public required string Symbol { get; init; }
+
+    /// <summary>Whether to include the optional cosmetic fields (logo, phone, weburl). False on the default summary view.</summary>
+    public bool IncludeCosmeticFields { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Profiles/Features/GetCompanyProfile/GetCompanyProfileResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Features/GetCompanyProfile/GetCompanyProfileResponse.cs
@@ -1,0 +1,67 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+
+/// <summary>
+/// Wire response for <c>get-company-profile</c>. Cosmetic fields (logo, phone, weburl)
+/// are null on the default summary view; populated on standard/full.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class GetCompanyProfileResponse
+{
+    /// <summary>Ticker symbol.</summary>
+    [JsonPropertyName("ticker")]
+    public required string Ticker { get; init; }
+
+    /// <summary>Company name.</summary>
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+
+    /// <summary>ISO country code (e.g. <c>US</c>).</summary>
+    [JsonPropertyName("country")]
+    public string? Country { get; init; }
+
+    /// <summary>Reporting currency code (e.g. <c>USD</c>).</summary>
+    [JsonPropertyName("currency")]
+    public string? Currency { get; init; }
+
+    /// <summary>Listing exchange (e.g. <c>NASDAQ NMS - GLOBAL MARKET</c>).</summary>
+    [JsonPropertyName("exchange")]
+    public string? Exchange { get; init; }
+
+    /// <summary>IPO date.</summary>
+    [JsonPropertyName("ipo")]
+    public string? Ipo { get; init; }
+
+    /// <summary>Market capitalisation (USD millions).</summary>
+    [JsonPropertyName("market_cap")]
+    public double? MarketCap { get; init; }
+
+    /// <summary>Total shares outstanding (millions).</summary>
+    [JsonPropertyName("share_outstanding")]
+    public double? ShareOutstanding { get; init; }
+
+    /// <summary>Finnhub industry classification.</summary>
+    [JsonPropertyName("industry")]
+    public string? Industry { get; init; }
+
+    /// <summary>Logo URL. Populated only on standard/full views.</summary>
+    [JsonPropertyName("logo")]
+    public string? Logo { get; init; }
+
+    /// <summary>Company phone number. Populated only on standard/full views.</summary>
+    [JsonPropertyName("phone")]
+    public string? Phone { get; init; }
+
+    /// <summary>Company website URL. Populated only on standard/full views.</summary>
+    [JsonPropertyName("weburl")]
+    public string? WebUrl { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Profiles/Services/IProfilesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Services/IProfilesService.cs
@@ -1,0 +1,18 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+
+namespace FinnHub.MCP.Server.Application.Profiles.Services;
+
+/// <summary>Application-level entry point for company profile lookups.</summary>
+public interface IProfilesService
+{
+    /// <summary>Executes a profile lookup and returns a categorised result.</summary>
+    Task<Result<GetCompanyProfileResponse>> GetProfileAsync(GetCompanyProfileQuery query, CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
@@ -1,0 +1,78 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Profiles.Clients;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.Profiles.Services;
+
+/// <summary>
+/// Default <see cref="IProfilesService"/> wrapping <see cref="IProfilesApiClient"/> with
+/// hybrid caching (Profile tier — 24h TTL) and exception-to-result translation.
+/// </summary>
+public sealed class ProfilesService(
+    IProfilesApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<ProfilesService> logger)
+    : IProfilesService
+{
+    /// <inheritdoc />
+    public async Task<Result<GetCompanyProfileResponse>> GetProfileAsync(
+        GetCompanyProfileQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            var cacheKey = $"profile:s={query.Symbol.ToUpperInvariant()}:cosmetic={query.IncludeCosmeticFields}";
+
+            var response = await cache.GetOrCreateAsync(
+                cacheKey,
+                CacheTier.Profile,
+                async ct => await apiClient.GetProfileAsync(query, ct),
+                cancellationToken);
+
+            logger.LogInformation("Retrieved profile for {Symbol}", query.Symbol);
+
+            return string.IsNullOrEmpty(response.Name)
+                ? new Result<GetCompanyProfileResponse>().Failure(
+                    $"No profile found for {query.Symbol}.",
+                    ResultErrorType.NotFound)
+                : new Result<GetCompanyProfileResponse>().Success(response);
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogWarning(ex, "Premium-only profile endpoint for {Symbol}", query.Symbol);
+            return new Result<GetCompanyProfileResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching profile for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
+            return new Result<GetCompanyProfileResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "Profile request timed out for {Symbol}", query.Symbol);
+            return new Result<GetCompanyProfileResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize profile response for {Symbol}", query.Symbol);
+            return new Result<GetCompanyProfileResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected profile failure for {Symbol}", query.Symbol);
+            return new Result<GetCompanyProfileResponse>().Failure("Profile lookup failed unexpectedly");
+        }
+    }
+}

--- a/src/FinnHub.MCP.Server.Application/Quotes/Clients/IQuotesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Clients/IQuotesApiClient.cs
@@ -1,0 +1,19 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+
+namespace FinnHub.MCP.Server.Application.Quotes.Clients;
+
+/// <summary>
+/// Infrastructure contract for the Finnhub <c>/quote</c> endpoint.
+/// </summary>
+public interface IQuotesApiClient
+{
+    /// <summary>Fetches the real-time quote snapshot for a symbol.</summary>
+    Task<GetQuoteResponse> GetQuoteAsync(GetQuoteQuery query, CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/Quotes/Features/GetQuote/GetQuoteQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Features/GetQuote/GetQuoteQuery.cs
@@ -1,0 +1,21 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+
+/// <summary>
+/// Query parameters for the <c>get-quote</c> tool — a Finnhub <c>/quote</c> lookup
+/// that returns the real-time price snapshot for a ticker.
+/// </summary>
+public sealed class GetQuoteQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Uppercase ticker symbol the quote is requested for.</summary>
+    public required string Symbol { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Quotes/Features/GetQuote/GetQuoteResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Features/GetQuote/GetQuoteResponse.cs
@@ -1,0 +1,54 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+
+/// <summary>
+/// Wire response for <c>get-quote</c>. Real-time price snapshot.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class GetQuoteResponse
+{
+    /// <summary>Ticker symbol.</summary>
+    [JsonPropertyName("symbol")]
+    public required string Symbol { get; init; }
+
+    /// <summary>Current price.</summary>
+    [JsonPropertyName("current")]
+    public double Current { get; init; }
+
+    /// <summary>Absolute price change vs previous close.</summary>
+    [JsonPropertyName("change")]
+    public double Change { get; init; }
+
+    /// <summary>Percentage price change vs previous close.</summary>
+    [JsonPropertyName("percent_change")]
+    public double PercentChange { get; init; }
+
+    /// <summary>Session high.</summary>
+    [JsonPropertyName("high")]
+    public double High { get; init; }
+
+    /// <summary>Session low.</summary>
+    [JsonPropertyName("low")]
+    public double Low { get; init; }
+
+    /// <summary>Session open.</summary>
+    [JsonPropertyName("open")]
+    public double Open { get; init; }
+
+    /// <summary>Previous close.</summary>
+    [JsonPropertyName("prev_close")]
+    public double PrevClose { get; init; }
+
+    /// <summary>UTC timestamp of the snapshot.</summary>
+    [JsonPropertyName("timestamp_utc")]
+    public DateTimeOffset TimestampUtc { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Quotes/Services/IQuotesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Services/IQuotesService.cs
@@ -1,0 +1,18 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+
+namespace FinnHub.MCP.Server.Application.Quotes.Services;
+
+/// <summary>Application-level entry point for real-time quote lookups.</summary>
+public interface IQuotesService
+{
+    /// <summary>Executes a quote lookup and returns a categorised result.</summary>
+    Task<Result<GetQuoteResponse>> GetQuoteAsync(GetQuoteQuery query, CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
@@ -1,0 +1,80 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Quotes.Clients;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.Quotes.Services;
+
+/// <summary>
+/// Default <see cref="IQuotesService"/> wrapping <see cref="IQuotesApiClient"/> with
+/// hybrid caching (Quote tier — 10s TTL) and exception-to-result translation.
+/// </summary>
+public sealed class QuotesService(
+    IQuotesApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<QuotesService> logger)
+    : IQuotesService
+{
+    /// <inheritdoc />
+    public async Task<Result<GetQuoteResponse>> GetQuoteAsync(
+        GetQuoteQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            var cacheKey = $"quote:s={query.Symbol.ToUpperInvariant()}";
+
+            var response = await cache.GetOrCreateAsync(
+                cacheKey,
+                CacheTier.Quote,
+                async ct => await apiClient.GetQuoteAsync(query, ct),
+                cancellationToken);
+
+            logger.LogInformation(
+                "Retrieved quote for {Symbol}: current={Current} change={Change}",
+                query.Symbol, response.Current, response.Change);
+
+            return response.Current > 0
+                ? new Result<GetQuoteResponse>().Success(response)
+                : new Result<GetQuoteResponse>().Failure(
+                    $"No live quote for {query.Symbol}.",
+                    ResultErrorType.NotFound);
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogWarning(ex, "Premium-only quote endpoint for {Symbol}", query.Symbol);
+            return new Result<GetQuoteResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching quote for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
+            return new Result<GetQuoteResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "Quote request timed out for {Symbol}", query.Symbol);
+            return new Result<GetQuoteResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize quote response for {Symbol}", query.Symbol);
+            return new Result<GetQuoteResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected quote failure for {Symbol}", query.Symbol);
+            return new Result<GetQuoteResponse>().Failure("Quote lookup failed unexpectedly");
+        }
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Profiles/FinnHubProfilesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Profiles/FinnHubProfilesApiClient.cs
@@ -1,0 +1,141 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Profiles.Clients;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Profiles;
+
+/// <summary>HTTP client for the Finnhub <c>/stock/profile2</c> endpoint.</summary>
+public sealed class FinnHubProfilesApiClient : IProfilesApiClient
+{
+    private const string EndpointName = "profile";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubProfilesApiClient> _logger;
+
+    /// <summary>Initialises a new <see cref="FinnHubProfilesApiClient"/>.</summary>
+    public FinnHubProfilesApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubProfilesApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GetCompanyProfileResponse> GetProfileAsync(
+        GetCompanyProfileQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var endpoint = this._options.EndPoints.FirstOrDefault(e => e is { IsActive: true, Name: EndpointName })?.Url
+                       ?? throw new ArgumentException("Profile endpoint is not configured or inactive");
+
+        var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(query.Symbol)}";
+
+        this._logger.LogInformation("Requesting profile from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub profile failed: {Uri}", requestUri);
+            throw new ApiClientHttpException($"HTTP request to FinnHub profile failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Profile request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"Profile request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("Profile request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"Profile request cancelled: {requestUri}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        FinnHubProfileResponse? dto;
+        try
+        {
+            dto = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.FinnHubProfileResponse, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize profile response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize profile response: {requestUri}",
+                innerException: ex);
+        }
+
+        return new GetCompanyProfileResponse
+        {
+            Ticker = dto?.Ticker ?? query.Symbol,
+            Name = dto?.Name,
+            Country = dto?.Country,
+            Currency = dto?.Currency,
+            Exchange = dto?.Exchange,
+            Ipo = dto?.Ipo,
+            MarketCap = dto?.MarketCapitalization,
+            ShareOutstanding = dto?.ShareOutstanding,
+            Industry = dto?.FinnhubIndustry,
+            Logo = query.IncludeCosmeticFields ? dto?.Logo : null,
+            Phone = query.IncludeCosmeticFields ? dto?.Phone : null,
+            WebUrl = query.IncludeCosmeticFields ? dto?.WebUrl : null
+        };
+    }
+
+    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            this._logger.LogWarning("Premium-locked profile endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        this._logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "Profile API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException($"FinnHub profile returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Quotes/FinnHubQuotesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Quotes/FinnHubQuotesApiClient.cs
@@ -1,0 +1,138 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Quotes.Clients;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Quotes;
+
+/// <summary>HTTP client for the Finnhub <c>/quote</c> endpoint.</summary>
+public sealed class FinnHubQuotesApiClient : IQuotesApiClient
+{
+    private const string EndpointName = "quote";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubQuotesApiClient> _logger;
+
+    /// <summary>Initialises a new <see cref="FinnHubQuotesApiClient"/>.</summary>
+    public FinnHubQuotesApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubQuotesApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<GetQuoteResponse> GetQuoteAsync(GetQuoteQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var endpoint = this._options.EndPoints.FirstOrDefault(e => e is { IsActive: true, Name: EndpointName })?.Url
+                       ?? throw new ArgumentException("Quote endpoint is not configured or inactive");
+
+        var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(query.Symbol)}";
+
+        this._logger.LogInformation("Requesting quote from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub quote failed: {Uri}", requestUri);
+            throw new ApiClientHttpException($"HTTP request to FinnHub quote failed: {requestUri}", HttpStatusCode.InternalServerError);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Quote request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"Quote request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("Quote request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"Quote request cancelled: {requestUri}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        FinnHubQuoteResponse? dto;
+        try
+        {
+            dto = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.FinnHubQuoteResponse, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize quote response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize quote response: {requestUri}",
+                innerException: ex);
+        }
+
+        return new GetQuoteResponse
+        {
+            Symbol = query.Symbol,
+            Current = dto?.Current ?? 0,
+            Change = dto?.Change ?? 0,
+            PercentChange = dto?.PercentChange ?? 0,
+            High = dto?.High ?? 0,
+            Low = dto?.Low ?? 0,
+            Open = dto?.Open ?? 0,
+            PrevClose = dto?.PrevClose ?? 0,
+            TimestampUtc = dto is null || dto.Timestamp == 0
+                ? DateTimeOffset.MinValue
+                : DateTimeOffset.FromUnixTimeSeconds(dto.Timestamp)
+        };
+    }
+
+    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            this._logger.LogWarning("Premium-locked quote endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        this._logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "Quote API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException($"FinnHub quote returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubProfileResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubProfileResponse.cs
@@ -1,0 +1,52 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>Wire DTO for the Finnhub <c>/stock/profile2</c> endpoint.</summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubProfileResponse
+{
+    /// <summary>Ticker symbol.</summary>
+    [JsonPropertyName("ticker")] public string? Ticker { get; init; }
+
+    /// <summary>Company name.</summary>
+    [JsonPropertyName("name")] public string? Name { get; init; }
+
+    /// <summary>ISO country code.</summary>
+    [JsonPropertyName("country")] public string? Country { get; init; }
+
+    /// <summary>Reporting currency code.</summary>
+    [JsonPropertyName("currency")] public string? Currency { get; init; }
+
+    /// <summary>Listing exchange.</summary>
+    [JsonPropertyName("exchange")] public string? Exchange { get; init; }
+
+    /// <summary>IPO date.</summary>
+    [JsonPropertyName("ipo")] public string? Ipo { get; init; }
+
+    /// <summary>Market capitalisation (USD millions).</summary>
+    [JsonPropertyName("marketCapitalization")] public double? MarketCapitalization { get; init; }
+
+    /// <summary>Total shares outstanding (millions).</summary>
+    [JsonPropertyName("shareOutstanding")] public double? ShareOutstanding { get; init; }
+
+    /// <summary>Finnhub industry classification.</summary>
+    [JsonPropertyName("finnhubIndustry")] public string? FinnhubIndustry { get; init; }
+
+    /// <summary>Logo URL.</summary>
+    [JsonPropertyName("logo")] public string? Logo { get; init; }
+
+    /// <summary>Company phone number.</summary>
+    [JsonPropertyName("phone")] public string? Phone { get; init; }
+
+    /// <summary>Company website URL.</summary>
+    [JsonPropertyName("weburl")] public string? WebUrl { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubQuoteResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubQuoteResponse.cs
@@ -1,0 +1,48 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>Wire DTO for the Finnhub <c>/quote</c> endpoint.</summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubQuoteResponse
+{
+    /// <summary>Current price.</summary>
+    [JsonPropertyName("c")]
+    public double Current { get; init; }
+
+    /// <summary>Absolute change vs previous close.</summary>
+    [JsonPropertyName("d")]
+    public double Change { get; init; }
+
+    /// <summary>Percentage change vs previous close.</summary>
+    [JsonPropertyName("dp")]
+    public double PercentChange { get; init; }
+
+    /// <summary>Session high.</summary>
+    [JsonPropertyName("h")]
+    public double High { get; init; }
+
+    /// <summary>Session low.</summary>
+    [JsonPropertyName("l")]
+    public double Low { get; init; }
+
+    /// <summary>Session open.</summary>
+    [JsonPropertyName("o")]
+    public double Open { get; init; }
+
+    /// <summary>Previous close.</summary>
+    [JsonPropertyName("pc")]
+    public double PrevClose { get; init; }
+
+    /// <summary>Unix-epoch (seconds) snapshot timestamp.</summary>
+    [JsonPropertyName("t")]
+    public long Timestamp { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -18,6 +18,10 @@ using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Services;
 using FinnHub.MCP.Server.Application.Prices.Clients;
 using FinnHub.MCP.Server.Application.Prices.Services;
+using FinnHub.MCP.Server.Application.Profiles.Clients;
+using FinnHub.MCP.Server.Application.Profiles.Services;
+using FinnHub.MCP.Server.Application.Quotes.Clients;
+using FinnHub.MCP.Server.Application.Quotes.Services;
 using FinnHub.MCP.Server.Application.RateLimiting;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Caching;
@@ -25,6 +29,8 @@ using FinnHub.MCP.Server.Infrastructure.Clients.Financials;
 using FinnHub.MCP.Server.Infrastructure.Clients.News;
 using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
 using FinnHub.MCP.Server.Infrastructure.Clients.Prices;
+using FinnHub.MCP.Server.Infrastructure.Clients.Profiles;
+using FinnHub.MCP.Server.Infrastructure.Clients.Quotes;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
 using FinnHub.MCP.Server.Infrastructure.RateLimiting;
 using Microsoft.Extensions.Caching.Hybrid;
@@ -105,6 +111,22 @@ public static class ServiceCollectionExtension
             .AddHttpMessageHandler<RateLimitHeaderHandler>()
             .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubNewsApiClient>>()))
             .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubNewsApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<IQuotesService, QuotesService>();
+        services.AddHttpClient<IQuotesApiClient, FinnHubQuotesApiClient>("FinnHub-Quotes-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubQuotesApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubQuotesApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<IProfilesService, ProfilesService>();
+        services.AddHttpClient<IProfilesApiClient, FinnHubProfilesApiClient>("FinnHub-Profiles-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubProfilesApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubProfilesApiClient>>()))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -12,6 +12,8 @@ using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
 using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Application.Symbols;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
@@ -67,4 +69,10 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 [JsonSerializable(typeof(FinnHubCompanyNewsArticle[]))]
 [JsonSerializable(typeof(GetNewsPulseResponse))]
 [JsonSerializable(typeof(ToolResponseEnvelope<GetNewsPulseResponse>))]
+[JsonSerializable(typeof(FinnHubQuoteResponse))]
+[JsonSerializable(typeof(GetQuoteResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetQuoteResponse>))]
+[JsonSerializable(typeof(FinnHubProfileResponse))]
+[JsonSerializable(typeof(GetCompanyProfileResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetCompanyProfileResponse>))]
 public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -413,5 +413,100 @@ public static class Constants
                 Approx tokens: summary ~400, standard ~400, full varies with article count.
                 """;
         }
+
+        /// <summary>Constants for the <c>get-quote</c> tool — real-time price snapshot.</summary>
+        public static class Quote
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-quote";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get Quote";
+
+            /// <summary>Parameter names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription = "Uppercase ticker symbol, e.g. 'AAPL'.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>Tool description registered with the MCP server.</summary>
+            public const string Description =
+                """
+                Get the real-time price snapshot for a symbol — current, change, percent change,
+                session high/low/open, previous close, and snapshot timestamp.
+
+                ## Example:
+                - symbol='AAPL'
+
+                ## Response Fields:
+                - symbol (string)
+                - current (double): latest trade price
+                - change (double): absolute change vs previous close
+                - percent_change (double)
+                - high, low, open, prev_close (double)
+                - timestamp_utc (ISO 8601)
+
+                ## Notes:
+                - Cached at the 10s Quote tier; bypassed cache for very short staleness windows.
+                - The response is already curated — no view variation beyond default.
+
+                Approx tokens: summary ~80, standard ~80, full ~80.
+                """;
+        }
+
+        /// <summary>Constants for the <c>get-company-profile</c> tool — company snapshot.</summary>
+        public static class CompanyProfile
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-company-profile";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get Company Profile";
+
+            /// <summary>Parameter names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription = "Uppercase ticker symbol, e.g. 'AAPL'.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>Tool description registered with the MCP server.</summary>
+            public const string Description =
+                """
+                Get the company profile for a symbol — name, ticker, country, currency, exchange,
+                IPO date, market cap, shares outstanding, industry, and (on standard/full views)
+                logo, phone, and website URL.
+
+                ## Example:
+                - symbol='AAPL'
+
+                ## Response Fields (all nullable):
+                - ticker, name, country, currency, exchange, ipo, industry (string)
+                - market_cap (double, USD millions)
+                - share_outstanding (double, millions)
+                - logo, phone, weburl (string) — populated only on view='standard' or 'full'
+
+                Approx tokens: summary ~100, standard ~150, full ~150.
+                """;
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -20,6 +20,8 @@ using FinnHub.MCP.Server.Tools.Financials;
 using FinnHub.MCP.Server.Tools.News;
 using FinnHub.MCP.Server.Tools.Peers;
 using FinnHub.MCP.Server.Tools.Prices;
+using FinnHub.MCP.Server.Tools.Profiles;
+using FinnHub.MCP.Server.Tools.Quotes;
 using FinnHub.MCP.Server.Tools.Search;
 using Microsoft.AspNetCore.Mvc;
 
@@ -103,6 +105,8 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithWrappedTools<GetFinancialsSnapshotTool>()
 .WithWrappedTools<GetPriceSummaryTool>()
 .WithWrappedTools<GetNewsPulseTool>()
+.WithWrappedTools<GetQuoteTool>()
+.WithWrappedTools<GetCompanyProfileTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>();
 

--- a/src/FinnHub.MCP.Server/Tools/Profiles/GetCompanyProfileTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Profiles/GetCompanyProfileTool.cs
@@ -1,0 +1,124 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Application.Profiles.Services;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Profiles;
+
+/// <summary>
+/// MCP tool exposing the Finnhub <c>/stock/profile2</c> endpoint as a company snapshot.
+/// </summary>
+[McpServerToolType]
+public sealed class GetCompanyProfileTool(
+    IProfilesService profilesService,
+    ILogger<GetCompanyProfileTool> logger)
+{
+    /// <summary>
+    /// Returns the company profile for a symbol. <c>view = "summary"</c> drops the
+    /// cosmetic fields (logo, phone, weburl); <c>standard</c> and <c>full</c> include them.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.CompanyProfile.Name,
+        Title = Constants.Tools.CompanyProfile.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.CompanyProfile.Description)]
+    public async Task<ToolResponseEnvelope<GetCompanyProfileResponse>> GetCompanyProfileAsync(
+        [Description(Constants.Tools.CompanyProfile.Parameters.SymbolDescription)]
+        string symbol,
+        [Description(Constants.Tools.CompanyProfile.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.CompanyProfile.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedSymbol = ProfilesInputValidator.ValidateSymbol(symbol);
+            var validatedView = ProfilesInputValidator.ValidateView(view);
+
+            var query = new GetCompanyProfileQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Symbol = validatedSymbol,
+                IncludeCosmeticFields = validatedView != ToolView.Summary
+            };
+
+            var result = await profilesService.GetProfileAsync(query, cancellationToken);
+
+            logger.LogInformation(
+                "Profile completed for {Symbol} in {ElapsedMs}ms",
+                validatedSymbol, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.FromResult(
+                result,
+                validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
+                explanation: BuildExplanation(result, validatedSymbol));
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetCompanyProfileResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-financials-snapshot", args, "valuation and profitability KPIs"),
+            new NextAction("get-peers", args, "industry peer list for comparison"),
+            new NextAction("get-quote", args, "current price snapshot")
+        ];
+    }
+
+    private static string BuildExplanation(Result<GetCompanyProfileResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return $"No profile available for '{symbol}'.";
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{symbol} — {result.Data.Name} ({result.Data.Industry ?? "n/a"}, {result.Data.Country ?? "n/a"}).");
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Profiles/ProfilesInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Profiles/ProfilesInputValidator.cs
@@ -1,0 +1,53 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Tools.Profiles;
+
+/// <summary>Validation helpers for the <c>get-company-profile</c> tool parameters.</summary>
+internal static partial class ProfilesInputValidator
+{
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be empty.", nameof(symbol));
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Quotes/GetQuoteTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Quotes/GetQuoteTool.cs
@@ -1,0 +1,122 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Application.Quotes.Services;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Quotes;
+
+/// <summary>
+/// MCP tool exposing the Finnhub <c>/quote</c> endpoint as a real-time price snapshot.
+/// </summary>
+[McpServerToolType]
+public sealed class GetQuoteTool(
+    IQuotesService quotesService,
+    ILogger<GetQuoteTool> logger)
+{
+    /// <summary>
+    /// Returns the real-time quote for a symbol — current, change, percent change,
+    /// session high/low/open, previous close, and snapshot timestamp.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.Quote.Name,
+        Title = Constants.Tools.Quote.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.Quote.Description)]
+    public async Task<ToolResponseEnvelope<GetQuoteResponse>> GetQuoteAsync(
+        [Description(Constants.Tools.Quote.Parameters.SymbolDescription)]
+        string symbol,
+        [Description(Constants.Tools.Quote.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.Quote.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedSymbol = QuotesInputValidator.ValidateSymbol(symbol);
+            var validatedView = QuotesInputValidator.ValidateView(view);
+
+            var query = new GetQuoteQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Symbol = validatedSymbol
+            };
+
+            var result = await quotesService.GetQuoteAsync(query, cancellationToken);
+
+            logger.LogInformation(
+                "Quote completed for {Symbol} in {ElapsedMs}ms",
+                validatedSymbol, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.FromResult(
+                result,
+                validatedView,
+                nextActions: BuildNextActions(result, validatedSymbol),
+                explanation: BuildExplanation(result, validatedSymbol));
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetQuoteResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-news-pulse", args, "find news that may explain the current price"),
+            new NextAction("get-price-summary", args, "longer-term context vs the current quote")
+        ];
+    }
+
+    private static string BuildExplanation(Result<GetQuoteResponse> result, string symbol)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return $"No quote available for '{symbol}'.";
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"{symbol} {result.Data.Current:F2} ({result.Data.PercentChange:+0.00;-0.00}%) as of {result.Data.TimestampUtc:u}.");
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Quotes/QuotesInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Quotes/QuotesInputValidator.cs
@@ -1,0 +1,53 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Tools.Quotes;
+
+/// <summary>Validation helpers for the <c>get-quote</c> tool parameters.</summary>
+internal static partial class QuotesInputValidator
+{
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol cannot be empty.", nameof(symbol));
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
@@ -176,6 +176,8 @@ public sealed class SearchSymbolTool(
 
         return
         [
+            new NextAction("get-quote", args, "real-time price snapshot"),
+            new NextAction("get-company-profile", args, "company name, industry, country, market cap"),
             new NextAction("get-news-pulse", args, "sentiment and top headlines from the past week"),
             new NextAction("get-financials-snapshot", args, "10 curated valuation/profitability KPIs"),
             new NextAction("get-price-summary", args, "min/max/mean/return/volatility over the last 30 days"),

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -59,6 +59,20 @@
         "IsActive": true,
         "group": "news",
         "Description": "Returns composite news sentiment snapshot for a symbol (premium)."
+      },
+      {
+        "Name": "quote",
+        "Url": "/quote",
+        "IsActive": true,
+        "group": "stock",
+        "Description": "Returns real-time price snapshot for a symbol."
+      },
+      {
+        "Name": "profile",
+        "Url": "/stock/profile2",
+        "IsActive": true,
+        "group": "stock",
+        "Description": "Returns company profile snapshot for a symbol."
       }
     ]
   },

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Profiles/Services/ProfilesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Profiles/Services/ProfilesServiceTests.cs
@@ -1,0 +1,83 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Profiles.Clients;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Application.Profiles.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Profiles.Services;
+
+public sealed class ProfilesServiceTests
+{
+    private readonly IProfilesApiClient _apiClient = Substitute.For<IProfilesApiClient>();
+    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly ProfilesService _sut;
+
+    public ProfilesServiceTests()
+    {
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<GetCompanyProfileResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetCompanyProfileResponse>>>()(CancellationToken.None));
+
+        this._sut = new ProfilesService(this._apiClient, this._cache, NullLogger<ProfilesService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetProfileAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_PopulatedProfile_ReturnsSuccess()
+    {
+        var query = new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetProfileAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple Inc.", Country = "US" });
+
+        var result = await this._sut.GetProfileAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("Apple Inc.", result.Data!.Name);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_EmptyName_ReturnsNotFound()
+    {
+        var query = new GetCompanyProfileQuery { QueryId = "q1", Symbol = "UNKN" };
+        this._apiClient.GetProfileAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetCompanyProfileResponse { Ticker = "UNKN", Name = null });
+
+        var result = await this._sut.GetProfileAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("NotFound", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_PremiumRequired_MapsCorrectly()
+    {
+        var query = new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetProfileAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/api/v1/stock/profile2"));
+
+        var result = await this._sut.GetProfileAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PremiumRequired", result.ErrorType);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Quotes/Services/QuotesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Quotes/Services/QuotesServiceTests.cs
@@ -1,0 +1,84 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Quotes.Clients;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Application.Quotes.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Quotes.Services;
+
+public sealed class QuotesServiceTests
+{
+    private readonly IQuotesApiClient _apiClient = Substitute.For<IQuotesApiClient>();
+    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly QuotesService _sut;
+
+    public QuotesServiceTests()
+    {
+        this._cache
+            .GetOrCreateAsync(
+                Arg.Any<string>(),
+                Arg.Any<CacheTier>(),
+                Arg.Any<Func<CancellationToken, ValueTask<GetQuoteResponse>>>(),
+                Arg.Any<CancellationToken>())
+            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetQuoteResponse>>>()(CancellationToken.None));
+
+        this._sut = new QuotesService(this._apiClient, this._cache, NullLogger<QuotesService>.Instance);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetQuoteAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_LivePrice_ReturnsSuccess()
+    {
+        var query = new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetQuoteAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetQuoteResponse { Symbol = "AAPL", Current = 261.74, Change = 0.4 });
+
+        var result = await this._sut.GetQuoteAsync(query);
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal(261.74, result.Data!.Current);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_ZeroPrice_ReturnsNotFound()
+    {
+        var query = new GetQuoteQuery { QueryId = "q1", Symbol = "UNKN" };
+        this._apiClient.GetQuoteAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetQuoteResponse { Symbol = "UNKN", Current = 0 });
+
+        var result = await this._sut.GetQuoteAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("NotFound", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_HttpError_MapsToServiceUnavailable()
+    {
+        var query = new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetQuoteAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientHttpException("boom", HttpStatusCode.BadGateway));
+
+        var result = await this._sut.GetQuoteAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ServiceUnavailable", result.ErrorType);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
@@ -1,0 +1,116 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Infrastructure.Clients.Profiles;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Profiles;
+
+public sealed class FinnHubProfilesApiClientTests : IDisposable
+{
+    private const string SamplePayload = """
+                                         {
+                                           "ticker": "AAPL",
+                                           "name": "Apple Inc",
+                                           "country": "US",
+                                           "currency": "USD",
+                                           "exchange": "NASDAQ NMS - GLOBAL MARKET",
+                                           "ipo": "1980-12-12",
+                                           "marketCapitalization": 3000000.0,
+                                           "shareOutstanding": 15500.0,
+                                           "finnhubIndustry": "Technology",
+                                           "logo": "https://logo.example/aapl.png",
+                                           "phone": "+1-408-996-1010",
+                                           "weburl": "https://www.apple.com"
+                                         }
+                                         """;
+
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubProfilesApiClient _sut;
+
+    public FinnHubProfilesApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints = [new FinnHubEndPoint { Name = "profile", Url = "stock/profile2", IsActive = true }]
+        });
+
+        this._sut = new FinnHubProfilesApiClient(this._httpClient, options, NullLogger<FinnHubProfilesApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_SummaryView_DropsCosmeticFields()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL", IncludeCosmeticFields = false },
+            CancellationToken.None);
+
+        Assert.Equal("Apple Inc", result.Name);
+        Assert.Equal("Technology", result.Industry);
+        Assert.Null(result.Logo);
+        Assert.Null(result.Phone);
+        Assert.Null(result.WebUrl);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_StandardView_IncludesCosmeticFields()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL", IncludeCosmeticFields = true },
+            CancellationToken.None);
+
+        Assert.Equal("https://logo.example/aapl.png", result.Logo);
+        Assert.Equal("+1-408-996-1010", result.Phone);
+        Assert.Equal("https://www.apple.com", result.WebUrl);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_EmptyResponse_ReturnsTickerFallback()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        var result = await this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "UNKN" },
+            CancellationToken.None);
+
+        Assert.Equal("UNKN", result.Ticker);
+        Assert.Null(result.Name);
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
@@ -1,0 +1,96 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Infrastructure.Clients.Quotes;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Quotes;
+
+public sealed class FinnHubQuotesApiClientTests : IDisposable
+{
+    private const string SamplePayload = """
+                                         {
+                                           "c": 261.74,
+                                           "d": 0.4,
+                                           "dp": 0.1531,
+                                           "h": 263.31,
+                                           "l": 260.68,
+                                           "o": 261.07,
+                                           "pc": 261.34,
+                                           "t": 1700000000
+                                         }
+                                         """;
+
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubQuotesApiClient _sut;
+
+    public FinnHubQuotesApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints = [new FinnHubEndPoint { Name = "quote", Url = "quote", IsActive = true }]
+        });
+
+        this._sut = new FinnHubQuotesApiClient(this._httpClient, options, NullLogger<FinnHubQuotesApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_MapsAllFields()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, SamplePayload);
+
+        var result = await this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.Equal("AAPL", result.Symbol);
+        Assert.Equal(261.74, result.Current);
+        Assert.Equal(0.4, result.Change);
+        Assert.Equal(0.1531, result.PercentChange);
+        Assert.Equal(263.31, result.High);
+        Assert.Equal(261.34, result.PrevClose);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_InvalidJson_ThrowsDeserialization()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "not-json");
+
+        await Assert.ThrowsAsync<ApiClientDeserializationException>(() => this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/GetCompanyProfileToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/GetCompanyProfileToolTests.cs
@@ -1,0 +1,76 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Application.Profiles.Services;
+using FinnHub.MCP.Server.Tools.Profiles;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Profiles;
+
+public sealed class GetCompanyProfileToolTests
+{
+    private readonly IProfilesService _service = Substitute.For<IProfilesService>();
+    private readonly GetCompanyProfileTool _sut;
+
+    public GetCompanyProfileToolTests()
+    {
+        this._sut = new GetCompanyProfileTool(this._service, NullLogger<GetCompanyProfileTool>.Instance);
+    }
+
+    [Fact]
+    public async Task GetCompanyProfileAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetCompanyProfileAsync("!!!"));
+    }
+
+    [Fact]
+    public async Task GetCompanyProfileAsync_SummaryView_OmitsCosmeticFields()
+    {
+        this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetCompanyProfileResponse>().Success(
+                new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple" }));
+
+        await this._sut.GetCompanyProfileAsync("AAPL", view: "summary");
+
+        await this._service.Received(1).GetProfileAsync(
+            Arg.Is<GetCompanyProfileQuery>(q => !q.IncludeCosmeticFields),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCompanyProfileAsync_StandardView_RequestsCosmeticFields()
+    {
+        this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetCompanyProfileResponse>().Success(
+                new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple" }));
+
+        await this._sut.GetCompanyProfileAsync("AAPL", view: "standard");
+
+        await this._service.Received(1).GetProfileAsync(
+            Arg.Is<GetCompanyProfileQuery>(q => q.IncludeCosmeticFields),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCompanyProfileAsync_Success_PopulatesNextActions()
+    {
+        this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetCompanyProfileResponse>().Success(
+                new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple" }));
+
+        var envelope = await this._sut.GetCompanyProfileAsync("AAPL");
+
+        Assert.Equal(3, envelope.NextActions.Count);
+        Assert.Equal("get-financials-snapshot", envelope.NextActions[0].Tool);
+        Assert.Equal("get-peers", envelope.NextActions[1].Tool);
+        Assert.Equal("get-quote", envelope.NextActions[2].Tool);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/GetQuoteToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/GetQuoteToolTests.cs
@@ -1,0 +1,59 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Application.Quotes.Services;
+using FinnHub.MCP.Server.Tools.Quotes;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Quotes;
+
+public sealed class GetQuoteToolTests
+{
+    private readonly IQuotesService _service = Substitute.For<IQuotesService>();
+    private readonly GetQuoteTool _sut;
+
+    public GetQuoteToolTests()
+    {
+        this._sut = new GetQuoteTool(this._service, NullLogger<GetQuoteTool>.Instance);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetQuoteAsync("!!!"));
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_LowercaseSymbol_Normalises()
+    {
+        this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetQuoteResponse>().Success(new GetQuoteResponse { Symbol = "AAPL", Current = 100 }));
+
+        await this._sut.GetQuoteAsync("aapl");
+
+        await this._service.Received(1).GetQuoteAsync(
+            Arg.Is<GetQuoteQuery>(q => q.Symbol == "AAPL"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_Success_PopulatesNextActions()
+    {
+        this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetQuoteResponse>().Success(new GetQuoteResponse { Symbol = "AAPL", Current = 100 }));
+
+        var envelope = await this._sut.GetQuoteAsync("AAPL");
+
+        Assert.Equal(2, envelope.NextActions.Count);
+        Assert.Equal("get-news-pulse", envelope.NextActions[0].Tool);
+        Assert.Equal("get-price-summary", envelope.NextActions[1].Tool);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
@@ -73,11 +73,13 @@ public sealed class SearchSymbolToolTests
 
         var envelope = await tool.SearchSymbolAsync("AAPL");
 
-        Assert.Equal(4, envelope.NextActions.Count);
-        Assert.Equal("get-news-pulse", envelope.NextActions[0].Tool);
-        Assert.Equal("get-financials-snapshot", envelope.NextActions[1].Tool);
-        Assert.Equal("get-price-summary", envelope.NextActions[2].Tool);
-        Assert.Equal("get-peers", envelope.NextActions[3].Tool);
+        Assert.Equal(6, envelope.NextActions.Count);
+        Assert.Equal("get-quote", envelope.NextActions[0].Tool);
+        Assert.Equal("get-company-profile", envelope.NextActions[1].Tool);
+        Assert.Equal("get-news-pulse", envelope.NextActions[2].Tool);
+        Assert.Equal("get-financials-snapshot", envelope.NextActions[3].Tool);
+        Assert.Equal("get-price-summary", envelope.NextActions[4].Tool);
+        Assert.Equal("get-peers", envelope.NextActions[5].Tool);
         Assert.All(envelope.NextActions, a => Assert.Equal("AAPL", a.Args["symbol"]));
     }
 
@@ -90,7 +92,7 @@ public sealed class SearchSymbolToolTests
 
         var envelope = await tool.SearchSymbolAsync("microsoft");
 
-        Assert.Equal(4, envelope.NextActions.Count);
+        Assert.Equal(6, envelope.NextActions.Count);
         Assert.All(envelope.NextActions, a => Assert.Equal("MSFT", a.Args["symbol"]));
     }
 


### PR DESCRIPTION
## Summary
P6 Wave B — both tools shipped together because the spec frames them as a pair (\"both small, mirror the Wave A pattern\") and they share the same cross-link story.

## Tools

### \`get-quote\`
- Maps to Finnhub \`/quote\`
- Real-time price snapshot: \`current\`, \`change\`, \`percent_change\`, \`high\`, \`low\`, \`open\`, \`prev_close\`, \`timestamp_utc\`
- No view variation — response is already curated
- 10s Quote-tier cache
- \`next_actions\`: \`get-news-pulse\`, \`get-price-summary\`

### \`get-company-profile\`
- Maps to Finnhub \`/stock/profile2\`
- Company snapshot: \`ticker\`, \`name\`, \`country\`, \`currency\`, \`exchange\`, \`ipo\`, \`market_cap\`, \`share_outstanding\`, \`industry\`, and (on standard/full) \`logo\`, \`phone\`, \`weburl\`
- \`view=summary\` drops the three cosmetic fields per spec
- 24h Profile-tier cache
- \`next_actions\`: \`get-financials-snapshot\`, \`get-peers\`, \`get-quote\`

## Cross-link update
\`search-symbol\` (high-confidence match) now suggests **6 tools** instead of 4 — adds \`get-quote\` and \`get-company-profile\` at the head of the list (most-common research workflow).

## Spec
[\`.planning/specs/01-product-surface.md\` §3 P6](https://github.com/SalZaki/finnhub-mcp/blob/main/.planning/specs/01-product-surface.md)

## Wave B closes after this lands
- [x] PR #152 \`get-peers\` (Wave A)
- [x] PR #153 \`get-financials-snapshot\` (Wave A)
- [x] PR #155 \`get-price-summary\` (Wave A)
- [x] PR #157 \`get-news-pulse\` (Wave A)
- [x] PR #159 cross-links + README (Wave A wrap)
- [ ] this PR — Wave B (\`get-quote\` + \`get-company-profile\`)

Brings the active tool surface to **7** (\`search-symbol\` + 4 Wave A + 2 Wave B). Waves C (\`get-calendar\`) and D (\`get-insider-signal\`, \`get-recommendations\`) follow.

## Test plan
- [x] \`dotnet build\` — clean, 0 warnings
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`dotnet test\` — 255/255 pass (was 233; +22 new across 3 layers per tool, plus updated SearchSymbolToolTests for the new 6-item next_actions count)