### PR TITLE
docs: update CLAUDE.md with issue workflow, live-smoke, current coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,7 +144,7 @@ Refresh fixtures when Finnhub changes a shape or you add an endpoint.
 **Things to know:**
 - `CHANGELOG.md` is generated; don't edit it by hand.
 - After a promotion lands on `release`, GitHub's UI will offer a "compare and pull request" prompt suggesting `release → main`. **It's noise** — that direction is circular (release-please adds CHANGELOG + manifest commits to `release` that main doesn't have; merging them back is meaningless). Dismiss the banner.
-- Recommended: enable branch protection on `release` in repo settings (PR + status checks required). Without it, anyone with push access can bypass the validate gate.
+- Branch protection on `release` is enabled (require PR + `Validate Release Branch` status check + no force push + no deletions). Direct pushes are blocked; the admin-merge escape valve remains for the Codecov-on-introducing-PR class of chicken-and-egg cases.
 
 ## Coverage
 
@@ -153,20 +153,59 @@ Refresh fixtures when Finnhub changes a shape or you add an endpoint.
 - **Project floor: 85% line.** Aggregate coverage across the codebase. PRs that drop below this fail the Codecov check.
 - **Patch floor: 80% line.** New / changed code in a PR must be ≥80% covered.
 
-`Program.cs` is excluded from coverage measurement (`ExcludeByFile` in `coverlet.runsettings`) — it's the host entry point validated by live smoke, not by unit tests. Adding it would force WebApplicationFactory tests that hit lines without validating behaviour.
+**Excluded from measurement** — both because the only meaningful test for them is end-to-end host bootstrap, which the live-smoke workflow covers:
 
-Baseline at the time of writing (PR #176): **91% line / 84% branch** with `Program.cs` excluded. Both well above the floor.
+- `Program.cs` — via `ExcludeByFile` in `coverlet.runsettings`
+- `ServiceCollectionExtension.cs` — via `[ExcludeFromCodeCoverage]` on the class with an XML doc explaining why
+
+Baseline at time of writing (PR #179 + #180 follow-up): **98% line / 90% branch / 100% method**. 437 tests across `FinnHub.MCP.Server.Tests.Unit`, `Application.Tests.Unit`, `Infrastructure.Tests.Unit`, and `LiveSmoke`.
 
 If coverage drops below the floor, your options are:
 1. Add tests covering the gap (preferred).
-2. Decorate the new code with `[ExcludeFromCodeCoverage]` and document why in the XML doc / commit message (rare — only for genuinely untestable code).
+2. Decorate the new code with `[ExcludeFromCodeCoverage]` and document why in the XML doc / commit message (rare — only for genuinely untestable code like DI wiring or host entry points).
 3. Admin-merge with explicit justification (escape valve, same as for the CI-flake cases).
+
+## Live smoke
+
+`.github/workflows/live-smoke.yml` runs daily at 07:00 UTC and on `workflow_dispatch`. It boots the server in-process via `WebApplicationFactory<Program>`, walks every MCP tool with `AAPL` (plus the unknown-symbol edge case for `get-quote`), and asserts `IsSuccess=true` or a tolerated typed failure (`PremiumRequired` / `NotFound`). On failure it opens an `upstream-drift`-labeled issue with the failing-run URL and a runbook pointer; de-dupes against any existing open `upstream-drift` issue from the last 24 hours.
+
+The live-smoke project is `tests/FinnHub.MCP.Server.Tests.LiveSmoke/`, tagged `[Trait("Category", "LiveSmoke")]` so `dotnet test` in CI (`dotnet.yml` and `release.yml`) excludes it via `--filter "Category!=LiveSmoke"`. Only the live-smoke workflow opts in. This protects the Finnhub quota on PR builds.
+
+Full runbook (failure causes, key rotation, local-run instructions) lives in `CONTRIBUTING.md → "Live-smoke runbook"`.
 
 ## Planning
 
-Roadmap and active design notes live in `.planning/`. Start with `.planning/ROADMAP.md` to see what's planned. Phase-level `SPEC.md` and `PLAN.md` documents describe ratified scope and approach; treat them as authoritative when they exist.
+Roadmap and active design notes live in `.planning/`:
 
-Intermediate working files (discussion notes, research dumps, review scratch) are gitignored — if you need them they live locally only.
+- `.planning/specs/01-product-surface.md` — Milestone 01, token-conscious tool fabric (envelope, middleware, HybridCache, P6 aggregation tools, P7 search-tools, P8 prompts)
+- `.planning/specs/02-distribution.md` — Milestone 02, hosted BYOK + AOT + Docker + dotnet tool + MCP registry
+
+Treat these as authoritative when they exist. Intermediate working files (discussion notes, research dumps, review scratch) are gitignored — if you need them they live locally only.
+
+Day-to-day tracking happens through GitHub Issues — see the next section. Issue bodies cite the relevant `.planning/specs/*.md` section in their `## Roadmap reference` field so the trace from issue → spec is always one click away.
+
+## Issue workflow
+
+All planned development is tracked through GitHub Issues with a strict hierarchy:
+
+```
+Epic            — milestone-sized initiative
+ └─ Feature     — discrete capability inside an Epic
+     └─ User Story — one end-user-facing increment, sized to a single PR
+         └─ Sub-task   — atomic engineering work item inside a Story
+```
+
+Authoritative doc: [`docs/ISSUE_WORKFLOW.md`](docs/ISSUE_WORKFLOW.md).
+
+- **Templates** — YAML forms in `.github/ISSUE_TEMPLATE/{epic,feature,user-story,sub-task}.yml` with required fields, field validation, and auto-applied type labels. Legacy markdown templates were removed (they shadowed the YAML); only `bug_report.md` and `feature_request.md` remain for community contributions. New work files into the YAML forms.
+- **GitHub Milestones** — `M1 — Token-Conscious Tool Fabric`, `M2 — Distribution & Hosting`, `M3 — Production Hardening`. Every Epic is assigned to one. Due dates currently unset; revisit per cycle.
+- **Labels** — type (`type:epic|feature|story|subtask`, applied by template), priority (`priority:critical|high|medium|low`), status (`status:backlog|ready|in-progress|blocked|in-review`), area (`area:tool|resource|prompt|meta-tool|transport|auth|cache|observability|hosting|distribution|testing|ci`), milestone (`milestone:m1-fabric|m2-distribution|m3-hardening`). Standard GitHub labels (`bug`, `documentation`, etc.) preserved for community use.
+- **Parent linkage** — use **both** GitHub's native sub-issues (via `gh api graphql -F query='mutation { addSubIssue(input: { issueId, subIssueId }) ... }'` — full snippet in `docs/ISSUE_WORKFLOW.md`) AND a textual `Parent <Level>: #N` line on the first line of the body. The first gives the GitHub UI parent-child navigation + progress bar; the second survives in markdown views and exports.
+- **Naming** — `[Epic <N>]`, `[Feature <N.M>]`, `[User Story <N.M.P>] As a <role>, I want <capability>`, `[Task] <verb-led short title>`. User Story bodies use the strict format `As a <role>, I want <capability>, so that <outcome>.` — no deviations.
+- **Branch naming** — `<type>/<short-description>` matching the Conventional Commits type the PR will land as (e.g. `feat/get-calendar-earnings-dispatch`, `chore/coverage-tightening`, `fix/live-smoke-unknown-symbol-assertion`).
+- **Quality bar** — no filler (`robust`, `seamless`, `leverage`, `comprehensive`, etc.), testable Given/When/Then acceptance criteria, self-contained bodies that an engineer can pick up cold, no fabricated requirements (mark `TBD` if the spec doesn't say).
+
+The 187-issue migration (Phase B, 2026-05-25) established this structure. The legacy issues `#42`, `#95`, `#96`, `#97` were closed with explanatory comments pointing to the new hierarchy. New work files into the existing hierarchy; new Epics get filed only for genuinely new milestone-sized initiatives.
 
 ## AI agent skills (gstack)
 
@@ -199,3 +238,7 @@ When any AI agent needs to browse, prefer gstack's `/browse` over `mcp__claude-i
 - **Don't ship synthetic-payload-only client tests.** Real Finnhub fixtures live under `tests/Fixtures/finnhub/`; use them. Mocks bypass URL resolution AND don't catch upstream shape drift.
 - **Don't guess the fix from a code-review reading when a live error is reported** — read the server log first (see "Debugging discipline" above). The financials misdiagnosis cost a release cycle for this exact reason.
 - **Don't `--squash` promotion PRs from `main → release`.** The squash collapses every inner commit into a single `chore(release): promote main to release` commit, hiding the `fix:` / `feat:` titles that drive release-please's version bump. release-please walks the squashed history, finds only `chore(release):` (hidden type), and skips releasing — leaving you with an empty release cycle that has to be repaired by a follow-up `--merge`. Always use `gh pr merge --merge` for promotion PRs. PR #178 was the canary; PR #180 was the recovery merge that brought the inner `fix(ci):` commits back into release's history.
+- **Don't file development work without a GitHub Issue.** Every PR that ships scope should reference one (`Closes #N` in the body). One-off bug fixes filed reactively are the only exception, and even those should get an issue retroactively if the fix is non-trivial.
+- **Don't bring back the markdown issue templates.** `epic.md`, `feature.md`, `user_story.md`, `task.md` were replaced by the YAML forms in PR #188 because the YAML versions enforce required fields and labels. The legacy files are gone; recreating them silently shadows the YAML and breaks the gate.
+- **Don't put a User Story under an Epic without an intermediate Feature.** The hierarchy is `Epic → Feature → User Story → Sub-task`. Skipping a level breaks the sub-issue parent navigation and the GitHub Project rollups. If the Feature is genuinely a placeholder, file it anyway with `TBD` content rather than pointing the Story at the Epic.
+- **Don't push directly to `release`.** Branch protection blocks it. Use a promotion PR with `--merge` (see above). The admin-merge escape valve exists for the Codecov-on-introducing-PR class only, not for routine pushes.


### PR DESCRIPTION
Brings CLAUDE.md in line with the state established over the recent session — issue workflow scaffolding (PR #188), live-smoke (PR #185), Phase B issue migration (187 issues), and branch protection on \`release\`.

## What changes in CLAUDE.md

### New sections

- **Issue workflow** — describes the Epic → Feature → User Story → Sub-task hierarchy, points to \`docs/ISSUE_WORKFLOW.md\`, lists the YAML templates, the 27-label set, the 3 GitHub milestones, parent-linking via both GraphQL sub-issues and textual \`Parent <Level>: #N\`, branch naming, quality bar. References the 187-issue Phase B migration and the closure of legacy issues #42 / #95 / #96 / #97.
- **Live smoke** — daily cron, in-process WebApplicationFactory, upstream-drift issue auto-open with 24h de-dup, \`--filter \"Category!=LiveSmoke\"\` exclusion from regular CI.

### Updated sections

- **Planning** — points at the two milestone specs as the authoritative roadmap, notes day-to-day tracking is now in GitHub Issues and that issue bodies cite spec sections in their \`Roadmap reference\` field.
- **Coverage** — baseline updated from 91% line / 84% branch (PR #176) to **98% / 90% / 100% method** (PR #179 + #180). Notes \`ServiceCollectionExtension\` is now also excluded alongside \`Program.cs\`.
- **CI section** — branch protection on \`release\` is now **enabled and enforced**, not just recommended.

### What not to do — four new entries

- Don't file dev work without a GitHub Issue (\`Closes #N\` in every PR body)
- Don't bring back the markdown issue templates (they shadow the YAML forms and bypass field validation)
- Don't skip levels in the Epic → Feature → User Story → Sub-task chain
- Don't push directly to \`release\` (branch protection blocks it; admin-merge is for Codecov-on-introducing-PR cases only)

## What does NOT change
- No application code touched
- No tests added or modified
- No issue / template / label changes (those landed in PR #188)

## Test plan
- [x] Markdown renders correctly in GitHub UI (preview)
- [x] Section structure preserved; only insertions and one-line updates to existing sections
- [x] All links and file references resolve