### PR TITLE
fix(test): accept typed NotFound as graceful degradation in live-smoke

### DIFF
--- a/tests/FinnHub.MCP.Server.Tests.LiveSmoke/ToolSmokeTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.LiveSmoke/ToolSmokeTests.cs
@@ -156,16 +156,19 @@ public sealed class ToolSmokeTests : IClassFixture<LiveSmokeFactory>
     public async Task GetQuote_UnknownSymbol_DegradesGracefully()
     {
         // Finnhub returns {"c":0,"d":null,"dp":null,...} for unknown tickers.
-        // Tool MUST still produce IsSuccess=true with degraded data — the
-        // BuildExplanation path renders n/a for nulls. This is the regression
-        // signature from PR #167 (defensive nullable DTOs).
+        // PR #167 made the DTOs tolerate the nulls so deserialization doesn't
+        // crash; the service layer is free to either pass that through as
+        // IsSuccess=true with degraded data, OR detect the all-zeros shape
+        // and return a typed NotFound envelope. Both are "graceful degradation"
+        // — the regression we're guarding against is an unhandled exception
+        // or a ServiceUnavailable bubbling up from a deserialization failure.
         var tool = new GetQuoteTool(
             this._services.GetRequiredService<IQuotesService>(),
             NullLogger<GetQuoteTool>.Instance);
 
         var envelope = await tool.GetQuoteAsync("ZZZZ");
 
-        AssertSuccessOrPremium(envelope.IsSuccess, envelope.ErrorType, envelope.ErrorMessage);
+        AssertGracefulDegradation(envelope.IsSuccess, envelope.ErrorType, envelope.ErrorMessage);
     }
 
     private static void AssertSuccessOrPremium(bool isSuccess, string? errorType, string? errorMessage)
@@ -183,6 +186,24 @@ public sealed class ToolSmokeTests : IClassFixture<LiveSmokeFactory>
         }
 
         Assert.Fail($"Tool failed against real Finnhub. error_type={errorType ?? "<null>"} error_message={errorMessage ?? "<null>"}");
+    }
+
+    private static void AssertGracefulDegradation(bool isSuccess, string? errorType, string? errorMessage)
+    {
+        // Tolerated outcomes for an unknown / nonsense input:
+        //   - IsSuccess=true  → service passed through degraded data (zeros / nulls)
+        //   - NotFound        → service detected the bogus symbol and returned a typed not-found
+        //   - PremiumRequired → endpoint is premium-gated (unlikely for /quote but kept for parity)
+        // Anything else (ServiceUnavailable, an uncaught exception type, etc.) means
+        // the failure path itself broke — that's the regression we want to catch.
+        if (isSuccess
+            || string.Equals(errorType, "NotFound", StringComparison.Ordinal)
+            || string.Equals(errorType, "PremiumRequired", StringComparison.Ordinal))
+        {
+            return;
+        }
+
+        Assert.Fail($"Unknown-symbol path failed unexpectedly. error_type={errorType ?? "<null>"} error_message={errorMessage ?? "<null>"}");
     }
 
     private static void RequireApiKey()


### PR DESCRIPTION
## Why
First live-smoke run (after PR #185) on real Finnhub: **7 of 8 tests passed**. The one failure was a test-side premise bug.

\`GetQuote_UnknownSymbol_DegradesGracefully\` failed with:
> Tool failed against real Finnhub. error_type=NotFound error_message=No live quote for ZZZZ.

I had asserted that an unknown ticker MUST return \`IsSuccess=true\` with degraded data. In reality the \`QuotesService\` correctly inspects the all-zeros payload from Finnhub and returns a typed \`NotFound\` envelope — which is arguably better UX for an LLM consumer than passing through \`{c:0, d:null}\`.

PR #167 made the DTOs tolerate nulls so deserialization doesn't crash. The service layer is free to interpret the resulting payload either way. Both are "graceful degradation."

## Fix
Split the assertion helper:

| Helper | Used by | Accepts |
|---|---|---|
| \`AssertSuccessOrPremium\` (existing) | 7 known-good-ticker tests | \`IsSuccess=true\` OR \`PremiumRequired\` |
| \`AssertGracefulDegradation\` (new) | unknown-ticker test | \`IsSuccess=true\` OR \`NotFound\` OR \`PremiumRequired\` |

What the smoke STILL fails on for the unknown-ticker case:
- \`ServiceUnavailable\` (Finnhub broke or returned an unexpected shape)
- Any uncaught exception type
- Deserialization throw

— which IS the regression class this whole workflow exists to catch.

## Verified
- 7 known-good tests still pass on the live-smoke run logs from the prior failure
- \`dotnet build\` clean
- \`dotnet format --verify-no-changes\` clean
- Can't end-to-end re-verify locally (dev key still 401s); next \`workflow_dispatch\` of \`live-smoke.yml\` after merge should report 8/8 green

## Test plan
- [x] Build clean
- [x] Format clean
- [ ] After merge: manual \`workflow_dispatch\` on live-smoke.yml → expect all 8 tests pass