### PR TITLE
fix(middleware): propagate declared view into budget-exceeded envelope

### DIFF
--- a/src/FinnHub.MCP.Server/Middleware/ToolInvocationMiddleware.cs
+++ b/src/FinnHub.MCP.Server/Middleware/ToolInvocationMiddleware.cs
@@ -71,7 +71,7 @@ public sealed class ToolInvocationMiddleware(
                 "tool {ToolName} view={View} tokens={ApproxTokens} budget={Budget} budget_exceeded=true duration_ms={ElapsedMs}",
                 toolName, declaredView, approxTokens, ceiling, stopwatch.ElapsedMilliseconds);
 
-            return BuildBudgetExceededResult(approxTokens, ceiling, rateLimit);
+            return BuildBudgetExceededResult(approxTokens, ceiling, declaredView, rateLimit);
         }
 
         PatchEnvelopeMetadata(result, approxTokens, rateLimit);
@@ -159,19 +159,32 @@ public sealed class ToolInvocationMiddleware(
         }
     }
 
-    private static CallToolResult BuildBudgetExceededResult(int approxTokens, int ceiling, RateLimitInfo? rateLimit)
+    private static CallToolResult BuildBudgetExceededResult(
+        int approxTokens,
+        int ceiling,
+        ToolView declaredView,
+        RateLimitInfo? rateLimit)
     {
+        // Recovery hint must match the view the caller actually asked for.
+        // Telling a Standard caller to "retry with view=standard" sends them
+        // around in a circle. Full never trips this path (int.MaxValue ceiling).
+        var recoveryHint = declaredView switch
+        {
+            ToolView.Standard => "Retry with view=full, or a sparser fields projection.",
+            _ => "Retry with view=standard, view=full, or a sparser fields projection."
+        };
+
         var envelope = new JsonObject
         {
             ["is_success"] = false,
             ["data"] = null,
             ["error_message"] = "response exceeded token budget for declared view",
             ["error_type"] = nameof(ResultErrorType.BudgetExceeded),
-            ["view"] = "summary",
+            ["view"] = declaredView.ToString().ToLowerInvariant(),
             ["next_actions"] = new JsonArray(),
             ["explanation"] =
                 $"Response would be ~{approxTokens} tokens against a {ceiling}-token ceiling. " +
-                "Retry with view=standard, view=full, or a sparser fields projection.",
+                recoveryHint,
             ["approx_tokens"] = approxTokens,
             ["rate_limit"] = BuildRateLimitNode(rateLimit),
             ["sentiment_source"] = null,

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Middleware/ToolInvocationMiddlewareTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Middleware/ToolInvocationMiddlewareTests.cs
@@ -99,6 +99,26 @@ public sealed class ToolInvocationMiddlewareTests
     }
 
     [Fact]
+    public async Task InvokeAsync_StandardOverBudget_EnvelopeReportsStandardView()
+    {
+        // Regression: BudgetExceeded envelope previously hardcoded view="summary"
+        // regardless of the actually-declared view, and the recovery hint advised
+        // "retry with view=standard" even for callers who already did. Now both
+        // the view field and the recovery hint must reflect the declared view.
+        var inner = MakeInnerTool(SmallEnvelopeJson());
+        var middleware = new ToolInvocationMiddleware(inner, new StubTokenEstimator(2_001), this._rateLimitTracker, this._logger);
+
+        var result = await middleware.InvokeAsync(MakeRequest("standard"), CancellationToken.None);
+
+        Assert.True(result.IsError);
+        var node = ReadEnvelope(result);
+        Assert.Equal("standard", (string?)node!["view"]);
+        var explanation = (string?)node["explanation"] ?? string.Empty;
+        Assert.DoesNotContain("view=standard", explanation);
+        Assert.Contains("view=full", explanation);
+    }
+
+    [Fact]
     public async Task InvokeAsync_TextOnlyResult_PatchesApproxTokens()
     {
         // The SDK's AIFunctionMcpServerTool emits the envelope into Content[0].Text


### PR DESCRIPTION
Closes #394 (CLEANUP.md High H7).

## Why
`BuildBudgetExceededResult` hardcoded `view: "summary"` regardless of what the caller actually asked for. The recovery hint advised "retry with view=standard" even for Standard callers — guiding them in a circle.

## Change
Pass `declaredView` through to `BuildBudgetExceededResult`, write its lowercase string form into the envelope's `view` field, and switch the recovery hint based on input view.

## Regression test
`InvokeAsync_StandardOverBudget_EnvelopeReportsStandardView` asserts:
- envelope's `view` is `"standard"` (not `"summary"`)
- recovery hint does NOT contain `view=standard` (would be circular)
- recovery hint DOES contain `view=full` (the right next step)

## Test plan
- [x] All 14 ToolInvocationMiddleware tests pass locally
- [x] No format regressions