### PR TITLE
test(app): switch 6 service tests to FakeFinnHubCache

### DIFF
--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Financials/Services/FinancialsServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Financials/Services/FinancialsServiceTests.cs
@@ -6,11 +6,11 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Financials.Clients;
 using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Financials.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -21,18 +21,11 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Financi
 public sealed class FinancialsServiceTests
 {
     private readonly IFinancialsApiClient _apiClient = Substitute.For<IFinancialsApiClient>();
-    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FakeFinnHubCache _cache = new();
     private readonly FinancialsService _sut;
 
     public FinancialsServiceTests()
     {
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<GetFinancialsSnapshotResponse>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetFinancialsSnapshotResponse>>>()(CancellationToken.None));
 
         this._sut = new FinancialsService(this._apiClient, this._cache, NullLogger<FinancialsService>.Instance);
     }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
@@ -5,11 +5,11 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.News.Clients;
 using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
 using FinnHub.MCP.Server.Application.News.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -20,27 +20,11 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.News.Se
 public sealed class NewsServiceTests
 {
     private readonly INewsApiClient _apiClient = Substitute.For<INewsApiClient>();
-    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FakeFinnHubCache _cache = new();
     private readonly NewsService _sut;
 
     public NewsServiceTests()
     {
-        // Cache delegates passthrough for both list and sentiment payloads.
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<IReadOnlyList<CompanyNewsArticle>>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<IReadOnlyList<CompanyNewsArticle>>>>()(CancellationToken.None));
-
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<NewsSentiment>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<NewsSentiment>>>()(CancellationToken.None));
 
         this._sut = new NewsService(this._apiClient, this._cache, NullLogger<NewsService>.Instance);
     }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Peers/Services/PeersServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Peers/Services/PeersServiceTests.cs
@@ -6,11 +6,11 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
 using FinnHub.MCP.Server.Application.Peers.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -21,19 +21,12 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Peers.S
 public sealed class PeersServiceTests
 {
     private readonly IPeersApiClient _apiClient = Substitute.For<IPeersApiClient>();
-    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FakeFinnHubCache _cache = new();
     private readonly PeersService _sut;
 
     public PeersServiceTests()
     {
         // Cache passes through to factory by default
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<GetPeersResponse>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetPeersResponse>>>()(CancellationToken.None));
 
         this._sut = new PeersService(this._apiClient, this._cache, NullLogger<PeersService>.Instance);
     }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Prices/Services/PricesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Prices/Services/PricesServiceTests.cs
@@ -6,11 +6,11 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Prices.Clients;
 using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
 using FinnHub.MCP.Server.Application.Prices.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -21,18 +21,11 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Prices.
 public sealed class PricesServiceTests
 {
     private readonly IPricesApiClient _apiClient = Substitute.For<IPricesApiClient>();
-    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FakeFinnHubCache _cache = new();
     private readonly PricesService _sut;
 
     public PricesServiceTests()
     {
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<GetPriceSummaryResponse>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetPriceSummaryResponse>>>()(CancellationToken.None));
 
         this._sut = new PricesService(this._apiClient, this._cache, NullLogger<PricesService>.Instance);
     }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Profiles/Services/ProfilesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Profiles/Services/ProfilesServiceTests.cs
@@ -5,11 +5,11 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Profiles.Clients;
 using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
 using FinnHub.MCP.Server.Application.Profiles.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -20,18 +20,11 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Profile
 public sealed class ProfilesServiceTests
 {
     private readonly IProfilesApiClient _apiClient = Substitute.For<IProfilesApiClient>();
-    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FakeFinnHubCache _cache = new();
     private readonly ProfilesService _sut;
 
     public ProfilesServiceTests()
     {
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<GetCompanyProfileResponse>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetCompanyProfileResponse>>>()(CancellationToken.None));
 
         this._sut = new ProfilesService(this._apiClient, this._cache, NullLogger<ProfilesService>.Instance);
     }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Quotes/Services/QuotesServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Quotes/Services/QuotesServiceTests.cs
@@ -6,11 +6,11 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
-using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Quotes.Clients;
 using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
 using FinnHub.MCP.Server.Application.Quotes.Services;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
 using Microsoft.Extensions.Logging.Abstractions;
 using NSubstitute;
 using NSubstitute.ExceptionExtensions;
@@ -21,18 +21,11 @@ namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Quotes.
 public sealed class QuotesServiceTests
 {
     private readonly IQuotesApiClient _apiClient = Substitute.For<IQuotesApiClient>();
-    private readonly IFinnHubCache _cache = Substitute.For<IFinnHubCache>();
+    private readonly FakeFinnHubCache _cache = new();
     private readonly QuotesService _sut;
 
     public QuotesServiceTests()
     {
-        this._cache
-            .GetOrCreateAsync(
-                Arg.Any<string>(),
-                Arg.Any<CacheTier>(),
-                Arg.Any<Func<CancellationToken, ValueTask<GetQuoteResponse>>>(),
-                Arg.Any<CancellationToken>())
-            .Returns(call => call.Arg<Func<CancellationToken, ValueTask<GetQuoteResponse>>>()(CancellationToken.None));
 
         this._sut = new QuotesService(this._apiClient, this._cache, NullLogger<QuotesService>.Instance);
     }
@@ -54,6 +47,26 @@ public sealed class QuotesServiceTests
 
         Assert.True(result.IsSuccess);
         Assert.Equal(261.74, result.Data!.Current);
+    }
+
+    [Fact]
+    public async Task GetQuoteAsync_TwoIdenticalCalls_HitsApiClientExactlyOnce()
+    {
+        // Real cache semantics — FakeFinnHubCache returns the cached value on
+        // the second call instead of re-invoking the factory. This locks in
+        // the "two consecutive identical calls hit upstream exactly once"
+        // contract from .planning/specs/01-product-surface.md §3 P2 — the
+        // contract every Wave A/B service was supposed to satisfy but only
+        // SearchService had a regression test for.
+        var query = new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetQuoteAsync(query, Arg.Any<CancellationToken>())
+            .Returns(new GetQuoteResponse { Symbol = "AAPL", Current = 261.74 });
+
+        await this._sut.GetQuoteAsync(query);
+        await this._sut.GetQuoteAsync(query);
+
+        Assert.Equal(1, this._cache.FactoryInvocationCount);
+        await this._apiClient.Received(1).GetQuoteAsync(query, Arg.Any<CancellationToken>());
     }
 
     [Fact]


### PR DESCRIPTION
Closes #398 (CLEANUP.md High H11).

## Why
Every Wave A/B service test repeated the same 8-line `IFinnHubCache` Substitute boilerplate. The existing `FakeFinnHubCache` in `TestDoubles/` — already used by `SearchServiceTests` + `SymbolResolverTests` — solves it for free AND gives every test the `FactoryInvocationCount` affordance to assert real cache semantics ("two identical calls hit upstream exactly once").

## Change
- 6 service test classes: `Substitute.For<IFinnHubCache>()` → `new FakeFinnHubCache()`
- Removed cache-passthrough `Returns(...)` boilerplate from each constructor (~50 lines net)
- Removed now-unused `using FinnHub.MCP.Server.Application.Caching;` (3 files)
- Added `GetQuoteAsync_TwoIdenticalCalls_HitsApiClientExactlyOnce` to `QuotesServiceTests` as the representative demonstration

## Test plan
- [x] All 134 Application tests pass locally
- [x] `dotnet format --verify-no-changes` clean
- [x] Net diff: 12 insertions, 57 deletions across 6 files (per the pre-format-strip)