### PR TITLE
fix(p6a): tolerate mixed types in /stock/metric response

### DIFF
--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
@@ -108,10 +108,15 @@ public sealed class FinnHubFinancialsApiClient : IFinancialsApiClient
         return Project(query, dto?.Metric);
     }
 
-    private static GetFinancialsSnapshotResponse Project(GetFinancialsSnapshotQuery query, Dictionary<string, double?>? metric)
+    private static GetFinancialsSnapshotResponse Project(GetFinancialsSnapshotQuery query, Dictionary<string, JsonElement>? metric)
     {
         double? Get(string key) =>
-            metric is not null && metric.TryGetValue(key, out var value) ? value : null;
+            metric is not null
+            && metric.TryGetValue(key, out var value)
+            && value.ValueKind == JsonValueKind.Number
+            && value.TryGetDouble(out var d)
+                ? d
+                : null;
 
         return new GetFinancialsSnapshotResponse
         {
@@ -127,9 +132,27 @@ public sealed class FinnHubFinancialsApiClient : IFinancialsApiClient
             Beta = Get("beta"),
             RevenuePerShareTtm = Get("revenuePerShareTTM"),
             Raw = query.IncludeRaw && metric is not null
-                ? new Dictionary<string, double?>(metric)
+                ? BuildRaw(metric)
                 : null
         };
+    }
+
+    /// <summary>
+    /// Builds the numeric-only subset of the raw upstream metric dictionary.
+    /// Non-numeric values (date strings, etc.) are skipped so the wire shape
+    /// stays <c>Dictionary&lt;string, double?&gt;</c>.
+    /// </summary>
+    private static Dictionary<string, double?> BuildRaw(Dictionary<string, JsonElement> metric)
+    {
+        var raw = new Dictionary<string, double?>(metric.Count, StringComparer.Ordinal);
+        foreach (var (key, value) in metric)
+        {
+            if (value.ValueKind == JsonValueKind.Number && value.TryGetDouble(out var d))
+            {
+                raw[key] = d;
+            }
+        }
+        return raw;
     }
 
     private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubFinancialsResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubFinancialsResponse.cs
@@ -6,6 +6,7 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace FinnHub.MCP.Server.Infrastructure.Dtos;
@@ -13,8 +14,9 @@ namespace FinnHub.MCP.Server.Infrastructure.Dtos;
 /// <summary>
 /// Wire DTO for the Finnhub <c>/stock/metric</c> endpoint. The upstream payload
 /// nests a flat metric dictionary under a <c>metric</c> property; the dictionary
-/// has dozens of keys, all numeric or string-formatted dates. We project only
-/// the numeric subset and let the client map specific keys to typed KPIs.
+/// contains a mix of numeric KPIs and string-formatted dates
+/// (e.g. <c>52WeekHighDate: "2024-12-26"</c>), so values are held as
+/// <see cref="JsonElement"/> and coerced to <c>double?</c> by the client.
 /// </summary>
 [ExcludeFromCodeCoverage]
 public sealed class FinnHubFinancialsResponse
@@ -27,7 +29,7 @@ public sealed class FinnHubFinancialsResponse
     [JsonPropertyName("metricType")]
     public string? MetricType { get; init; }
 
-    /// <summary>Flat dictionary of metric names to numeric values.</summary>
+    /// <summary>Flat dictionary of metric names to raw JSON values (numbers, strings, or null).</summary>
     [JsonPropertyName("metric")]
-    public Dictionary<string, double?>? Metric { get; init; }
+    public Dictionary<string, JsonElement>? Metric { get; init; }
 }

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
@@ -105,6 +105,46 @@ public sealed class FinnHubFinancialsApiClientTests : IDisposable
     }
 
     [Fact]
+    public async Task GetSnapshotAsync_MixedNumericAndStringValues_ParsesNumericKpisAndSkipsStrings()
+    {
+        // Real Finnhub /stock/metric?metric=all responses interleave numeric KPIs with
+        // string-formatted dates like 52WeekHighDate. Confirm we don't throw on the
+        // string values and that the raw dictionary only carries the numeric subset.
+        const string MixedPayload = """
+                                    {
+                                      "symbol": "NVDA",
+                                      "metricType": "all",
+                                      "metric": {
+                                        "marketCapitalization": 3000000.0,
+                                        "peTTM": 50.4,
+                                        "52WeekHigh": 199.6,
+                                        "52WeekHighDate": "2024-12-26",
+                                        "52WeekLow": 164.1,
+                                        "52WeekLowDate": "2024-04-19",
+                                        "beta": 1.8
+                                      }
+                                    }
+                                    """;
+        this._handler.SetResponse(HttpStatusCode.OK, MixedPayload);
+
+        var result = await this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "NVDA", IncludeRaw = true },
+            CancellationToken.None);
+
+        Assert.Equal(3000000.0, result.MarketCap);
+        Assert.Equal(50.4, result.PeTtm);
+        Assert.Equal(199.6, result.Week52High);
+        Assert.Equal(1.8, result.Beta);
+
+        // raw carries only the numeric keys; the string-typed date fields are filtered out.
+        Assert.NotNull(result.Raw);
+        Assert.True(result.Raw!.ContainsKey("marketCapitalization"));
+        Assert.True(result.Raw.ContainsKey("52WeekHigh"));
+        Assert.False(result.Raw.ContainsKey("52WeekHighDate"));
+        Assert.False(result.Raw.ContainsKey("52WeekLowDate"));
+    }
+
+    [Fact]
     public async Task GetSnapshotAsync_Forbidden_ThrowsPremiumRequired()
     {
         this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");


### PR DESCRIPTION
## Symptom
Calling \`get-financials-snapshot\` with a real Finnhub key against any common ticker (e.g. NVDA, AAPL) returns:

\`\`\`
InvalidResponse — "Invalid response from service"
\`\`\`

…on every view. Reproduced live in Claude Code; v1.18.0 has the bug too.

## Root cause
Finnhub's \`/stock/metric?metric=all\` response interleaves numeric KPIs with string-formatted date fields:

\`\`\`json
{
  "metric": {
    "marketCapitalization": 3000000.0,
    "peTTM": 50.4,
    "52WeekHigh": 199.6,
    "52WeekHighDate": "2024-12-26",   <-- string
    "52WeekLow": 164.1,
    "52WeekLowDate": "2024-04-19",    <-- string
    ...
  }
}
\`\`\`

Our DTO is typed as \`Dictionary<string, double?>\`. \`System.Text.Json\` throws on the first string value, the client wraps it as \`ApiClientDeserializationException\`, and the service maps it to \`InvalidResponse\`.

The unit tests used a synthetic all-numeric payload — that's why CI was green but live failed.

## Fix
- DTO now holds \`Dictionary<string, JsonElement>\` so deserialization tolerates any value type
- Curated KPI extraction uses \`JsonElement.TryGetDouble\` — non-numeric values resolve to \`null\`
- \`view=full\`'s \`raw\` dictionary keeps the existing \`Dictionary<string, double?>\` shape by filtering the upstream dict to its numeric subset

## Regression coverage
New test \`GetSnapshotAsync_MixedNumericAndStringValues_ParsesNumericKpisAndSkipsStrings\` uses a payload that mirrors the real Finnhub shape (numeric KPIs + date strings) and asserts both that the curated fields parse and that \`raw\` excludes the date keys.

## Test plan
- [x] \`dotnet build\` — clean
- [x] \`dotnet format --verify-no-changes\` — clean
- [x] \`dotnet test\` — 256/256 pass (was 255; +1 regression)
- [ ] Live re-test of \`get-financials-snapshot\` after merge

## Ship
Tag this for tonight's release batch.