### PR TITLE
fix(ci): restore PDB generation in Debug builds so coverlet can instrument

### DIFF
--- a/src/FinnHub.MCP.Server.Application/FinnHub.MCP.Server.Application.csproj
+++ b/src/FinnHub.MCP.Server.Application/FinnHub.MCP.Server.Application.csproj
@@ -7,6 +7,9 @@
     <Nullable>enable</Nullable>
     <Title>FinnHub MCP Server Application</Title>
     <NeutralLanguage>en-GB</NeutralLanguage>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- Slim release artifacts: skip symbols for the published binary. -->
     <PublishSymbols>false</PublishSymbols>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
+++ b/src/FinnHub.MCP.Server.Infrastructure/FinnHub.MCP.Server.Infrastructure.csproj
@@ -7,6 +7,9 @@
     <Nullable>enable</Nullable>
     <Title>FinnHub MCP Server Infrastructure</Title>
     <NeutralLanguage>en-GB</NeutralLanguage>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- Slim release artifacts: skip symbols for the published binary. -->
     <PublishSymbols>false</PublishSymbols>
     <DebugType>None</DebugType>
   </PropertyGroup>

--- a/src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj
+++ b/src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj
@@ -10,9 +10,12 @@
     <NeutralLanguage>en-GB</NeutralLanguage>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     <RepositoryUrl>https://github.com/salzaki/finnhub-mcp</RepositoryUrl>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- Slim release artifacts: skip symbols for the published binary. -->
     <PublishSymbols>false</PublishSymbols>
     <DebugType>None</DebugType>
-    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup Label="Packages">
     <PackageReference Include="ModelContextProtocol" />


### PR DESCRIPTION
## Why
Coverlet has been emitting empty coverage XML (`lines-valid="0"`) for the entire history of the repo — we just never noticed because Codecov uploaded the empty file and reported nothing useful. CLAUDE.md flagged this as "known broken" in the recent retrospective.

Root cause: all three source csproj files set
```xml
<DebugType>None</DebugType>
```
**unconditionally**. No PDB → no instrumentation → no coverage data. The setting was meant to slim release artifacts but is silently killing Debug-mode (test-mode) coverage too.

## Fix
Move `DebugType=None` (and the paired `PublishSymbols=false`) into a `Configuration == 'Release'`-conditioned `PropertyGroup`. Debug builds now emit portable PDBs and coverlet instruments normally; Release builds still produce a slim binary with no symbols.

```diff
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     ...
-    <PublishSymbols>false</PublishSymbols>
-    <DebugType>None</DebugType>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
+    <!-- Slim release artifacts: skip symbols for the published binary. -->
+    <PublishSymbols>false</PublishSymbols>
+    <DebugType>None</DebugType>
+  </PropertyGroup>
```

Same change in all three source csprojs (Application, Infrastructure, Server).

## Verified locally
- `dotnet build` (Debug, default) — clean, PDBs land in `bin/Debug`
- `dotnet build -c Release` — clean, no PDBs in `bin/Release` (intent preserved)
- `dotnet test --collect:"XPlat Code Coverage" --settings coverlet.runsettings` now produces real per-project numbers:

| Project | Line | Branch |
|---|---|---|
| Application | **75.94%** | 71.21% |
| Infrastructure | **51.94%** | 48.50% |
| Server | **39.18%** | 47.57% |

Was 0% across the board before this fix.

## Doesn't include
- Coverage threshold enforcement in CI — that's a follow-up once we agree on a target.
- The "coverage tooling is broken" note in CLAUDE.md — removed in a follow-up once this lands.
- The Phase A test-backfill work surfaced by the gap analysis — separate PR(s).

## Test plan
- [x] `dotnet build` (Debug) — clean
- [x] `dotnet build -c Release` — clean
- [x] `dotnet test` — all tests pass (no behavioural change)
- [x] Coverage XML now non-empty
