### PR TITLE
test(search): pin full /api/v1/search URL with Assert.Equal

### DIFF
--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
@@ -226,6 +226,43 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
         Assert.Contains("exchange=NASDAQ", requestUri);
     }
 
+    /// <summary>
+    /// Regression: pin the full on-wire URL so the slash-tolerant <c>BuildRequestUri</c>
+    /// in this client can't silently regress into the PR #169 bug class (relative path +
+    /// missing trailing slash on <c>BaseAddress</c> dropping <c>/v1</c>, surfacing as
+    /// HTML deserialization on the Finnhub landing page). Mirrors the
+    /// <c>Hits&lt;…&gt;Endpoint</c> pattern in every other client test.
+    /// </summary>
+    [Fact]
+    public async Task SearchSymbolAsync_HitsApiV1SearchEndpoint()
+    {
+        this._messageHandler.SetResponse(HttpStatusCode.OK, """{"count":0,"result":[]}""");
+
+        await this._sut.SearchSymbolAsync(
+            new SearchSymbolQuery { Query = "AAPL", QueryId = "q1" },
+            CancellationToken.None);
+
+        Assert.NotNull(this._messageHandler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/search?q=AAPL",
+            this._messageHandler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task SearchSymbolAsync_HitsApiV1SearchEndpoint_WithExchange()
+    {
+        this._messageHandler.SetResponse(HttpStatusCode.OK, """{"count":0,"result":[]}""");
+
+        await this._sut.SearchSymbolAsync(
+            new SearchSymbolQuery { Query = "AAPL", Exchange = "NASDAQ", QueryId = "q1" },
+            CancellationToken.None);
+
+        Assert.NotNull(this._messageHandler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/search?q=AAPL&exchange=NASDAQ",
+            this._messageHandler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
     [Fact]
     public async Task SearchSymbolAsync_WithEmptyResponse_ReturnsEmptySymbolsList()
     {


### PR DESCRIPTION
Closes #389 (CLEANUP.md Critical C1).

## Why
The 6 Wave A/B client tests each carry an `Hits<…>Endpoint` test pinning the full on-wire URL with `Assert.Equal` — required by CLAUDE.md MANDATORY rule because the slash-tolerant `BuildRequestUri` is the exact code shape where a PR #169-class bug (`/api/v1` → `/api` drop) could silently regress.

The Search client's only existing URI assertion uses `Assert.Contains`, which would not catch that.

## Changes
Two new tests mirroring `FinnHubProfilesApiClientTests.cs:108-120`:
- `SearchSymbolAsync_HitsApiV1SearchEndpoint` (bare query)
- `SearchSymbolAsync_HitsApiV1SearchEndpoint_WithExchange` (with the exchange query param)

## Test plan
- [x] Both new tests pass locally
- [x] `dotnet format --verify-no-changes` clean
- [x] Existing search tests unchanged