### PR TITLE
test: phase A coverage backfill — 91% line / 84% branch

### DIFF
--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Exceptions/ApiClientExceptionTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Exceptions/ApiClientExceptionTests.cs
@@ -1,0 +1,112 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Exceptions;
+
+/// <summary>
+/// Constructor + property coverage for every concrete <see cref="ApiClientException"/>
+/// subclass. Bumps coverage from ~50% line to 100% and pins the wire <c>ErrorCode</c>
+/// strings that downstream consumers (logging, error-type mapping) depend on.
+/// </summary>
+public sealed class ApiClientExceptionTests
+{
+    [Fact]
+    public void ApiClientHttpException_PreservesAllConstructorArgs()
+    {
+        var inner = new InvalidOperationException("inner");
+        var ex = new ApiClientHttpException("boom", HttpStatusCode.BadGateway, "body", "https://x/y", inner);
+
+        Assert.Equal("boom", ex.Message);
+        Assert.Equal(HttpStatusCode.BadGateway, ex.StatusCode);
+        Assert.Equal("body", ex.ResponseContent);
+        Assert.Equal("https://x/y", ex.RequestUri);
+        Assert.Same(inner, ex.InnerException);
+        Assert.Equal("API_CLIENT_HTTP", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ApiClientHttpException_OptionalArgs_DefaultToNull()
+    {
+        var ex = new ApiClientHttpException("boom", HttpStatusCode.InternalServerError);
+
+        Assert.Null(ex.ResponseContent);
+        Assert.Null(ex.RequestUri);
+        Assert.Null(ex.InnerException);
+    }
+
+    [Fact]
+    public void ApiClientDeserializationException_PreservesResponseContentAndInner()
+    {
+        var inner = new System.Text.Json.JsonException("bad json");
+        var ex = new ApiClientDeserializationException("boom", "<html>", inner);
+
+        Assert.Equal("boom", ex.Message);
+        Assert.Equal("<html>", ex.ResponseContent);
+        Assert.Same(inner, ex.InnerException);
+        Assert.Equal("API_CLIENT_DESERIALIZATION", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ApiClientPremiumRequiredException_PreservesEndpointAndContent()
+    {
+        var ex = new ApiClientPremiumRequiredException("/api/v1/stock/candle", "premium-only");
+
+        Assert.Equal("/api/v1/stock/candle", ex.Endpoint);
+        Assert.Equal("premium-only", ex.ResponseContent);
+        Assert.Contains("premium plan", ex.Message);
+        Assert.Equal("API_CLIENT_PREMIUM_REQUIRED", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ApiClientTimeoutException_HasExpectedErrorCode()
+    {
+        var inner = new TimeoutException();
+        var ex = new ApiClientTimeoutException("timed out", inner);
+
+        Assert.Equal("timed out", ex.Message);
+        Assert.Same(inner, ex.InnerException);
+        Assert.Equal("API_CLIENT_TIMEOUT", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ApiClientCancelledException_HasExpectedErrorCode()
+    {
+        var ex = new ApiClientCancelledException("cancelled");
+
+        Assert.Equal("cancelled", ex.Message);
+        Assert.Equal("API_CLIENT_CANCELLED", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ApiClientUnexpectedException_HasExpectedErrorCode()
+    {
+        var inner = new Exception("root cause");
+        var ex = new ApiClientUnexpectedException("oops", inner);
+
+        Assert.Equal("oops", ex.Message);
+        Assert.Same(inner, ex.InnerException);
+        Assert.Equal("API_CLIENT_UNEXPECTED", ex.ErrorCode);
+    }
+
+    [Fact]
+    public void ApiClientException_BaseClass_CorrelationAndSourceServiceSettable()
+    {
+        var ex = new ApiClientHttpException("boom", HttpStatusCode.OK)
+        {
+            CorrelationId = "req-123",
+            SourceService = "finnhub"
+        };
+
+        Assert.Equal("req-123", ex.CorrelationId);
+        Assert.Equal("finnhub", ex.SourceService);
+        Assert.True(ex.OccurredAtUtc <= DateTimeOffset.UtcNow);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Financials/FinnHubFinancialsApiClientTests.cs
@@ -198,6 +198,37 @@ public sealed class FinnHubFinancialsApiClientTests : IDisposable
             CancellationToken.None));
     }
 
+    [Fact]
+    public async Task GetSnapshotAsync_HttpRequestException_ThrowsHttpException()
+    {
+        this._handler.SetException(new HttpRequestException("network unreachable"));
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() => this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSnapshotAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetSnapshotAsync(
+            new GetFinancialsSnapshotQuery { QueryId = "q1", Symbol = "AAPL" },
+            cts.Token));
+    }
+
     public void Dispose()
     {
         this._handler.Dispose();

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
@@ -163,6 +163,34 @@ public sealed class FinnHubNewsApiClientTests : IDisposable
         Assert.Equal("h2", result[0].Headline);
     }
 
+    [Fact]
+    public async Task GetSentimentAsync_HttpRequestException_ThrowsHttpException()
+    {
+        this._handler.SetException(new HttpRequestException("network unreachable"));
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() =>
+            this._sut.GetSentimentAsync("AAPL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSentimentAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() =>
+            this._sut.GetSentimentAsync("AAPL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSentimentAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() =>
+            this._sut.GetSentimentAsync("AAPL", cts.Token));
+    }
+
     public void Dispose()
     {
         this._handler.Dispose();

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
@@ -117,6 +117,37 @@ public sealed class FinnHubPeersApiClientTests : IDisposable
             CancellationToken.None));
     }
 
+    [Fact]
+    public async Task GetPeersAsync_HttpRequestException_ThrowsHttpException()
+    {
+        this._handler.SetException(new HttpRequestException("network unreachable"));
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() => this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            cts.Token));
+    }
+
     public void Dispose()
     {
         this._handler.Dispose();

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
@@ -143,6 +143,37 @@ public sealed class FinnHubPricesApiClientTests : IDisposable
         Assert.Contains("resolution=W", this._handler.LastRequest!.RequestUri!.Query, StringComparison.Ordinal);
     }
 
+    [Fact]
+    public async Task GetSummaryAsync_HttpRequestException_ThrowsHttpException()
+    {
+        this._handler.SetException(new HttpRequestException("network unreachable"));
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() => this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetSummaryAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            cts.Token));
+    }
+
     public void Dispose()
     {
         this._handler.Dispose();

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
@@ -129,6 +129,37 @@ public sealed class FinnHubProfilesApiClientTests : IDisposable
             CancellationToken.None));
     }
 
+    [Fact]
+    public async Task GetProfileAsync_HttpRequestException_ThrowsHttpException()
+    {
+        this._handler.SetException(new HttpRequestException("network unreachable"));
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() => this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetProfileAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
+            cts.Token));
+    }
+
     public void Dispose()
     {
         this._handler.Dispose();

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
@@ -117,6 +117,37 @@ public sealed class FinnHubQuotesApiClientTests : IDisposable
             CancellationToken.None));
     }
 
+    [Fact]
+    public async Task GetQuoteAsync_HttpRequestException_ThrowsHttpException()
+    {
+        this._handler.SetException(new HttpRequestException("network unreachable"));
+
+        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() => this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetQuoteAsync(
+            new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
+            cts.Token));
+    }
+
     public void Dispose()
     {
         this._handler.Dispose();

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/FinancialsInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/FinancialsInputValidatorTests.cs
@@ -1,0 +1,42 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Financials;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Financials;
+
+public sealed class FinancialsInputValidatorTests
+{
+    [Theory]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("aapl", "AAPL")]
+    [InlineData("BRK.B", "BRK.B")]
+    public void ValidateSymbol_Valid_Normalises(string input, string expected) =>
+        Assert.Equal(expected, FinancialsInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    public void ValidateSymbol_Invalid_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => FinancialsInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("full", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, FinancialsInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_Unknown_Throws() =>
+        Assert.Throws<ArgumentException>(() => FinancialsInputValidator.ValidateView("nonsense"));
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/GetFinancialsSnapshotToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/GetFinancialsSnapshotToolTests.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Tools.Financials;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Financials;
@@ -66,5 +67,23 @@ public sealed class GetFinancialsSnapshotToolTests
     {
         await Assert.ThrowsAsync<ArgumentException>(() =>
             this._sut.GetFinancialsSnapshotAsync("AAPL", view: "nonsense"));
+    }
+
+    [Fact]
+    public async Task GetFinancialsSnapshotAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => this._sut.GetFinancialsSnapshotAsync("AAPL"));
+    }
+
+    [Fact]
+    public async Task GetFinancialsSnapshotAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => this._sut.GetFinancialsSnapshotAsync("AAPL"));
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/GetNewsPulseToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/GetNewsPulseToolTests.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.News.Services;
 using FinnHub.MCP.Server.Tools.News;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.News;
@@ -66,5 +67,23 @@ public sealed class GetNewsPulseToolTests
     {
         await Assert.ThrowsAsync<ArgumentException>(() =>
             this._sut.GetNewsPulseAsync("AAPL", view: "nonsense"));
+    }
+
+    [Fact]
+    public async Task GetNewsPulseAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => this._sut.GetNewsPulseAsync("AAPL"));
+    }
+
+    [Fact]
+    public async Task GetNewsPulseAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => this._sut.GetNewsPulseAsync("AAPL"));
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/NewsInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/NewsInputValidatorTests.cs
@@ -1,0 +1,40 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.News;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.News;
+
+public sealed class NewsInputValidatorTests
+{
+    [Theory]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("aapl", "AAPL")]
+    public void ValidateSymbol_Valid_Normalises(string input, string expected) =>
+        Assert.Equal(expected, NewsInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("!!!")]
+    public void ValidateSymbol_Invalid_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => NewsInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("full", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, NewsInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_Unknown_Throws() =>
+        Assert.Throws<ArgumentException>(() => NewsInputValidator.ValidateView("nonsense"));
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Peers.Services;
 using FinnHub.MCP.Server.Tools.Peers;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Peers;
@@ -81,5 +82,23 @@ public sealed class GetPeersToolTests
     {
         await Assert.ThrowsAsync<ArgumentException>(() =>
             this._sut.GetPeersAsync("AAPL", grouping: "nonsense"));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => this._sut.GetPeersAsync("AAPL"));
+    }
+
+    [Fact]
+    public async Task GetPeersAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => this._sut.GetPeersAsync("AAPL"));
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/PeersInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/PeersInputValidatorTests.cs
@@ -1,0 +1,57 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Tools.Peers;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Peers;
+
+public sealed class PeersInputValidatorTests
+{
+    [Theory]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("aapl", "AAPL")]
+    [InlineData(" AAPL ", "AAPL")]
+    public void ValidateSymbol_Valid_Normalises(string input, string expected) =>
+        Assert.Equal(expected, PeersInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("!!!")]
+    [InlineData("1AAPL")]
+    public void ValidateSymbol_Invalid_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => PeersInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null, PeersGrouping.Industry)]
+    [InlineData("", PeersGrouping.Industry)]
+    [InlineData("industry", PeersGrouping.Industry)]
+    [InlineData("INDUSTRY", PeersGrouping.Industry)]
+    [InlineData("subindustry", PeersGrouping.SubIndustry)]
+    [InlineData("sector", PeersGrouping.Sector)]
+    public void ValidateGrouping_KnownValues_MapToEnum(string? input, PeersGrouping expected) =>
+        Assert.Equal(expected, PeersInputValidator.ValidateGrouping(input));
+
+    [Fact]
+    public void ValidateGrouping_Unknown_Throws() =>
+        Assert.Throws<ArgumentException>(() => PeersInputValidator.ValidateGrouping("nonsense"));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("full", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, PeersInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_Unknown_Throws() =>
+        Assert.Throws<ArgumentException>(() => PeersInputValidator.ValidateView("nonsense"));
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/GetPriceSummaryToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/GetPriceSummaryToolTests.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Prices.Services;
 using FinnHub.MCP.Server.Tools.Prices;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Prices;
@@ -66,5 +67,23 @@ public sealed class GetPriceSummaryToolTests
         await this._service.Received(1).GetSummaryAsync(
             Arg.Is<GetPriceSummaryQuery>(q => q.Period == PricePeriod.NinetyDays),
             Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetPriceSummaryAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => this._sut.GetPriceSummaryAsync("AAPL"));
+    }
+
+    [Fact]
+    public async Task GetPriceSummaryAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => this._sut.GetPriceSummaryAsync("AAPL"));
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/PricesInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/PricesInputValidatorTests.cs
@@ -1,0 +1,59 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Tools.Prices;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Prices;
+
+public sealed class PricesInputValidatorTests
+{
+    [Theory]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("aapl", "AAPL")]
+    public void ValidateSymbol_Valid_Normalises(string input, string expected) =>
+        Assert.Equal(expected, PricesInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("!!!")]
+    public void ValidateSymbol_Invalid_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => PricesInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null, PricePeriod.ThirtyDays)]
+    [InlineData("", PricePeriod.ThirtyDays)]
+    [InlineData("7d", PricePeriod.SevenDays)]
+    [InlineData("30d", PricePeriod.ThirtyDays)]
+    [InlineData("90d", PricePeriod.NinetyDays)]
+    [InlineData("1y", PricePeriod.OneYear)]
+    [InlineData("1Y", PricePeriod.OneYear)]
+    public void ValidatePeriod_KnownValues_MapToEnum(string? input, PricePeriod expected) =>
+        Assert.Equal(expected, PricesInputValidator.ValidatePeriod(input));
+
+    [Theory]
+    [InlineData("5h")]
+    [InlineData("2y")]
+    [InlineData("nonsense")]
+    public void ValidatePeriod_Unknown_Throws(string input) =>
+        Assert.Throws<ArgumentException>(() => PricesInputValidator.ValidatePeriod(input));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("full", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, PricesInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_Unknown_Throws() =>
+        Assert.Throws<ArgumentException>(() => PricesInputValidator.ValidateView("nonsense"));
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/GetCompanyProfileToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/GetCompanyProfileToolTests.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Profiles.Services;
 using FinnHub.MCP.Server.Tools.Profiles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Profiles;
@@ -72,5 +73,23 @@ public sealed class GetCompanyProfileToolTests
         Assert.Equal("get-financials-snapshot", envelope.NextActions[0].Tool);
         Assert.Equal("get-peers", envelope.NextActions[1].Tool);
         Assert.Equal("get-quote", envelope.NextActions[2].Tool);
+    }
+
+    [Fact]
+    public async Task GetCompanyProfileAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => this._sut.GetCompanyProfileAsync("AAPL"));
+    }
+
+    [Fact]
+    public async Task GetCompanyProfileAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => this._sut.GetCompanyProfileAsync("AAPL"));
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/ProfilesInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/ProfilesInputValidatorTests.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Profiles;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Profiles;
+
+public sealed class ProfilesInputValidatorTests
+{
+    [Theory]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("aapl", "AAPL")]
+    [InlineData(" AAPL ", "AAPL")]
+    [InlineData("BRK.B", "BRK.B")]
+    public void ValidateSymbol_Valid_NormalisesToUppercase(string input, string expected) =>
+        Assert.Equal(expected, ProfilesInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    [InlineData("1AAPL")]
+    [InlineData("TOOLONGSYMBOLNAME1234567890")]
+    public void ValidateSymbol_Invalid_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => ProfilesInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("", ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("full", ToolView.Full)]
+    [InlineData("FULL", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, ProfilesInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_UnknownValue_Throws() =>
+        Assert.Throws<ArgumentException>(() => ProfilesInputValidator.ValidateView("nonsense"));
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/GetQuoteToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/GetQuoteToolTests.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Quotes.Services;
 using FinnHub.MCP.Server.Tools.Quotes;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
+using NSubstitute.ExceptionExtensions;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Quotes;
@@ -55,5 +56,24 @@ public sealed class GetQuoteToolTests
         Assert.Equal(2, envelope.NextActions.Count);
         Assert.Equal("get-news-pulse", envelope.NextActions[0].Tool);
         Assert.Equal("get-price-summary", envelope.NextActions[1].Tool);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => this._sut.GetQuoteAsync("AAPL"));
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => this._sut.GetQuoteAsync("AAPL"));
+        Assert.Equal("downstream broke", ex.Message);
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/QuotesInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/QuotesInputValidatorTests.cs
@@ -1,0 +1,50 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Quotes;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Quotes;
+
+public sealed class QuotesInputValidatorTests
+{
+    [Theory]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("aapl", "AAPL")]
+    [InlineData(" AAPL ", "AAPL")]
+    [InlineData("BRK.B", "BRK.B")]
+    [InlineData("RDS-A", "RDS-A")]
+    public void ValidateSymbol_Valid_NormalisesToUppercase(string input, string expected) =>
+        Assert.Equal(expected, QuotesInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData("!!!")]
+    [InlineData("1AAPL")]
+    [InlineData("AAPL@INVALID")]
+    [InlineData("TOOLONGSYMBOLNAME1234567890")]
+    public void ValidateSymbol_Invalid_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => QuotesInputValidator.ValidateSymbol(input));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("", ToolView.Summary)]
+    [InlineData("   ", ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("SUMMARY", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("full", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, QuotesInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_UnknownValue_Throws() =>
+        Assert.Throws<ArgumentException>(() => QuotesInputValidator.ValidateView("nonsense"));
+}


### PR DESCRIPTION
## Result
| Metric | Before | After |
|---|---|---|
| Total tests | 269 | **405** (+136) |
| Aggregate line coverage (ex-`Program.cs`) | 50% | **91.1%** |
| Aggregate branch coverage (ex-`Program.cs`) | 52% | **84.3%** |

This is **Phase A** of the test-backfill plan from the gap analysis (after PR #175 unblocked coverlet measurement). Pushes us comfortably above the 80% threshold we agreed to target.

## Four buckets of additions

### Group 1 — Exception class constructors
`tests/.../Application.Tests.Unit/Exceptions/ApiClientExceptionTests.cs` (new file, 8 tests)

Pins the wire `ErrorCode` strings each subclass exposes (downstream consumers map on these for error-type translation). Each `ApiClient*Exception` was at 50% line because tests only exercised one constructor signature; this hits all of them and verifies properties round-trip correctly.

### Group 2 — Input validator branches
6 new files, one per tool: `tests/.../Tests.Unit/Tools/{Quotes,Profiles,Peers,Financials,Prices,News}/*InputValidatorTests.cs`

Exhaustive theory-driven coverage of every rejection path: null, empty, whitespace, regex-rejected, length-exceeded, unknown enum values, case-insensitivity. Validators were at 60-83% line; now ~95%+.

### Group 3 — Tool catch blocks
Appended 12 tests across the 6 existing tool test files:
- `OperationCanceledException` propagation (cancellation token)
- Generic `Exception` propagation (unexpected downstream failures)

Was 50-67% branch on the tool methods because only the `ArgumentException` catch was tested.

### Group 4 — Client exception paths
Appended 18 tests across the 6 newer client test files (`FinnHubSearchApiClientTests` already had these — used as the pattern reference):
- `HttpRequestException` → `ApiClientHttpException`
- `TaskCanceledException(inner=TimeoutException)` → `ApiClientTimeoutException`
- Pre-cancelled `CancellationToken` → `ApiClientCancelledException`

## Deliberately NOT in this PR
- **`[ExcludeFromCodeCoverage]` on `Program.cs`** — that's a separate decision (cheap exclusion vs. WebApplicationFactory integration tests). Currently drags aggregate down ~30 points.
- **Rare branch fills** (e.g., `dto?.Field` null-path in client projections, `IncludeRaw=true vs false` in raw filter) — diminishing-returns territory, would require contrived tests that don't validate meaningful behavior.
- **Coverage threshold in CI** — separate PR once we agree on a floor (proposed: 85% line, 75% branch, with `Program.cs` excluded).

## Test plan
- [x] `dotnet build` — clean, 0 warnings
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test` — 405/405 pass
- [x] Local coverage measurement confirms the numbers above
- [x] Hook accepted the commit (subject under 72 chars — the 92-char first attempt was rejected, validating the hook works end-to-end)
