### PR TITLE
fix(infra): preserve inner exception, use ServiceUnavailable for transport failures

### DIFF
--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
@@ -70,7 +70,10 @@ public sealed class FinnHubFinancialsApiClient : IFinancialsApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub financials failed: {Uri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub financials failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub financials failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/News/FinnHubNewsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/News/FinnHubNewsApiClient.cs
@@ -136,7 +136,10 @@ public sealed class FinnHubNewsApiClient : INewsApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub news failed: {Uri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub news failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub news failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Peers/FinnHubPeersApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Peers/FinnHubPeersApiClient.cs
@@ -70,7 +70,10 @@ public sealed class FinnHubPeersApiClient : IPeersApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub peers failed: {Uri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub peers failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub peers failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Prices/FinnHubPricesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Prices/FinnHubPricesApiClient.cs
@@ -74,7 +74,10 @@ public sealed class FinnHubPricesApiClient : IPricesApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub candle failed: {Uri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub candle failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub candle failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Profiles/FinnHubProfilesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Profiles/FinnHubProfilesApiClient.cs
@@ -66,7 +66,10 @@ public sealed class FinnHubProfilesApiClient : IProfilesApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub profile failed: {Uri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub profile failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub profile failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Quotes/FinnHubQuotesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Quotes/FinnHubQuotesApiClient.cs
@@ -64,7 +64,10 @@ public sealed class FinnHubQuotesApiClient : IQuotesApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub quote failed: {Uri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub quote failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub quote failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -169,7 +169,10 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient
         catch (HttpRequestException ex)
         {
             this._logger.LogError(ex, "HTTP request to FinnHub API failed. URI: {RequestUri}", requestUri);
-            throw new ApiClientHttpException($"HTTP request to FinnHub API failed: {requestUri}", HttpStatusCode.InternalServerError);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub API failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
         }
         catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
         {

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Quotes/FinnHubQuotesApiClientTests.cs
@@ -118,13 +118,24 @@ public sealed class FinnHubQuotesApiClientTests : IDisposable
     }
 
     [Fact]
-    public async Task GetQuoteAsync_HttpRequestException_ThrowsHttpException()
+    public async Task GetQuoteAsync_HttpRequestException_PreservesInnerExceptionAndUsesServiceUnavailable()
     {
-        this._handler.SetException(new HttpRequestException("network unreachable"));
+        // Regression: previously this catch block constructed
+        // ApiClientHttpException(..., HttpStatusCode.InternalServerError) with no
+        // inner exception. The wrapped HttpRequestException's stack trace and
+        // underlying socket/DNS detail were dropped (undermining CLAUDE.md
+        // "read the server logs first" debugging discipline), and the status
+        // code falsely claimed Finnhub returned 500 when the request never
+        // reached Finnhub (DNS failure, socket reset, TLS error).
+        var network = new HttpRequestException("DNS resolution failed");
+        this._handler.SetException(network);
 
-        await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetQuoteAsync(
+        var ex = await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetQuoteAsync(
             new GetQuoteQuery { QueryId = "q1", Symbol = "AAPL" },
             CancellationToken.None));
+
+        Assert.Same(network, ex.InnerException);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
     }
 
     [Fact]


### PR DESCRIPTION
Closes #390 (partial — see scope note) (CLEANUP.md High H2 + H3).

## Why
All 7 `FinnHub<Group>ApiClient` classes caught `HttpRequestException` and threw `ApiClientHttpException(..., HttpStatusCode.InternalServerError)` with no `innerException` argument. Two problems compounded:

1. **Inner exception dropped** — the wrapped exception's stack trace + underlying socket/DNS detail were dropped before reaching the logs. Undermines CLAUDE.md's "read server logs first" debugging discipline. The financials misdiagnosis (PR #166 vs #169) was the canonical example of how that costs release cycles.
2. **Wrong status code** — `HttpRequestException` from `HttpClient.SendAsync` means the request never got a response. Wrapping with `InternalServerError` falsely told the rest of the stack "Finnhub returned 500" — indistinguishable from `HandleErrorAsync` wrapping a real upstream 500.

## Change
- All 7 clients: `ApiClientHttpException(..., HttpStatusCode.InternalServerError)` → `ApiClientHttpException(..., HttpStatusCode.ServiceUnavailable, innerException: ex)`
- Status code `ServiceUnavailable` (503) signals "couldn't reach Finnhub" distinct from "Finnhub said 500"
- Inner exception now reaches the logger

## Scope split
Story #390's third acceptance criterion (`HttpResponseMessage` dispose via `using var response`) is **deferred to #406 / F5.9**. Rationale: F5.9's shared `FinnHubResponseErrors` extraction is the right place to do the dispose pattern across all 7 clients cleanly, including the News client restructure. Doing dispose now would put per-client `using` plumbing in place that #406 would immediately rip out. Better to land #390's debugging-fidelity wins now (high value, mechanical) and roll dispose into #406 (architectural).

The remaining work is captured in #406's acceptance criteria.

## Regression test
`FinnHubQuotesApiClientTests.GetQuoteAsync_HttpRequestException_PreservesInnerExceptionAndUsesServiceUnavailable` asserts both `ex.InnerException` is the original `HttpRequestException` AND `ex.StatusCode == ServiceUnavailable`. One representative client test is sufficient at this level; the other 6 follow the identical pattern under the same shared catch shape, which will be enforced in #406's shared helper.

## Test plan
- [x] All 93 Infrastructure tests pass locally
- [x] Build clean (0 warnings)
- [x] `dotnet format --verify-no-changes` clean