### PR TITLE
test(infra): adopt captured Finnhub fixtures in 5 client tests

### DIFF
--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/News/FinnHubNewsApiClientTests.cs
@@ -9,6 +9,7 @@ using System.Net;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Infrastructure.Clients.News;
+using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -189,6 +190,27 @@ public sealed class FinnHubNewsApiClientTests : IDisposable
 
         await Assert.ThrowsAsync<ApiClientCancelledException>(() =>
             this._sut.GetSentimentAsync("AAPL", cts.Token));
+    }
+
+    /// <summary>
+    /// Real captured Finnhub /company-news response for AAPL (155KB, many articles).
+    /// Proves the parser handles the real wire shape — synthetic CompanyNewsPayload
+    /// above only covers 2 articles. Catches Finnhub shape drift on the next fixture
+    /// refresh — see CLAUDE.md "Don't ship synthetic-payload-only client tests".
+    /// </summary>
+    [Fact]
+    public async Task GetCompanyNewsAsync_RealAaplFixture_ParsesAllArticles()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, Fixture.LoadFinnHub("company-news-AAPL"));
+
+        var result = await this._sut.GetCompanyNewsAsync(
+            "AAPL",
+            new DateOnly(2024, 1, 1),
+            new DateOnly(2024, 12, 31),
+            CancellationToken.None);
+
+        Assert.NotEmpty(result);
+        Assert.All(result, a => Assert.False(string.IsNullOrEmpty(a.Headline)));
     }
 
     public void Dispose()

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Peers/FinnHubPeersApiClientTests.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
 using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
+using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -146,6 +147,24 @@ public sealed class FinnHubPeersApiClientTests : IDisposable
         await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetPeersAsync(
             new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
             cts.Token));
+    }
+
+    /// <summary>
+    /// Real captured Finnhub /stock/peers response for AAPL (industry grouping).
+    /// Catches Finnhub shape drift on the next fixture refresh — see CLAUDE.md
+    /// "Don't ship synthetic-payload-only client tests".
+    /// </summary>
+    [Fact]
+    public async Task GetPeersAsync_RealAaplFixture_ParsesPeerArray()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, Fixture.LoadFinnHub("peers-AAPL-industry"));
+
+        var result = await this._sut.GetPeersAsync(
+            new GetPeersQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.NotEmpty(result.Peers);
+        Assert.Contains("AAPL", result.Peers);
     }
 
     public void Dispose()

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Prices/FinnHubPricesApiClientTests.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
 using FinnHub.MCP.Server.Infrastructure.Clients.Prices;
+using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -172,6 +173,23 @@ public sealed class FinnHubPricesApiClientTests : IDisposable
         await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetSummaryAsync(
             new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
             cts.Token));
+    }
+
+    /// <summary>
+    /// Real captured Finnhub /stock/candle response — currently the premium-locked
+    /// error shape (free-tier accounts can't reach this endpoint). When served as a
+    /// 403 Forbidden, the client correctly throws ApiClientPremiumRequiredException.
+    /// Re-capture the fixture once a paid key is available to replace with happy-path
+    /// candle data.
+    /// </summary>
+    [Fact]
+    public async Task GetSummaryAsync_RealAaplCandleFixture_PremiumLocked_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, Fixture.LoadFinnHub("candle-AAPL"));
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetSummaryAsync(
+            new GetPriceSummaryQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None));
     }
 
     public void Dispose()

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Profiles/FinnHubProfilesApiClientTests.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
 using FinnHub.MCP.Server.Infrastructure.Clients.Profiles;
+using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -158,6 +159,29 @@ public sealed class FinnHubProfilesApiClientTests : IDisposable
         await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetProfileAsync(
             new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
             cts.Token));
+    }
+
+    /// <summary>
+    /// Real captured Finnhub /stock/profile2 response for AAPL. Proves the parser
+    /// handles the actual wire shape including fields the synthetic SamplePayload
+    /// doesn't carry (e.g. estimateCurrency). Catches Finnhub shape drift on the
+    /// next fixture refresh — see CLAUDE.md "Don't ship synthetic-payload-only client tests".
+    /// </summary>
+    [Fact]
+    public async Task GetProfileAsync_RealAaplFixture_MapsAllFields()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, Fixture.LoadFinnHub("profile-AAPL"));
+
+        var result = await this._sut.GetProfileAsync(
+            new GetCompanyProfileQuery { QueryId = "q1", Symbol = "AAPL" },
+            CancellationToken.None);
+
+        Assert.Equal("AAPL", result.Ticker);
+        Assert.Equal("US", result.Country);
+        Assert.Equal("USD", result.Currency);
+        Assert.False(string.IsNullOrEmpty(result.Exchange));
+        Assert.False(string.IsNullOrEmpty(result.Industry));
+        Assert.True(result.MarketCap > 0);
     }
 
     public void Dispose()

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
@@ -13,6 +13,7 @@ using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using NSubstitute;
@@ -403,6 +404,27 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
         Assert.Equal(string.Empty, result.Symbols[0].Description);
         Assert.Equal(string.Empty, result.Symbols[0].DisplaySymbol);
         Assert.Equal(string.Empty, result.Symbols[0].Type);
+    }
+
+    /// <summary>
+    /// Real captured Finnhub /search?q=apple response. Catches Finnhub shape drift
+    /// on the next fixture refresh — see CLAUDE.md "Don't ship synthetic-payload-only
+    /// client tests". The synthetic JsonSerializer.Serialize round-trips in the other
+    /// tests assert the parser handles the shape we just generated; this proves it
+    /// handles the actual upstream shape.
+    /// </summary>
+    [Fact]
+    public async Task SearchSymbolAsync_RealAppleFixture_ParsesAllSymbols()
+    {
+        this._messageHandler.SetResponse(HttpStatusCode.OK, Fixture.LoadFinnHub("search-apple"));
+
+        var result = await this._sut.SearchSymbolAsync(
+            new SearchSymbolQuery { Query = "apple", QueryId = "q1" },
+            CancellationToken.None);
+
+        Assert.NotEmpty(result.Symbols);
+        Assert.Contains(result.Symbols, s => s.Symbol == "AAPL");
+        Assert.All(result.Symbols, s => Assert.False(string.IsNullOrEmpty(s.Symbol)));
     }
 
     public void Dispose()


### PR DESCRIPTION
Closes #396 (CLEANUP.md High H14).

## Why
CLAUDE.md "Don't ship synthetic-payload-only client tests": **real captures are non-negotiable**. PR #167 captured fixtures for all 7 clients but only Quotes + Financials adopted them. The other 5 shipped with synthetic constants or `JsonSerializer.Serialize` round-trips — exactly the shape-drift regression vector CLAUDE.md cites PR #166 and PR #167 against.

## Change
Added a `Real<...>Fixture` test to each of the 5 holdout client tests, mirroring `FinnHubQuotesApiClientTests.cs:42-57`:

| Client | Fixture | What it asserts |
|---|---|---|
| Profiles | `profile-AAPL.json` | real shape parses (country, currency, exchange, industry, market cap > 0) |
| News | `company-news-AAPL.json` (155KB) | many real articles parse with non-empty headlines |
| Peers | `peers-AAPL-industry.json` | real flat ticker array; contains AAPL |
| Prices | `candle-AAPL.json` (premium-error fixture) | client throws `PremiumRequired` when served as 403 — re-capture with paid key for happy-path later |
| Search | `search-apple.json` | real symbol array parses; contains AAPL |

Existing synthetic tests preserved — they cover edge cases (empty body, null fields, premium-error path with hand-coded JSON).

## Test plan
- [x] All 98 Infrastructure tests pass locally (was 93 before this PR — added 5)
- [x] `dotnet format --verify-no-changes` clean
- [x] No code change to clients; just test additions