### PR TITLE
refactor: propagate cancellation as typed exception instead of demoting to Unknown

### DIFF
--- a/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
@@ -65,6 +65,13 @@ public sealed class FinancialsService(
             logger.LogError(ex, "Failed to deserialize financials response for {Symbol}", query.Symbol);
             return new Result<GetFinancialsSnapshotResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected financials failure for {Symbol}", query.Symbol);

--- a/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
@@ -105,6 +105,13 @@ public sealed class NewsService(
             logger.LogError(ex, "Failed to deserialize news response for {Symbol}", query.Symbol);
             return new Result<GetNewsPulseResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected news failure for {Symbol}", query.Symbol);

--- a/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
@@ -71,6 +71,13 @@ public sealed class PeersService(
             logger.LogError(ex, "Failed to deserialize peers response for {Symbol}", query.Symbol);
             return new Result<GetPeersResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected peers failure for {Symbol}", query.Symbol);

--- a/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
@@ -71,6 +71,13 @@ public sealed class PricesService(
             logger.LogError(ex, "Failed to deserialize candle response for {Symbol}", query.Symbol);
             return new Result<GetPriceSummaryResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected candle failure for {Symbol}", query.Symbol);

--- a/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
@@ -69,6 +69,13 @@ public sealed class ProfilesService(
             logger.LogError(ex, "Failed to deserialize profile response for {Symbol}", query.Symbol);
             return new Result<GetCompanyProfileResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected profile failure for {Symbol}", query.Symbol);

--- a/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
@@ -73,6 +73,13 @@ public sealed class QuotesService(
             logger.LogError(ex, "Failed to deserialize quote response for {Symbol}", query.Symbol);
             return new Result<GetQuoteResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected quote failure for {Symbol}", query.Symbol);

--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
@@ -92,6 +92,13 @@ public sealed class SearchService(
             logger.Log(LogLevel.Error, ex, "Failed to deserialize response from FinnHub Api for query: {Query}", query.Query);
             return new Result<SearchSymbolResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected symbol search failure for query: {Query}", query.Query);

--- a/src/FinnHub.MCP.Server.Application/Symbols/SymbolResolver.cs
+++ b/src/FinnHub.MCP.Server.Application/Symbols/SymbolResolver.cs
@@ -144,6 +144,13 @@ public sealed partial class SymbolResolver(
             logger.LogError(ex, "Deserialisation error resolving symbol for input '{Input}'.", originalInput);
             return new Result<ResolvedSymbol>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
+        catch (ApiClientCancelledException)
+        {
+            // Caller-initiated cancellation — surface as a typed cancel rather than
+            // demoting to the catch-all "Unknown" failure that the base ApiClientException
+            // arm below produces.
+            throw;
+        }
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected resolver failure for input '{Input}'.", originalInput);

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Quotes/Services/QuotesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Quotes/Services/QuotesServiceTests.cs
@@ -81,4 +81,20 @@ public sealed class QuotesServiceTests
         Assert.False(result.IsSuccess);
         Assert.Equal("ServiceUnavailable", result.ErrorType);
     }
+
+    [Fact]
+    public async Task GetQuoteAsync_Cancelled_RethrowsTypedException_DoesNotDemoteToUnknown()
+    {
+        // Regression: previously the catch (ApiClientException ex) catch-all
+        // turned ApiClientCancelledException into ResultErrorType.Unknown with
+        // a generic "lookup failed unexpectedly" message — indistinguishable
+        // from a real upstream failure. Now the typed catch arm rethrows.
+        var query = new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetQuoteAsync(query, Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientCancelledException("cancelled by caller"));
+
+        var ex = await Assert.ThrowsAsync<ApiClientCancelledException>(
+            () => this._sut.GetQuoteAsync(query));
+        Assert.Equal("cancelled by caller", ex.Message);
+    }
 }


### PR DESCRIPTION
Closes #391 (CLEANUP.md High H4).

## Why
Every Application service ended with `catch (ApiClientException ex)` returning `Failure("... unexpectedly", Unknown)`. The infrastructure clients throw `ApiClientCancelledException` (subclass of `ApiClientException`) on caller-initiated cancellation, so cancellation was demoted to `Unknown` in the result envelope — indistinguishable from a real upstream failure.

## Decision
Option (a) from the Story: keep `ApiClientCancelledException` and catch it specifically in every service. Simpler than removing the typed exception entirely; preserves the existing taxonomy.

## Change
Adds `catch (ApiClientCancelledException) { throw; }` as the first catch arm in 8 services. The base `ApiClientException` arm now handles only genuinely unexpected subclasses.

Services touched: PricesService, FinancialsService, QuotesService, SearchService, NewsService, SymbolResolver, PeersService, ProfilesService.

## Regression test
`QuotesServiceTests.GetQuoteAsync_Cancelled_RethrowsTypedException_DoesNotDemoteToUnknown` covers the new contract. The 7 other services follow the same pattern; one representative test is sufficient at this level (per the M14 cleanup theme, we'll consolidate the per-service Facts).

## Test plan
- [x] All Application tests pass locally (5 QuotesService tests including the new one)
- [x] All other tests pass
- [x] `dotnet format --verify-no-changes` clean
- [x] No code in the tool layer needs changes — `ApiClientCancelledException` propagating up reaches the tool's existing `catch (Exception ex)` arm and is logged + rethrown (the next cleanup, M10, will downgrade the cancel log level)