### PR TITLE
ci: enforce conventional commits via Husky.Net + PR title validator

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "husky": {
+      "version": "0.9.1",
+      "commands": [
+        "husky"
+      ],
+      "rollForward": false
+    }
+  }
+}

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,51 @@
+name: PR Title
+
+# Server-side conventional-commit enforcement on the PR title.
+#
+# The .husky/commit-msg hook catches non-conforming messages locally, but it
+# can be bypassed with --no-verify or skipped on clones that haven't run
+# `dotnet tool restore`. This job is the safety net — PR titles are what
+# release-please reads when commits are squashed, so they must conform.
+#
+# Allowed types mirror .husky/commit-msg and .release-please-config.json.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+    branches: [main, develop, release]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate-title:
+    name: ✅ Conventional Commit Title
+    runs-on: ubuntu-latest
+    steps:
+      - name: 🔖 Lint PR title
+        uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            build
+            ci
+            chore
+            docs
+            test
+          requireScope: false
+          subjectPattern: ^.{1,72}$
+          subjectPatternError: |
+            The subject "{subject}" found in the PR title "{title}"
+            must be 1–72 characters. Conventional Commits expects:
+              <type>(<optional scope>)<optional !>: <subject>
+            Examples:
+              feat(p6c): add get-calendar tool
+              fix(p6a): handle null in /quote response
+              ci: gate releases through release branch

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------------------------------------------------
+# Conventional-commit validator.
+# Rejects commits whose first line does not match the Conventional Commits spec
+# the release-please config in .release-please-config.json depends on.
+#
+# Allowed types are taken directly from release-please's changelog-sections.
+# Scope is optional; ! marks a breaking change; subject is 1–72 chars after the colon+space.
+# ---------------------------------------------------------------------------------------------------------------------
+
+. "$(dirname "$0")/_/husky.sh"
+
+# $1 is the path to the file holding the commit message (set by git).
+MSG_FILE="$1"
+FIRST_LINE="$(head -n1 "$MSG_FILE")"
+
+# Allow auto-generated messages git uses verbatim — no need to rewrite these.
+case "$FIRST_LINE" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*|"amend! "*)
+    exit 0
+    ;;
+esac
+
+PATTERN='^(feat|fix|perf|refactor|revert|style|build|ci|chore|docs|test)(\([a-z0-9._-]+\))?!?: .{1,72}$'
+
+if ! [[ "$FIRST_LINE" =~ $PATTERN ]]; then
+  echo
+  echo "❌ Commit message does not follow Conventional Commits."
+  echo
+  echo "   Got:       $FIRST_LINE"
+  echo "   Expected:  <type>(<optional scope>)<optional !>: <subject>"
+  echo
+  echo "   Allowed types: feat, fix, perf, refactor, revert, style,"
+  echo "                  build, ci, chore, docs, test"
+  echo
+  echo "   Examples:"
+  echo "     feat(p6c): add get-calendar tool"
+  echo "     fix(p6a): handle null in /quote response"
+  echo "     ci: gate releases through release branch"
+  echo "     feat!: drop support for net8"
+  echo
+  echo "   Reason: release-please reads these prefixes to compute version"
+  echo "   bumps and CHANGELOG entries. A non-conforming message breaks"
+  echo "   the release pipeline silently."
+  echo
+  exit 1
+fi

--- a/.husky/task-runner.json
+++ b/.husky/task-runner.json
@@ -1,0 +1,14 @@
+{
+   "$schema": "https://alirezanet.github.io/Husky.Net/schema.json",
+   "tasks": [
+      {
+         "name": "welcome-message-example",
+         "command": "bash",
+         "args": [ "-c", "echo Husky.Net is awesome!" ],
+         "windows": {
+            "command": "cmd",
+            "args": ["/c", "echo Husky.Net is awesome!" ]
+         }
+      }
+   ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing to finnhub-mcp
+
+## Setup after cloning
+
+```bash
+git clone https://github.com/SalZaki/finnhub-mcp.git
+cd finnhub-mcp
+
+# Restore .NET tools (currently: Husky.Net for git hooks)
+dotnet tool restore
+
+# Install local git hooks (commit-msg validator + future hooks)
+dotnet husky install
+
+# Optional: pull dependencies
+dotnet restore
+```
+
+The `dotnet tool restore` + `dotnet husky install` steps install a `commit-msg`
+git hook that validates every commit message against the Conventional Commits
+spec — required because `release-please` reads these prefixes to compute
+version bumps and CHANGELOG entries.
+
+## Commit message format
+
+Every commit must follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+<type>(<optional scope>)<optional !>: <subject>
+```
+
+**Allowed types** (mirror `.release-please-config.json`):
+
+| Type       | Section in CHANGELOG     | Version bump |
+|------------|--------------------------|--------------|
+| `feat`     | ✨ Features              | minor        |
+| `fix`      | 🐛 Bug Fixes             | patch        |
+| `perf`     | ⚡ Performance           | patch        |
+| `refactor` | ♻️ Refactoring           | patch        |
+| `revert`   | ⏪ Reverts                | patch        |
+| `style`    | 💄 Style                 | patch        |
+| `build`    | 🔧 Build System          | patch        |
+| `ci`       | 👷 CI/CD                 | patch        |
+| `chore`    | 🧹 Chores (hidden)       | none         |
+| `docs`     | 📚 Documentation (hidden)| none         |
+| `test`     | 🧪 Tests (hidden)        | none         |
+
+Append `!` after the type or scope to mark a **BREAKING CHANGE** — release-please
+treats this as a major bump (or minor pre-1.0).
+
+**Examples:**
+
+```text
+feat(p6c): add get-calendar tool with parameter dispatch
+fix(p6a): tolerate mixed types in /stock/metric response
+ci: validate before release-please so failed tests do not create orphan releases
+refactor!: drop net8 target
+chore: install Husky.Net and conventional-commit validator
+```
+
+The first line must be 1–72 characters total (after the `:` and space).
+
+## Bypassing the hook (don't, except in genuine emergencies)
+
+`git commit --no-verify` skips the local hook. The server-side
+`PR Title` action will still block the PR — that one cannot be bypassed.
+
+## Release flow
+
+Releases are gated through the `release` branch. The path is documented in
+`.planning/specs/01-product-surface.md` and the workflow files
+`.github/workflows/dotnet.yml` + `release.yml`. Short version:
+
+1. Feature/fix PRs merge to `main` as normal
+2. Open a promotion PR from `main` → `release` when ready to ship
+3. Merging it triggers `validate` (format + tests), then `release-please`
+   opens its own PR against `release`
+4. Merging the release-please PR tags the release and triggers the
+   6-platform build matrix
+
+## Project conventions
+
+See `CLAUDE.md` for the broader project conventions (project layout,
+source-generated JSON, NSubstitute for mocks, no third-party HTTP clients,
+etc.).


### PR DESCRIPTION
## Why
release-please reads conventional-commit prefixes to compute version bumps and CHANGELOG entries. Nothing in the repo currently *enforces* that authors actually use the format — a single non-conforming commit silently breaks the release pipeline.

Two-layer enforcement:

| Layer | What | Bypassable? |
|---|---|---|
| **`.husky/commit-msg` hook** | Validates the commit message on `git commit`, locally | Yes (`--no-verify`) |
| **`PR Title` workflow** | Validates the PR title on every open/edit/sync | No |

The two together cover both local-only and forked-clone-with-no-hook-installed cases.

## What's in this PR

### `.config/dotnet-tools.json` + `.husky/`
- New dotnet local tool: `Husky.Net 0.9.1`
- Initialized via `dotnet husky install` — creates `.husky/_/husky.sh` runtime + `.husky/task-runner.json`

### `.husky/commit-msg`
Bash hook. Regex validates the first line of the message against:
```
^(feat|fix|perf|refactor|revert|style|build|ci|chore|docs|test)(\([a-z0-9._-]+\))?!?: .{1,72}$
```
Allowed types mirror `.release-please-config.json` exactly. Auto-generated messages (`Merge `, `Revert `, `fixup!`, `squash!`, `amend!`) are passed through.

Rejection message explains what's wrong, lists allowed types, gives examples, and cites release-please as the reason — so a contributor knows why this exists, not just that it exists.

### `.github/workflows/pr-title.yml`
Uses `amannn/action-semantic-pull-request@v5` (the de-facto standard). Same type allowlist, same subject length, same error message style. Runs on PRs targeting `main`/`develop`/`release`.

### `CONTRIBUTING.md`
New file. Covers:
- Setup steps after cloning (`dotnet tool restore` + `dotnet husky install`)
- Full conventional-commit reference with the type → CHANGELOG section → version bump table
- Examples
- Bypass guidance ("don't, except in emergencies")
- Pointer to the gated release flow

## Verification
Ran the hook through both branches locally:
- ❌ `git commit -m "WIP fix random stuff"` → **rejected** with the help message
- ✅ `git commit -m "chore: install Husky.Net and conventional-commit validator"` → **accepted**

Both commits in this PR went through the hook (proving the path is self-bootstrapping).

## Setup needed on existing clones

```bash
dotnet tool restore
dotnet husky install
```

Documented in CONTRIBUTING.md. New clones pick it up automatically per the doc.

## Doesn't change
- The conventional-commit *spec* itself (already used throughout the repo)
- release-please config
- Existing commit history
- Any source code
