### PR TITLE
fix(config): add trailing slash to Development appsettings BaseUrl

### DIFF
--- a/src/FinnHub.MCP.Server/appsettings.Development.json
+++ b/src/FinnHub.MCP.Server/appsettings.Development.json
@@ -8,7 +8,7 @@
   "AllowedHosts": "*",
   "FinnHub": {
     "ApiKey": "",
-    "BaseUrl": "https://finnhub.io/api/v1",
+    "BaseUrl": "https://finnhub.io/api/v1/",
     "TimeoutSeconds": 10,
     "Endpoints": [
       {


### PR DESCRIPTION
Closes #395 (CLEANUP.md High H8).

## Why
`appsettings.Development.json` declared `FinnHub:BaseUrl` without the trailing slash that production has. `ConfigureFinnHubClient`'s defensive normalization saves it at runtime, but the file is the spec — and it should embody the right shape so a future contributor copying it for a new environment doesn't reintroduce the PR #169 bug class.

## Change
One character. `https://finnhub.io/api/v1` → `https://finnhub.io/api/v1/`. Now matches `appsettings.json`.

## Test plan
- [x] No code change needed — `ConfigureFinnHubClient` normalization remains in place per CLAUDE.md "don't strip the trailing-slash normalization"
- [x] `dotnet test` still passes (no test depends on the missing slash)