### PR TITLE
fix(news): catch ApiClientPremiumRequiredException on company-news path

### DIFF
--- a/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
@@ -90,6 +90,16 @@ public sealed class NewsService(
                     ResultErrorType.NotFound)
                 : new Result<GetNewsPulseResponse>().Success(response);
         }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            // Finnhub has gated /news-sentiment behind premium before; if they ever do
+            // the same for /company-news, surface a typed PremiumRequired envelope so
+            // the LLM sees premium=true and can hint at an upgrade. Matches the 6
+            // sibling services that all carry this catch (FinancialsService.cs:48-52
+            // and similar).
+            logger.LogWarning(ex, "News endpoint is premium-locked for {Symbol}", query.Symbol);
+            return new Result<GetNewsPulseResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching news for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
@@ -98,6 +98,25 @@ public sealed class NewsServiceTests
     }
 
     [Fact]
+    public async Task GetPulseAsync_PremiumOnCompanyNews_ReturnsPremiumRequired()
+    {
+        // Regression: NewsService previously only caught ApiClientPremiumRequiredException
+        // on the sentiment call. If Finnhub ever gates /company-news behind premium
+        // (they've done this to /news-sentiment), the failure became `Unknown` instead
+        // of `PremiumRequired`, breaking the envelope's premium=true flag.
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .Returns(new NewsSentiment(null, null, null));
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/api/v1/company-news"));
+
+        var result = await this._sut.GetPulseAsync(query);
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PremiumRequired", result.ErrorType);
+    }
+
+    [Fact]
     public async Task GetPulseAsync_NoArticles_ReturnsNotFound()
     {
         var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "UNKN" };


### PR DESCRIPTION
Closes #392 (CLEANUP.md High H5).

## Why
`NewsService.GetPulseAsync` only handled premium-gating on the `/news-sentiment` call. The two `/company-news` calls had no premium catch, so a future Finnhub policy change would surface as `Unknown` instead of `PremiumRequired` — breaking the envelope's `premium=true` flag that the LLM consumer relies on.

## Change
Adds a `catch (ApiClientPremiumRequiredException ex)` arm mirroring `FinancialsService.cs:48-52` (the 6-service-precedent pattern). Logs at Warning, returns typed `PremiumRequired` failure.

## Regression test
`GetPulseAsync_PremiumOnCompanyNews_ReturnsPremiumRequired` mocks the client to throw `ApiClientPremiumRequiredException` on `GetCompanyNewsAsync` and asserts `result.ErrorType == "PremiumRequired"`.

## Test plan
- [x] All NewsService tests pass locally including the new one
- [x] No format regressions