### PR TITLE
fix(peers): project once, derive explanation + total_count from projected result

### DIFF
--- a/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
@@ -66,15 +66,21 @@ public sealed class GetPeersTool(
 
             var result = await peersService.GetPeersAsync(query, cancellationToken);
 
+            // Project once, derive everything else from the projected result so
+            // total_count, explanation, and next_actions can't disagree on the
+            // peer count. Was a real bug: a 30-peer upstream result on a summary
+            // call produced data.total_count=10 but explanation="Found 30 peer(s)".
+            var projectedResult = ProjectByView(result, validatedView);
+
             logger.LogInformation(
                 "Peers completed for {Symbol} in {ElapsedMs}ms: {Count} peers",
-                validatedSymbol, stopwatch.ElapsedMilliseconds, result.Data?.TotalCount ?? 0);
+                validatedSymbol, stopwatch.ElapsedMilliseconds, projectedResult.Data?.TotalCount ?? 0);
 
             return EnvelopeFactory.FromResult(
-                ProjectByView(result, validatedView),
+                projectedResult,
                 validatedView,
-                nextActions: BuildNextActions(result, validatedSymbol),
-                explanation: BuildExplanation(result, validatedSymbol));
+                nextActions: BuildNextActions(projectedResult, validatedSymbol),
+                explanation: BuildExplanation(projectedResult, validatedSymbol));
         }
         catch (OperationCanceledException ex)
         {

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
@@ -112,4 +112,24 @@ public sealed class GetPeersToolTests
 
         Assert.Empty(envelope.NextActions);
     }
+
+    [Fact]
+    public async Task GetPeersAsync_SummaryView_ExplanationCountMatchesProjectedTotal()
+    {
+        // Regression: previously the tool projected `data.peers` to 10 but read
+        // the original 30-peer result for the explanation string, producing an
+        // envelope where data.total_count=10 but the explanation said
+        // "Found 30 peer(s)". Both must derive from the same projected result.
+        var manyPeers = Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray();
+        this._service
+            .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Result<GetPeersResponse>().Success(
+                new GetPeersResponse { Peers = manyPeers, Grouping = "industry" }));
+
+        var envelope = await this._sut.GetPeersAsync("AAPL", view: "summary");
+
+        Assert.Equal(10, envelope.Data!.TotalCount);
+        Assert.Contains("10 peer(s)", envelope.Explanation);
+        Assert.DoesNotContain("30 peer(s)", envelope.Explanation);
+    }
 }


### PR DESCRIPTION
Closes #393 (CLEANUP.md High H6).

## Why
`GetPeersTool.GetPeersAsync` projected `data.peers` to 10 but read the **original** 30-peer result for the explanation string. The envelope's `data.total_count` and the explanation string disagreed — a model that summarised "Apple has 30 industry peers" off the explanation and then iterated over the data saw 10.

## Change
Project once via `ProjectByView`, then pass the projected result to `BuildExplanation`, `BuildNextActions`, and the success-log count. All three now derive from the same source.

## Regression test
`GetPeersAsync_SummaryView_ExplanationCountMatchesProjectedTotal` — asserts the count in the explanation string matches `data.total_count` AND does not contain the original (un-projected) count.

## Test plan
- [x] All 9 GetPeers tests pass locally including the new one
- [x] No format regressions