### PR TITLE
refactor: convert Result<T>.Success/.Failure to static factories

### DIFF
--- a/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
@@ -43,27 +43,27 @@ public sealed class FinancialsService(
 
             logger.LogInformation("Retrieved financials snapshot for {Symbol}", query.Symbol);
 
-            return new Result<GetFinancialsSnapshotResponse>().Success(response);
+            return Result<GetFinancialsSnapshotResponse>.Success(response);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
             logger.LogWarning(ex, "Premium-only financials endpoint for {Symbol}", query.Symbol);
-            return new Result<GetFinancialsSnapshotResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<GetFinancialsSnapshotResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching financials for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
-            return new Result<GetFinancialsSnapshotResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<GetFinancialsSnapshotResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "Financials request timed out for {Symbol}", query.Symbol);
-            return new Result<GetFinancialsSnapshotResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<GetFinancialsSnapshotResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Failed to deserialize financials response for {Symbol}", query.Symbol);
-            return new Result<GetFinancialsSnapshotResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<GetFinancialsSnapshotResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -75,7 +75,7 @@ public sealed class FinancialsService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected financials failure for {Symbol}", query.Symbol);
-            return new Result<GetFinancialsSnapshotResponse>().Failure("Financials lookup failed unexpectedly");
+            return Result<GetFinancialsSnapshotResponse>.Failure("Financials lookup failed unexpectedly");
         }
     }
 

--- a/src/FinnHub.MCP.Server.Application/Models/Result.cs
+++ b/src/FinnHub.MCP.Server.Application/Models/Result.cs
@@ -39,6 +39,8 @@ namespace FinnHub.MCP.Server.Application.Models;
 /// </code>
 /// </example>
 [ExcludeFromCodeCoverage]
+[SuppressMessage("Design", "CA1000:Do not declare static members on generic types",
+    Justification = "Success/Failure are factory methods returning Result<T> itself — the established Result-pattern convention. T is inferred from the data argument on Success(data); Failure<T>(...) requires an explicit type argument. A non-generic helper class would force every Success call to also specify the type argument, which is the worse ergonomic tradeoff.")]
 public sealed class Result<T>
 {
     /// <summary>
@@ -86,18 +88,14 @@ public sealed class Result<T>
     /// </summary>
     /// <param name="data">The data to include in the successful result.</param>
     /// <returns>A new <see cref="Result{T}"/> instance representing a successful operation.</returns>
-    /// <remarks>
-    /// This method creates a result where <see cref="IsSuccess"/> is <c>true</c> and
-    /// <see cref="Data"/> contains the provided value. Error properties will be <c>null</c>.
-    /// </remarks>
     /// <example>
     /// <code>
-    /// var result = new Result&lt;User&gt;().Success(new User { Name = "John Doe" });
+    /// var result = Result&lt;User&gt;.Success(new User { Name = "John Doe" });
     /// Console.WriteLine(result.IsSuccess); // True
     /// Console.WriteLine(result.Data.Name); // "John Doe"
     /// </code>
     /// </example>
-    public Result<T> Success(T data) => new()
+    public static Result<T> Success(T data) => new()
     {
         IsSuccess = true,
         Data = data
@@ -109,20 +107,15 @@ public sealed class Result<T>
     /// <param name="errorMessage">A descriptive message explaining why the operation failed.</param>
     /// <param name="errorType">The category of error that occurred. Defaults to <see cref="ResultErrorType.Unknown"/>.</param>
     /// <returns>A new <see cref="Result{T}"/> instance representing a failed operation.</returns>
-    /// <remarks>
-    /// This method creates a result where <see cref="IsSuccess"/> is <c>false</c>,
-    /// <see cref="ErrorMessage"/> contains the provided message, and <see cref="ErrorType"/>
-    /// contains the string representation of the error type. The <see cref="Data"/> property will be <c>null</c>.
-    /// </remarks>
     /// <example>
     /// <code>
-    /// var result = new Result&lt;User&gt;().Failure("User not found", ResultErrorType.NotFound);
+    /// var result = Result&lt;User&gt;.Failure("User not found", ResultErrorType.NotFound);
     /// Console.WriteLine(result.IsSuccess); // False
     /// Console.WriteLine(result.ErrorMessage); // "User not found"
     /// Console.WriteLine(result.ErrorType); // "NotFound"
     /// </code>
     /// </example>
-    public Result<T> Failure(
+    public static Result<T> Failure(
         string errorMessage,
         ResultErrorType errorType = ResultErrorType.Unknown) => new()
         {

--- a/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
@@ -85,10 +85,10 @@ public sealed class NewsService(
                 query.Symbol, response.Count, prevWeek.Count, response.SentimentSource ?? "none");
 
             return response.Count == 0
-                ? new Result<GetNewsPulseResponse>().Failure(
+                ? Result<GetNewsPulseResponse>.Failure(
                     $"No news found for {query.Symbol} in the past week.",
                     ResultErrorType.NotFound)
-                : new Result<GetNewsPulseResponse>().Success(response);
+                : Result<GetNewsPulseResponse>.Success(response);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
@@ -98,22 +98,22 @@ public sealed class NewsService(
             // sibling services that all carry this catch (FinancialsService.cs:48-52
             // and similar).
             logger.LogWarning(ex, "News endpoint is premium-locked for {Symbol}", query.Symbol);
-            return new Result<GetNewsPulseResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<GetNewsPulseResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching news for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
-            return new Result<GetNewsPulseResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<GetNewsPulseResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "News request timed out for {Symbol}", query.Symbol);
-            return new Result<GetNewsPulseResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<GetNewsPulseResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Failed to deserialize news response for {Symbol}", query.Symbol);
-            return new Result<GetNewsPulseResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<GetNewsPulseResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -125,7 +125,7 @@ public sealed class NewsService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected news failure for {Symbol}", query.Symbol);
-            return new Result<GetNewsPulseResponse>().Failure("News pulse failed unexpectedly");
+            return Result<GetNewsPulseResponse>.Failure("News pulse failed unexpectedly");
         }
     }
 

--- a/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
@@ -46,30 +46,30 @@ public sealed class PeersService(
                 response.TotalCount, query.Symbol, query.Grouping);
 
             return response.HasResults
-                ? new Result<GetPeersResponse>().Success(response)
-                : new Result<GetPeersResponse>().Failure(
+                ? Result<GetPeersResponse>.Success(response)
+                : Result<GetPeersResponse>.Failure(
                     $"No peers found for {query.Symbol}.",
                     ResultErrorType.NotFound);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
             logger.LogWarning(ex, "Premium-only peers endpoint for {Symbol}", query.Symbol);
-            return new Result<GetPeersResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<GetPeersResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching peers for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
-            return new Result<GetPeersResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<GetPeersResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "Peers request timed out for {Symbol}", query.Symbol);
-            return new Result<GetPeersResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<GetPeersResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Failed to deserialize peers response for {Symbol}", query.Symbol);
-            return new Result<GetPeersResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<GetPeersResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -81,7 +81,7 @@ public sealed class PeersService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected peers failure for {Symbol}", query.Symbol);
-            return new Result<GetPeersResponse>().Failure("Peers lookup failed unexpectedly");
+            return Result<GetPeersResponse>.Failure("Peers lookup failed unexpectedly");
         }
     }
 

--- a/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
@@ -46,30 +46,30 @@ public sealed class PricesService(
                 query.Symbol, query.Period, response.CandleCount);
 
             return response.CandleCount > 0
-                ? new Result<GetPriceSummaryResponse>().Success(response)
-                : new Result<GetPriceSummaryResponse>().Failure(
+                ? Result<GetPriceSummaryResponse>.Success(response)
+                : Result<GetPriceSummaryResponse>.Failure(
                     $"No price data for {query.Symbol} over {query.Period}.",
                     ResultErrorType.NotFound);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
             logger.LogWarning(ex, "Premium-only candle endpoint for {Symbol}", query.Symbol);
-            return new Result<GetPriceSummaryResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<GetPriceSummaryResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching candles for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
-            return new Result<GetPriceSummaryResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<GetPriceSummaryResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "Candle request timed out for {Symbol}", query.Symbol);
-            return new Result<GetPriceSummaryResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<GetPriceSummaryResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Failed to deserialize candle response for {Symbol}", query.Symbol);
-            return new Result<GetPriceSummaryResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<GetPriceSummaryResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -81,7 +81,7 @@ public sealed class PricesService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected candle failure for {Symbol}", query.Symbol);
-            return new Result<GetPriceSummaryResponse>().Failure("Price summary failed unexpectedly");
+            return Result<GetPriceSummaryResponse>.Failure("Price summary failed unexpectedly");
         }
     }
 

--- a/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
@@ -44,30 +44,30 @@ public sealed class ProfilesService(
             logger.LogInformation("Retrieved profile for {Symbol}", query.Symbol);
 
             return string.IsNullOrEmpty(response.Name)
-                ? new Result<GetCompanyProfileResponse>().Failure(
+                ? Result<GetCompanyProfileResponse>.Failure(
                     $"No profile found for {query.Symbol}.",
                     ResultErrorType.NotFound)
-                : new Result<GetCompanyProfileResponse>().Success(response);
+                : Result<GetCompanyProfileResponse>.Success(response);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
             logger.LogWarning(ex, "Premium-only profile endpoint for {Symbol}", query.Symbol);
-            return new Result<GetCompanyProfileResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<GetCompanyProfileResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching profile for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
-            return new Result<GetCompanyProfileResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<GetCompanyProfileResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "Profile request timed out for {Symbol}", query.Symbol);
-            return new Result<GetCompanyProfileResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<GetCompanyProfileResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Failed to deserialize profile response for {Symbol}", query.Symbol);
-            return new Result<GetCompanyProfileResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<GetCompanyProfileResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -79,7 +79,7 @@ public sealed class ProfilesService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected profile failure for {Symbol}", query.Symbol);
-            return new Result<GetCompanyProfileResponse>().Failure("Profile lookup failed unexpectedly");
+            return Result<GetCompanyProfileResponse>.Failure("Profile lookup failed unexpectedly");
         }
     }
 }

--- a/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
@@ -48,30 +48,30 @@ public sealed class QuotesService(
             // Finnhub returns all-zero/null for unknown symbols. Anything with a
             // non-zero current price OR a real timestamp is treated as a live quote.
             return (response.Current is > 0) || response.TimestampUtc is not null
-                ? new Result<GetQuoteResponse>().Success(response)
-                : new Result<GetQuoteResponse>().Failure(
+                ? Result<GetQuoteResponse>.Success(response)
+                : Result<GetQuoteResponse>.Failure(
                     $"No live quote for {query.Symbol}.",
                     ResultErrorType.NotFound);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
             logger.LogWarning(ex, "Premium-only quote endpoint for {Symbol}", query.Symbol);
-            return new Result<GetQuoteResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<GetQuoteResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error fetching quote for {Symbol} (status: {Status})", query.Symbol, ex.StatusCode);
-            return new Result<GetQuoteResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<GetQuoteResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "Quote request timed out for {Symbol}", query.Symbol);
-            return new Result<GetQuoteResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<GetQuoteResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Failed to deserialize quote response for {Symbol}", query.Symbol);
-            return new Result<GetQuoteResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<GetQuoteResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -83,7 +83,7 @@ public sealed class QuotesService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected quote failure for {Symbol}", query.Symbol);
-            return new Result<GetQuoteResponse>().Failure("Quote lookup failed unexpectedly");
+            return Result<GetQuoteResponse>.Failure("Quote lookup failed unexpectedly");
         }
     }
 }

--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
@@ -65,8 +65,8 @@ public sealed class SearchService(
                 response.TotalCount, query);
 
             return response.HasResults
-                ? new Result<SearchSymbolResponse>().Success(response)
-                : new Result<SearchSymbolResponse>().Failure("No search symbol(s) found.", ResultErrorType.NotFound);
+                ? Result<SearchSymbolResponse>.Success(response)
+                : Result<SearchSymbolResponse>.Failure("No search symbol(s) found.", ResultErrorType.NotFound);
         }
         catch (ApiClientPremiumRequiredException ex)
         {
@@ -75,22 +75,22 @@ public sealed class SearchService(
                 "Premium-only endpoint hit for query: {Query} (Endpoint: {Endpoint})",
                 query.Query,
                 ex.Endpoint);
-            return new Result<SearchSymbolResponse>().Failure(ex.Message, ResultErrorType.PremiumRequired);
+            return Result<SearchSymbolResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error from FinnHub API for query: {Query} (Status: {StatusCode})", query.Query, ex.StatusCode.ToString());
-            return new Result<SearchSymbolResponse>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<SearchSymbolResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.Log(LogLevel.Warning, ex, "Request to FinnHub Api timed out for query: {Query}", query.Query);
-            return new Result<SearchSymbolResponse>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<SearchSymbolResponse>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.Log(LogLevel.Error, ex, "Failed to deserialize response from FinnHub Api for query: {Query}", query.Query);
-            return new Result<SearchSymbolResponse>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<SearchSymbolResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -102,7 +102,7 @@ public sealed class SearchService(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected symbol search failure for query: {Query}", query.Query);
-            return new Result<SearchSymbolResponse>().Failure("Symbol search failed unexpectedly");
+            return Result<SearchSymbolResponse>.Failure("Symbol search failed unexpectedly");
         }
         catch (Exception ex)
         {

--- a/src/FinnHub.MCP.Server.Application/Symbols/SymbolResolver.cs
+++ b/src/FinnHub.MCP.Server.Application/Symbols/SymbolResolver.cs
@@ -66,7 +66,7 @@ public sealed partial class SymbolResolver(
         {
             var resolved = new ResolvedSymbol(normalised, normalised, Exchange: null, Confidence: 1.0d, Candidates: []);
             this.LogResolution(input, "canonical", resolved);
-            return new Result<ResolvedSymbol>().Success(resolved);
+            return Result<ResolvedSymbol>.Success(resolved);
         }
 
         if (SuffixRegex().IsMatch(normalised))
@@ -74,7 +74,7 @@ public sealed partial class SymbolResolver(
             var parts = normalised.Split('.');
             var resolved = new ResolvedSymbol(parts[0], normalised, Exchange: parts[1], Confidence: 1.0d, Candidates: []);
             this.LogResolution(input, "suffix", resolved);
-            return new Result<ResolvedSymbol>().Success(resolved);
+            return Result<ResolvedSymbol>.Success(resolved);
         }
 
         if (ColonPrefixRegex().IsMatch(normalised))
@@ -82,7 +82,7 @@ public sealed partial class SymbolResolver(
             var parts = normalised.Split(':');
             var resolved = new ResolvedSymbol(parts[1], normalised, Exchange: parts[0], Confidence: 1.0d, Candidates: []);
             this.LogResolution(input, "colon", resolved);
-            return new Result<ResolvedSymbol>().Success(resolved);
+            return Result<ResolvedSymbol>.Success(resolved);
         }
 
         return await this.ResolveAmbiguousAsync(input, trimmed, cancellationToken);
@@ -113,7 +113,7 @@ public sealed partial class SymbolResolver(
                 logger.LogInformation(
                     "resolved input='{Input}' path=ambiguous canonical=- confidence=0.00 candidates=0",
                     originalInput);
-                return new Result<ResolvedSymbol>().Failure(
+                return Result<ResolvedSymbol>.Failure(
                     $"No symbol match for input '{originalInput}'.",
                     ResultErrorType.NotFound);
             }
@@ -127,22 +127,22 @@ public sealed partial class SymbolResolver(
             var top = candidates[0] with { Candidates = candidates };
 
             this.LogResolution(originalInput, "ambiguous", top);
-            return new Result<ResolvedSymbol>().Success(top);
+            return Result<ResolvedSymbol>.Success(top);
         }
         catch (ApiClientHttpException ex)
         {
             logger.LogError(ex, "HTTP error resolving symbol for input '{Input}'.", originalInput);
-            return new Result<ResolvedSymbol>().Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+            return Result<ResolvedSymbol>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
         }
         catch (ApiClientTimeoutException ex)
         {
             logger.LogWarning(ex, "Timeout resolving symbol for input '{Input}'.", originalInput);
-            return new Result<ResolvedSymbol>().Failure("Request timed out", ResultErrorType.Timeout);
+            return Result<ResolvedSymbol>.Failure("Request timed out", ResultErrorType.Timeout);
         }
         catch (ApiClientDeserializationException ex)
         {
             logger.LogError(ex, "Deserialisation error resolving symbol for input '{Input}'.", originalInput);
-            return new Result<ResolvedSymbol>().Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+            return Result<ResolvedSymbol>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
         }
         catch (ApiClientCancelledException)
         {
@@ -154,7 +154,7 @@ public sealed partial class SymbolResolver(
         catch (ApiClientException ex)
         {
             logger.LogError(ex, "Unexpected resolver failure for input '{Input}'.", originalInput);
-            return new Result<ResolvedSymbol>().Failure("Symbol resolution failed unexpectedly");
+            return Result<ResolvedSymbol>.Failure("Symbol resolution failed unexpectedly");
         }
     }
 

--- a/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Peers/GetPeersTool.cs
@@ -129,7 +129,7 @@ public sealed class GetPeersTool(
             Grouping = result.Data.Grouping
         };
 
-        return new Result<GetPeersResponse>().Success(projected);
+        return Result<GetPeersResponse>.Success(projected);
     }
 
     private static IReadOnlyList<NextAction> BuildNextActions(Result<GetPeersResponse> result, string symbol)

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Models/ToolResponseEnvelopeTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Models/ToolResponseEnvelopeTests.cs
@@ -63,7 +63,7 @@ public sealed class ToolResponseEnvelopeTests
     public void FromResult_SuccessResult_MapsToSuccessEnvelope()
     {
         var data = new SearchSymbolResponse { Symbols = [] };
-        var result = new Result<SearchSymbolResponse>().Success(data);
+        var result = Result<SearchSymbolResponse>.Success(data);
 
         var envelope = EnvelopeFactory.FromResult(result, ToolView.Standard, explanation: "found");
 
@@ -76,8 +76,7 @@ public sealed class ToolResponseEnvelopeTests
     [Fact]
     public void FromResult_FailureResult_MapsToFailureEnvelopeWithParsedErrorType()
     {
-        var result = new Result<SearchSymbolResponse>()
-            .Failure("boom", ResultErrorType.ServiceUnavailable);
+        var result = Result<SearchSymbolResponse>.Failure("boom", ResultErrorType.ServiceUnavailable);
 
         var envelope = EnvelopeFactory.FromResult(result);
 
@@ -90,7 +89,7 @@ public sealed class ToolResponseEnvelopeTests
     [Fact]
     public void FromResult_UnknownErrorTypeString_FallsBackToUnknown()
     {
-        var result = new Result<SearchSymbolResponse>().Failure("???", ResultErrorType.Unknown);
+        var result = Result<SearchSymbolResponse>.Failure("???", ResultErrorType.Unknown);
 
         var envelope = EnvelopeFactory.FromResult(result);
 
@@ -107,8 +106,7 @@ public sealed class ToolResponseEnvelopeTests
     [Fact]
     public void FromResult_PremiumRequiredFailure_AutoSetsPremiumFlag()
     {
-        var result = new Result<SearchSymbolResponse>()
-            .Failure("premium-only", ResultErrorType.PremiumRequired);
+        var result = Result<SearchSymbolResponse>.Failure("premium-only", ResultErrorType.PremiumRequired);
 
         var envelope = EnvelopeFactory.FromResult(result);
 
@@ -120,8 +118,7 @@ public sealed class ToolResponseEnvelopeTests
     [Fact]
     public void FromResult_NonPremiumFailure_LeavesPremiumFalse()
     {
-        var result = new Result<SearchSymbolResponse>()
-            .Failure("nope", ResultErrorType.NotFound);
+        var result = Result<SearchSymbolResponse>.Failure("nope", ResultErrorType.NotFound);
 
         var envelope = EnvelopeFactory.FromResult(result);
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/GetFinancialsSnapshotToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Financials/GetFinancialsSnapshotToolTests.cs
@@ -37,7 +37,7 @@ public sealed class GetFinancialsSnapshotToolTests
     {
         this._service
             .GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetFinancialsSnapshotResponse>().Success(
+            .Returns(Result<GetFinancialsSnapshotResponse>.Success(
                 new GetFinancialsSnapshotResponse { Symbol = "AAPL" }));
 
         await this._sut.GetFinancialsSnapshotAsync("aapl");
@@ -52,7 +52,7 @@ public sealed class GetFinancialsSnapshotToolTests
     {
         this._service
             .GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetFinancialsSnapshotResponse>().Success(
+            .Returns(Result<GetFinancialsSnapshotResponse>.Success(
                 new GetFinancialsSnapshotResponse { Symbol = "AAPL" }));
 
         await this._sut.GetFinancialsSnapshotAsync("AAPL", view: "full");
@@ -91,7 +91,7 @@ public sealed class GetFinancialsSnapshotToolTests
     public async Task GetFinancialsSnapshotAsync_FailureResult_ReturnsEmptyNextActions()
     {
         this._service.GetSnapshotAsync(Arg.Any<GetFinancialsSnapshotQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetFinancialsSnapshotResponse>().Failure("upstream-error"));
+            .Returns(Result<GetFinancialsSnapshotResponse>.Failure("upstream-error"));
 
         var envelope = await this._sut.GetFinancialsSnapshotAsync("AAPL");
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/GetNewsPulseToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/News/GetNewsPulseToolTests.cs
@@ -37,7 +37,7 @@ public sealed class GetNewsPulseToolTests
     {
         this._service
             .GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetNewsPulseResponse>().Success(
+            .Returns(Result<GetNewsPulseResponse>.Success(
                 new GetNewsPulseResponse { Symbol = "AAPL", Count = 1, SentimentSource = "finnhub" }));
 
         await this._sut.GetNewsPulseAsync("aapl");
@@ -52,7 +52,7 @@ public sealed class GetNewsPulseToolTests
     {
         this._service
             .GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetNewsPulseResponse>().Success(
+            .Returns(Result<GetNewsPulseResponse>.Success(
                 new GetNewsPulseResponse { Symbol = "AAPL", Count = 1 }));
 
         await this._sut.GetNewsPulseAsync("AAPL", view: "full");
@@ -91,7 +91,7 @@ public sealed class GetNewsPulseToolTests
     public async Task GetNewsPulseAsync_FailureResult_ReturnsEmptyNextActions()
     {
         this._service.GetPulseAsync(Arg.Any<GetNewsPulseQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetNewsPulseResponse>().Failure("upstream-error"));
+            .Returns(Result<GetNewsPulseResponse>.Failure("upstream-error"));
 
         var envelope = await this._sut.GetNewsPulseAsync("AAPL");
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Peers/GetPeersToolTests.cs
@@ -37,7 +37,7 @@ public sealed class GetPeersToolTests
     {
         this._service
             .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPeersResponse>().Success(
+            .Returns(Result<GetPeersResponse>.Success(
                 new GetPeersResponse { Peers = ["MSFT"], Grouping = "industry" }));
 
         await this._sut.GetPeersAsync("aapl");
@@ -53,7 +53,7 @@ public sealed class GetPeersToolTests
         var manyPeers = Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray();
         this._service
             .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPeersResponse>().Success(
+            .Returns(Result<GetPeersResponse>.Success(
                 new GetPeersResponse { Peers = manyPeers, Grouping = "industry" }));
 
         var envelope = await this._sut.GetPeersAsync("AAPL", view: "summary");
@@ -69,7 +69,7 @@ public sealed class GetPeersToolTests
         var manyPeers = Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray();
         this._service
             .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPeersResponse>().Success(
+            .Returns(Result<GetPeersResponse>.Success(
                 new GetPeersResponse { Peers = manyPeers, Grouping = "industry" }));
 
         var envelope = await this._sut.GetPeersAsync("AAPL", view: "full");
@@ -106,7 +106,7 @@ public sealed class GetPeersToolTests
     public async Task GetPeersAsync_FailureResult_ReturnsEmptyNextActions()
     {
         this._service.GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPeersResponse>().Failure("upstream-error"));
+            .Returns(Result<GetPeersResponse>.Failure("upstream-error"));
 
         var envelope = await this._sut.GetPeersAsync("AAPL");
 
@@ -123,7 +123,7 @@ public sealed class GetPeersToolTests
         var manyPeers = Enumerable.Range(1, 30).Select(i => $"P{i}").ToArray();
         this._service
             .GetPeersAsync(Arg.Any<GetPeersQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPeersResponse>().Success(
+            .Returns(Result<GetPeersResponse>.Success(
                 new GetPeersResponse { Peers = manyPeers, Grouping = "industry" }));
 
         var envelope = await this._sut.GetPeersAsync("AAPL", view: "summary");

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/GetPriceSummaryToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Prices/GetPriceSummaryToolTests.cs
@@ -44,7 +44,7 @@ public sealed class GetPriceSummaryToolTests
     {
         this._service
             .GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPriceSummaryResponse>().Success(
+            .Returns(Result<GetPriceSummaryResponse>.Success(
                 new GetPriceSummaryResponse { Symbol = "AAPL", Period = "30d", Resolution = "D", CandleCount = 1 }));
 
         await this._sut.GetPriceSummaryAsync("AAPL", view: "full");
@@ -59,7 +59,7 @@ public sealed class GetPriceSummaryToolTests
     {
         this._service
             .GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPriceSummaryResponse>().Success(
+            .Returns(Result<GetPriceSummaryResponse>.Success(
                 new GetPriceSummaryResponse { Symbol = "AAPL", Period = "90d", Resolution = "D", CandleCount = 1 }));
 
         await this._sut.GetPriceSummaryAsync("AAPL", period: "90d");
@@ -91,7 +91,7 @@ public sealed class GetPriceSummaryToolTests
     public async Task GetPriceSummaryAsync_FailureResult_ReturnsEmptyNextActions()
     {
         this._service.GetSummaryAsync(Arg.Any<GetPriceSummaryQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetPriceSummaryResponse>().Failure("upstream-error"));
+            .Returns(Result<GetPriceSummaryResponse>.Failure("upstream-error"));
 
         var envelope = await this._sut.GetPriceSummaryAsync("AAPL");
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/GetCompanyProfileToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Profiles/GetCompanyProfileToolTests.cs
@@ -36,7 +36,7 @@ public sealed class GetCompanyProfileToolTests
     public async Task GetCompanyProfileAsync_SummaryView_OmitsCosmeticFields()
     {
         this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetCompanyProfileResponse>().Success(
+            .Returns(Result<GetCompanyProfileResponse>.Success(
                 new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple" }));
 
         await this._sut.GetCompanyProfileAsync("AAPL", view: "summary");
@@ -50,7 +50,7 @@ public sealed class GetCompanyProfileToolTests
     public async Task GetCompanyProfileAsync_StandardView_RequestsCosmeticFields()
     {
         this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetCompanyProfileResponse>().Success(
+            .Returns(Result<GetCompanyProfileResponse>.Success(
                 new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple" }));
 
         await this._sut.GetCompanyProfileAsync("AAPL", view: "standard");
@@ -64,7 +64,7 @@ public sealed class GetCompanyProfileToolTests
     public async Task GetCompanyProfileAsync_Success_PopulatesNextActions()
     {
         this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetCompanyProfileResponse>().Success(
+            .Returns(Result<GetCompanyProfileResponse>.Success(
                 new GetCompanyProfileResponse { Ticker = "AAPL", Name = "Apple" }));
 
         var envelope = await this._sut.GetCompanyProfileAsync("AAPL");
@@ -97,7 +97,7 @@ public sealed class GetCompanyProfileToolTests
     public async Task GetCompanyProfileAsync_FailureResult_ReturnsEmptyNextActions()
     {
         this._service.GetProfileAsync(Arg.Any<GetCompanyProfileQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetCompanyProfileResponse>().Failure("upstream-error"));
+            .Returns(Result<GetCompanyProfileResponse>.Failure("upstream-error"));
 
         var envelope = await this._sut.GetCompanyProfileAsync("AAPL");
 

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/GetQuoteToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Quotes/GetQuoteToolTests.cs
@@ -36,7 +36,7 @@ public sealed class GetQuoteToolTests
     public async Task GetQuoteAsync_LowercaseSymbol_Normalises()
     {
         this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetQuoteResponse>().Success(new GetQuoteResponse { Symbol = "AAPL", Current = 100 }));
+            .Returns(Result<GetQuoteResponse>.Success(new GetQuoteResponse { Symbol = "AAPL", Current = 100 }));
 
         await this._sut.GetQuoteAsync("aapl");
 
@@ -49,7 +49,7 @@ public sealed class GetQuoteToolTests
     public async Task GetQuoteAsync_Success_PopulatesNextActions()
     {
         this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetQuoteResponse>().Success(new GetQuoteResponse { Symbol = "AAPL", Current = 100 }));
+            .Returns(Result<GetQuoteResponse>.Success(new GetQuoteResponse { Symbol = "AAPL", Current = 100 }));
 
         var envelope = await this._sut.GetQuoteAsync("AAPL");
 
@@ -81,7 +81,7 @@ public sealed class GetQuoteToolTests
     public async Task GetQuoteAsync_FailureResult_ReturnsEmptyNextActions()
     {
         this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetQuoteResponse>().Failure("upstream-error", ResultErrorType.ServiceUnavailable));
+            .Returns(Result<GetQuoteResponse>.Failure("upstream-error", ResultErrorType.ServiceUnavailable));
 
         var envelope = await this._sut.GetQuoteAsync("AAPL");
 
@@ -95,7 +95,7 @@ public sealed class GetQuoteToolTests
         // response is shape-valid but has null Current / PercentChange / TimestampUtc
         // (the unknown-symbol case Finnhub returns — see Fixtures/finnhub/quote-unknown.json).
         this._service.GetQuoteAsync(Arg.Any<GetQuoteQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<GetQuoteResponse>().Success(
+            .Returns(Result<GetQuoteResponse>.Success(
                 new GetQuoteResponse { Symbol = "ZZZZ" }));
 
         var envelope = await this._sut.GetQuoteAsync("ZZZZ");

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchSymbolToolTests.cs
@@ -112,7 +112,7 @@ public sealed class SearchSymbolToolTests
     public async Task SearchSymbolAsync_ServiceFailure_WrapsAsFailureEnvelope()
     {
         this._service.SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<SearchSymbolResponse>().Failure("not found", ResultErrorType.NotFound));
+            .Returns(Result<SearchSymbolResponse>.Failure("not found", ResultErrorType.NotFound));
         this.SetupResolver("ZZZZ", 1.0);
         var tool = new SearchSymbolTool(this._service, this._resolver, this._logger);
 
@@ -145,7 +145,7 @@ public sealed class SearchSymbolToolTests
         // results, but next_actions stays empty because there's no canonical to key off.
         this.SetupSuccess([Stock("AAPL", "Apple Inc.", confidence: 0.5)]);
         this._resolver.ResolveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<ResolvedSymbol>().Failure(
+            .Returns(Result<ResolvedSymbol>.Failure(
                 "no canonical pick", ResultErrorType.NotFound));
         var tool = new SearchSymbolTool(this._service, this._resolver, this._logger);
 
@@ -158,12 +158,12 @@ public sealed class SearchSymbolToolTests
 
     private void SetupSuccess(IReadOnlyList<StockSymbol> symbols) =>
         this._service.SearchSymbolAsync(Arg.Any<SearchSymbolQuery>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<SearchSymbolResponse>().Success(
+            .Returns(Result<SearchSymbolResponse>.Success(
                 new SearchSymbolResponse { Symbols = symbols }));
 
     private void SetupResolver(string canonical, double confidence) =>
         this._resolver.ResolveAsync(Arg.Any<string>(), Arg.Any<CancellationToken>())
-            .Returns(new Result<ResolvedSymbol>().Success(
+            .Returns(Result<ResolvedSymbol>.Success(
                 new ResolvedSymbol(canonical, canonical, Exchange: null, confidence, Candidates: [])));
 
     private static StockSymbol Stock(string symbol, string description, double confidence) => new()


### PR DESCRIPTION
Closes #399 (CLEANUP.md High H9).

## Why
`Result<T>.Success` and `Result<T>.Failure` were instance methods returning `new Result<T> { ... }`. The pervasive idiom `new Result<T>().Success(x)` allocated a throwaway with `IsSuccess=false`, ignored `this` inside the method body, then allocated the real instance. 86 call sites paying for this allocation.

The deeper smell: instance-method shape silently allowed `new Result<T>().Success(x).Failure("y")` returning a third `Result` with mixed semantics. Static factory makes intent unambiguous.

## Change
- `Result<T>.Success(T data)` → `public static`
- `Result<T>.Failure(string, ResultErrorType)` → `public static`
- 86 call sites migrated across 17 files (8 services + 1 tool + 8 test files + ToolResponseEnvelopeTests)
- Net effect: one fewer `Result<T>` allocation per call

## CA1000 suppression
The analyzer fires CA1000 ("do not declare static members on generic types") even though the rule's own exception list includes factory methods returning the same type. Suppressed at class level with justification — a non-generic helper class would force every `Success` call to also specify the type argument (regression in ergonomics) since the type can't be inferred from the data parameter alone in that shape.

## Verified
- 449 tests pass (was 446 — no test changes, just the migration)
- `grep -r "new Result<.*>().Success\|.Failure" src/ tests/` returns 0 hits
- `dotnet build` clean (0 warnings)
- `dotnet format --verify-no-changes` clean

## Test plan
- [x] Build clean
- [x] All tests pass
- [x] Format clean
- [x] Net allocation reduction on every Result<T> construction