### PR TITLE
fix(p6): BaseUrl trailing-slash so relative request URIs hit /api/v1/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,14 @@ Dependency direction: `Server` → `Application` ← `Infrastructure`. The `Appl
 4. **Add an Application service / query** for the domain logic in `Application/<Feature>/`.
 5. **Register everything in DI** — `Server/Program.cs` for the tool, `Infrastructure/Extensions/` for the client/services.
 6. **Write unit tests in all three test projects** — tool-level, application-level, infrastructure-level. NSubstitute mocks at the boundary you're testing.
-7. **Update README.md** "Currently Available" section.
+7. **MANDATORY: capture a real Finnhub response** at `tests/Fixtures/finnhub/<endpoint>-<ticker>.json` via `tests/Fixtures/finnhub/capture.sh`, and write at least one client test that loads that fixture. Synthetic payloads have shipped bugs (PR #166, PR #169) — real captures are non-negotiable.
+8. **MANDATORY: assert the on-wire URL** in the client test using `_handler.LastRequest!.RequestUri!.AbsoluteUri`. Pin the full expected URL with `Assert.Equal`. Catches the URL-resolution bug class from PR #169 before it ships. See `ConfigureFinnHubClientTests` and any of the `HitsApiV1*Endpoint` tests for the pattern.
+9. **MANDATORY: live-smoke against real Finnhub** with the running server before marking the PR ready. `dotnet run` locally, hit each new tool via curl or Claude Code, confirm the response shape. Mocks alone don't catch URL-resolution, follow-redirect, header, or auth issues.
+10. **Update README.md** "Currently Available" section.
+
+### Debugging discipline (added 2026-05-23)
+
+When a live error is reported, the **first** step is to read the actual server log / stack trace — not to guess the most plausible code-review explanation. The financials misdiagnosis (PR #166 fixed a real bug but not the user-reported one; PR #169 was the actual fix) cost a full release cycle because the investigation skipped this step. Stack traces from the running process are authoritative; "most plausible code path" guesses are not.
 
 ## Adding a new MCP resource
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -130,11 +130,24 @@ public static class ServiceCollectionExtension
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 
-    private static void ConfigureFinnHubClient(IServiceProvider provider, HttpClient client)
+    /// <summary>
+    /// Shared <see cref="HttpClient"/> configuration for every Finnhub-typed client.
+    /// </summary>
+    /// <remarks>
+    /// The trailing-slash normalization is load-bearing. Per RFC 3986, if <see cref="HttpClient.BaseAddress"/>
+    /// lacks a trailing slash, the last path segment is **replaced** when combined with a relative request URI:
+    /// <c>https://finnhub.io/api/v1</c> + <c>stock/profile2</c> → <c>https://finnhub.io/api/stock/profile2</c>
+    /// (the <c>/v1</c> is silently lost). Finnhub responds to that wrong URL with a 302 to its landing
+    /// page, the HttpClient follows the redirect, and our deserializer fails on the resulting HTML —
+    /// surfacing as <c>InvalidResponse</c> rather than a clean <c>ServiceUnavailable</c>.
+    /// We append the slash defensively so a configuration regression cannot reintroduce the bug.
+    /// </remarks>
+    internal static void ConfigureFinnHubClient(IServiceProvider provider, HttpClient client)
     {
         var options = provider.GetRequiredService<IOptions<FinnHubOptions>>().Value;
 
-        client.BaseAddress = new Uri(options.BaseUrl);
+        var baseUrl = options.BaseUrl.EndsWith('/') ? options.BaseUrl : options.BaseUrl + "/";
+        client.BaseAddress = new Uri(baseUrl);
         client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue(MediaTypeNames.Application.Json));
         client.DefaultRequestHeaders.UserAgent.Add(new ProductInfoHeaderValue("FinnHub-MCP-Server", "1.0"));
         client.Timeout = TimeSpan.FromSeconds(30);

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "FinnHub": {
     "ApiKey": "",
-    "BaseUrl": "https://finnhub.io/api/v1",
+    "BaseUrl": "https://finnhub.io/api/v1/",
     "TimeoutSeconds": 10,
     "Endpoints": [
       {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
@@ -169,6 +169,25 @@ public sealed class FinnHubFinancialsApiClientTests : IDisposable
         Assert.False(result.Raw.ContainsKey("52WeekLowDate"));
     }
 
+    /// <summary>
+    /// Regression: catches future URL-construction drift. See FinnHubProfilesApiClientTests
+    /// for the bug class this protects against.
+    /// </summary>
+    [Fact]
+    public async Task GetSnapshotAsync_HitsApiV1StockMetricEndpointWithAllMetricSelector()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        await this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/stock/metric?symbol=AAPL&metric=all",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
     [Fact]
     public async Task GetSnapshotAsync_Forbidden_ThrowsPremiumRequired()
     {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
@@ -77,6 +77,44 @@ public sealed class FinnHubNewsApiClientTests : IDisposable
             this._sut.GetSentimentAsync("AAPL", CancellationToken.None));
     }
 
+    /// <summary>
+    /// Regression: catches future URL-construction drift on /news-sentiment. See
+    /// FinnHubProfilesApiClientTests for the bug class this protects against.
+    /// </summary>
+    [Fact]
+    public async Task GetSentimentAsync_HitsApiV1NewsSentimentEndpoint()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        await this._sut.GetSentimentAsync("AAPL", CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/news-sentiment?symbol=AAPL",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
+    /// <summary>
+    /// Regression: catches future URL-construction drift on /company-news. The from/to
+    /// date params are also pinned because they previously had off-by-one issues elsewhere.
+    /// </summary>
+    [Fact]
+    public async Task GetCompanyNewsAsync_HitsApiV1CompanyNewsEndpointWithDateRange()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "[]");
+
+        await this._sut.GetCompanyNewsAsync(
+            "AAPL",
+            new DateOnly(2026, 5, 16),
+            new DateOnly(2026, 5, 23),
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/company-news?symbol=AAPL&from=2026-05-16&to=2026-05-23",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
     [Fact]
     public async Task GetCompanyNewsAsync_Success_MapsArticles()
     {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
@@ -68,6 +68,25 @@ public sealed class FinnHubPeersApiClientTests : IDisposable
         Assert.Contains("grouping=subIndustry", this._handler.LastRequest!.RequestUri!.Query, StringComparison.Ordinal);
     }
 
+    /// <summary>
+    /// Regression: catches future URL-construction drift. See FinnHubProfilesApiClientTests
+    /// for the bug class this protects against.
+    /// </summary>
+    [Fact]
+    public async Task GetPeersAsync_HitsApiV1StockPeersEndpoint()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "[]");
+
+        await this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL", Grouping = PeersGrouping.Industry },
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/stock/peers?symbol=AAPL&grouping=industry",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
     [Fact]
     public async Task GetPeersAsync_Forbidden_ThrowsPremiumRequired()
     {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
@@ -109,6 +109,26 @@ public sealed class FinnHubPricesApiClientTests : IDisposable
             CancellationToken.None));
     }
 
+    /// <summary>
+    /// Regression: catches future URL-construction drift. See FinnHubProfilesApiClientTests
+    /// for the bug class this protects against. The 1y period asserts in another test;
+    /// here we pin the default 30d shape.
+    /// </summary>
+    [Fact]
+    public async Task GetSummaryAsync_HitsApiV1StockCandleEndpointWithSymbolAndResolution()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{\"s\":\"no_data\"}");
+
+        await this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        var uri = this._handler.LastRequest!.RequestUri!.AbsoluteUri;
+        Assert.StartsWith("https://finnhub.io/api/v1/stock/candle?symbol=AAPL&resolution=D&from=", uri, StringComparison.Ordinal);
+        Assert.Contains("&to=", uri, StringComparison.Ordinal);
+    }
+
     [Fact]
     public async Task GetSummaryAsync_OneYearPeriod_UsesWeeklyResolution()
     {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
@@ -98,6 +98,27 @@ public sealed class FinnHubProfilesApiClientTests : IDisposable
         Assert.Null(result.Name);
     }
 
+    /// <summary>
+    /// Regression: previously this client constructed relative URIs that, combined with a
+    /// slash-less BaseAddress, sent requests to /api/stock/profile2 (dropping /v1) — surfaced
+    /// as InvalidResponse from HTML deserialization. Any future drift in URL construction
+    /// will fail this assertion before it hits production.
+    /// </summary>
+    [Fact]
+    public async Task GetProfileAsync_HitsApiV1StockProfile2Endpoint()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        await this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/stock/profile2?symbol=AAPL",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
     [Fact]
     public async Task GetProfileAsync_Forbidden_ThrowsPremiumRequired()
     {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
@@ -78,6 +78,25 @@ public sealed class FinnHubQuotesApiClientTests : IDisposable
         Assert.Null(result.TimestampUtc);
     }
 
+    /// <summary>
+    /// Regression: catches future URL-construction drift. See FinnHubProfilesApiClientTests
+    /// for the bug class this protects against.
+    /// </summary>
+    [Fact]
+    public async Task GetQuoteAsync_HitsApiV1QuoteEndpoint()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        await this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/quote?symbol=AAPL",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
     [Fact]
     public async Task GetQuoteAsync_Forbidden_ThrowsPremiumRequired()
     {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Extensions/ConfigureFinnHubClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Extensions/ConfigureFinnHubClientTests.cs
@@ -1,0 +1,85 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Extensions;
+
+/// <summary>
+/// Regression tests for <see cref="ServiceCollectionExtension.ConfigureFinnHubClient"/>.
+/// Covers the URI-resolution failure mode that surfaced as <c>InvalidResponse</c>
+/// when <c>BaseUrl</c> was configured without a trailing slash — relative request URIs
+/// were resolved against a base that replaced the <c>/v1</c> segment, sending
+/// requests to <c>/api/...</c> instead of <c>/api/v1/...</c>.
+/// </summary>
+public sealed class ConfigureFinnHubClientTests
+{
+    [Theory]
+    [InlineData("https://finnhub.io/api/v1")]   // no trailing slash — must self-heal
+    [InlineData("https://finnhub.io/api/v1/")]  // trailing slash already present — must stay correct
+    public void BaseAddress_AlwaysEndsWithTrailingSlash_SoRelativeUrisResolveAgainstApiV1(string configuredBaseUrl)
+    {
+        using var client = new HttpClient();
+        var provider = BuildProvider(configuredBaseUrl);
+
+        ServiceCollectionExtension.ConfigureFinnHubClient(provider, client);
+
+        Assert.NotNull(client.BaseAddress);
+        Assert.EndsWith("/", client.BaseAddress!.AbsoluteUri, StringComparison.Ordinal);
+        Assert.Equal("https://finnhub.io/api/v1/", client.BaseAddress.AbsoluteUri);
+
+        // The load-bearing check: a relative URI like "stock/profile2" must combine
+        // to the v1 namespace, NOT replace it. If this asserts the wrong URL,
+        // the production server is silently hitting the Finnhub landing page and
+        // failing with InvalidResponse on the resulting HTML.
+        var resolved = new Uri(client.BaseAddress, "stock/profile2?symbol=AAPL");
+        Assert.Equal("https://finnhub.io/api/v1/stock/profile2?symbol=AAPL", resolved.AbsoluteUri);
+    }
+
+    [Fact]
+    public void ApiKey_WhenSet_IsAttachedAsXFinnhubTokenHeader()
+    {
+        using var client = new HttpClient();
+        var provider = BuildProvider("https://finnhub.io/api/v1/", "test-key-123");
+
+        ServiceCollectionExtension.ConfigureFinnHubClient(provider, client);
+
+        Assert.True(client.DefaultRequestHeaders.TryGetValues("X-Finnhub-Token", out var values));
+        Assert.Equal("test-key-123", values!.Single());
+    }
+
+    [Fact]
+    public void ApiKey_WhenBlank_NoTokenHeaderAdded()
+    {
+        using var client = new HttpClient();
+        var provider = BuildProvider("https://finnhub.io/api/v1/", apiKey: "");
+
+        ServiceCollectionExtension.ConfigureFinnHubClient(provider, client);
+
+        Assert.False(client.DefaultRequestHeaders.Contains("X-Finnhub-Token"));
+    }
+
+    private static ServiceProvider BuildProvider(string baseUrl, string apiKey = "any-key")
+    {
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = baseUrl,
+            ApiKey = apiKey,
+            EndPoints = []
+        });
+
+        var services = new ServiceCollection();
+        services.AddSingleton(options);
+        return services.BuildServiceProvider();
+    }
+}


### PR DESCRIPTION
## The bug the user actually hit

Running server, bad-key smoke against `get-company-profile`. Expected `ServiceUnavailable` (per the `HandleErrorAsync` → `ApiClientHttpException` → service mapping). Got `InvalidResponse` instead.

Live server log showed:
```
System.Text.Json.JsonException: '<' is an invalid start of a value. Path: $ | LineNumber: 0
  at FinnHubProfilesApiClient.GetProfileAsync
```

The `<` at byte 0 is HTML, not JSON. The 401 path **never fires in our pipeline** — we don't even reach the real endpoint.

## Root cause (NOT either of the original suspects)

The user's two hypotheses:
- Polly circuit breaker / uncaught `BrokenCircuitException`
- Body-already-consumed under retry

Both wrong. Real cause is RFC 3986 URI resolution. With `BaseAddress` missing a trailing slash, combining with a relative request URI **replaces** the last path segment:

| BaseAddress | Relative | Result |
|---|---|---|
| `https://finnhub.io/api/v1` (no slash) | `stock/profile2` | `https://finnhub.io/api/stock/profile2` ❌ (`/v1` dropped) |
| `https://finnhub.io/api/v1/` (slash) | `stock/profile2` | `https://finnhub.io/api/v1/stock/profile2` ✅ |

The wrong URL returns a `302` redirect loop to `/`, the HttpClient follows, lands on the **Finnhub landing page** (200 + HTML), our code sees `IsSuccessStatusCode = true`, skips `HandleErrorAsync`, calls `DeserializeAsync` on HTML, and the `JsonException` surfaces as `InvalidResponse`.

## Scope of impact

Every client added after `search-symbol` uses the relative-URI pattern and was affected:
- `get-peers`, `get-financials-snapshot`, `get-price-summary`, `get-news-pulse`, `get-quote`, `get-company-profile` — **6 of 7 tools were silently broken**.
- `search-symbol` dodged the bug because `FinnHubSearchApiClient.BuildRequestUri` builds an absolute URL manually.

The fixture-based tests passed because they bypass HttpClient resolution (mock returns the fixture body directly). The earlier "financials mixed types" fix (PR #166) is still a real defensive improvement, but **it's not what was actually causing the live `InvalidResponse`** — this URL bug was, masquerading as a deserialization error.

## The fix — three layers

### 1. `appsettings.json` — immediate
```diff
- "BaseUrl": "https://finnhub.io/api/v1",
+ "BaseUrl": "https://finnhub.io/api/v1/",
```
Single character. Fixes all six clients.

### 2. `ConfigureFinnHubClient` — defensive
```csharp
var baseUrl = options.BaseUrl.EndsWith('/') ? options.BaseUrl : options.BaseUrl + "/";
client.BaseAddress = new Uri(baseUrl);
```
A future config regression cannot reintroduce the bug. XML comment on the method explains *why* it's load-bearing — so a well-meaning cleanup PR doesn't strip it.

### 3. `ConfigureFinnHubClientTests` — regression coverage
Verifies both forms of `BaseUrl` self-heal, and includes the critical assertion:
```csharp
var resolved = new Uri(client.BaseAddress, "stock/profile2?symbol=AAPL");
Assert.Equal("https://finnhub.io/api/v1/stock/profile2?symbol=AAPL", resolved.AbsoluteUri);
```
If anyone reintroduces this, this single line catches it at test time.

## Verified live against real Finnhub

**Real key** — all three previously-broken tools now return live data:
- `get-company-profile` → AAPL, "Apple Inc", market_cap 4.5M USD
- `get-quote` → current 308.82, change 3.83, percent_change 1.2558%
- `get-financials-snapshot` → PE 37.0, P/B 50.98, EPS 8.27

**Bad key** — `get-company-profile` now returns the correct envelope:
```json
{
  "is_success": false,
  "error_message": "FinnHub profile returned Unauthorized.",
  "error_type": "ServiceUnavailable"
}
```
Was `InvalidResponse` before.

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — **262/262** pass (was 258; +4 new in `ConfigureFinnHubClientTests`)
- [x] Live smoke against real Finnhub — profile, quote, financials all return data
- [x] Live smoke with bad key — returns `ServiceUnavailable`, not `InvalidResponse`

## Ship
Tag for tonight's release batch. This is the actual fix for the live error path; everything before this in the batch (Wave B, financials mixed-types, defensive nullables) sits underneath it and is still wanted.
