### PR TITLE
feat(tools): add get-calendar earnings dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 
 ### ✅ Currently Available
 
-**Tools (7):**
+**Tools (8):**
 - **`search-symbol`** — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10). On a high-confidence exact match, suggests `get-quote`, `get-company-profile`, `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, and `get-peers` as next actions.
 - **`get-quote`** — real-time price snapshot (current, change, percent change, session high/low/open, prev close, timestamp). Cached at the 10-second Quote tier.
 - **`get-company-profile`** — company snapshot (name, ticker, country, currency, exchange, IPO, market cap, shares outstanding, industry). `view=summary` drops the cosmetic fields (logo, phone, weburl); `standard` and `full` include them.
@@ -44,6 +44,7 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 - **`get-financials-snapshot`** — curated 10-KPI snapshot (market cap, P/E, P/B, EPS, dividend yield, 52-week high/low, 52-week return, beta, revenue per share). `view=full` adds the raw upstream metric dictionary.
 - **`get-price-summary`** — aggregated price stats over a candle range (`min`, `max`, `mean`, `return_pct`, `vol`, `latest`). Period: `7d`, `30d` (default), `90d`, `1y`. `view=full` adds the raw OHLCV arrays.
 - **`get-news-pulse`** — news pulse over the past 7 days: sentiment score (when available), top 5 headlines, article count, week-over-week delta. Gracefully degrades sentiment when the upstream `/news-sentiment` endpoint is premium-locked.
+- **`get-calendar`** — parameter-dispatched calendar lookup. v1 ships `kind=earnings` with date window (max 90 days) and optional symbol filter; IPO and economic kinds land in follow-up releases. Summary view caps at 10 events, standard at 25, full returns the complete window.
 
 Every tool returns the standard token-budgeted envelope with cross-linked `next_actions` and the most-recent observed Finnhub rate-limit headers.
 
@@ -53,7 +54,7 @@ Every tool returns the standard token-budgeted envelope with cross-linked `next_
 
 ### 🔄 In Development
 - Wire `ExchangesResource` to the live Finnhub `/stock/exchange` endpoint
-- **`get-calendar`** — parameter-dispatched calendar across earnings, IPO, and economic events
+- **`get-calendar`** — extend with `kind=ipo` and `kind=economic`
 
 ### 📋 Planned
 - **`get-insider-signal`** — net buy/sell aggregation over the past 30 days plus notable insider names

--- a/src/FinnHub.MCP.Server.Application/Calendar/Clients/ICalendarApiClient.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Clients/ICalendarApiClient.cs
@@ -1,0 +1,26 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+
+namespace FinnHub.MCP.Server.Application.Calendar.Clients;
+
+/// <summary>
+/// Infrastructure contract for the Finnhub <c>/calendar/*</c> endpoint family.
+/// </summary>
+public interface ICalendarApiClient
+{
+    /// <summary>
+    /// Fetches earnings releases scheduled within the supplied window, optionally
+    /// filtered to a single symbol.
+    /// </summary>
+    Task<IReadOnlyList<EarningsEvent>> GetEarningsCalendarAsync(
+        DateOnly from,
+        DateOnly to,
+        string? symbol,
+        CancellationToken cancellationToken);
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/CalendarKind.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/CalendarKind.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+
+/// <summary>
+/// Discriminator for the parameter-dispatched <c>get-calendar</c> tool.
+/// </summary>
+/// <remarks>
+/// The tool exposes one entry point that fans out to distinct Finnhub
+/// calendar endpoints. v1 ships <see cref="Earnings"/> only; IPO and economic
+/// calendars are added by follow-up stories that extend the validator and
+/// service switch.
+/// </remarks>
+public enum CalendarKind
+{
+    /// <summary>Corporate earnings releases (<c>/calendar/earnings</c>).</summary>
+    Earnings
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/EarningsEvent.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/EarningsEvent.cs
@@ -1,0 +1,63 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+
+/// <summary>
+/// A single corporate-earnings release from Finnhub's <c>/calendar/earnings</c> feed.
+/// </summary>
+/// <remarks>
+/// All financial fields are nullable: Finnhub returns <c>null</c> for
+/// <c>epsActual</c>/<c>revenueActual</c> on future-dated entries and for
+/// <c>epsEstimate</c>/<c>revenueEstimate</c> on symbols with no analyst coverage.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public sealed class EarningsEvent
+{
+    /// <summary>Ticker symbol of the reporting company.</summary>
+    [JsonPropertyName("symbol")]
+    public required string Symbol { get; init; }
+
+    /// <summary>Scheduled report date (calendar day, no time component).</summary>
+    [JsonPropertyName("date")]
+    public required DateOnly Date { get; init; }
+
+    /// <summary>
+    /// Session timing relative to the trading day: <c>bmo</c> (before market open),
+    /// <c>amc</c> (after market close), or <c>dmh</c> (during market hours). May be
+    /// <c>null</c> when Finnhub has not classified the release.
+    /// </summary>
+    [JsonPropertyName("hour")]
+    public string? Hour { get; init; }
+
+    /// <summary>Fiscal quarter (1–4) the release covers.</summary>
+    [JsonPropertyName("quarter")]
+    public int? Quarter { get; init; }
+
+    /// <summary>Fiscal year the release covers.</summary>
+    [JsonPropertyName("year")]
+    public int? Year { get; init; }
+
+    /// <summary>Reported EPS, or <c>null</c> if the release has not happened yet.</summary>
+    [JsonPropertyName("eps_actual")]
+    public double? EpsActual { get; init; }
+
+    /// <summary>Analyst-consensus EPS estimate, or <c>null</c> if no coverage.</summary>
+    [JsonPropertyName("eps_estimate")]
+    public double? EpsEstimate { get; init; }
+
+    /// <summary>Reported revenue, or <c>null</c> if the release has not happened yet.</summary>
+    [JsonPropertyName("revenue_actual")]
+    public double? RevenueActual { get; init; }
+
+    /// <summary>Analyst-consensus revenue estimate, or <c>null</c> if no coverage.</summary>
+    [JsonPropertyName("revenue_estimate")]
+    public double? RevenueEstimate { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/GetCalendarQuery.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/GetCalendarQuery.cs
@@ -1,0 +1,33 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+
+/// <summary>
+/// Query parameters for the <c>get-calendar</c> tool — a dispatched lookup
+/// against one of Finnhub's calendar endpoints (earnings, IPO, economic).
+/// </summary>
+public sealed class GetCalendarQuery
+{
+    /// <summary>Per-invocation correlation id; passed through for logging only.</summary>
+    public required string QueryId { get; init; }
+
+    /// <summary>Which calendar feed to dispatch to.</summary>
+    public required CalendarKind Kind { get; init; }
+
+    /// <summary>Inclusive start of the date window (UTC calendar day).</summary>
+    public required DateOnly From { get; init; }
+
+    /// <summary>Inclusive end of the date window (UTC calendar day).</summary>
+    public required DateOnly To { get; init; }
+
+    /// <summary>
+    /// Optional uppercase ticker filter. When <c>null</c> the upstream returns the
+    /// full calendar for the window; when set, results are filtered to that symbol.
+    /// </summary>
+    public string? Symbol { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/GetCalendarResponse.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Features/GetCalendar/GetCalendarResponse.cs
@@ -1,0 +1,50 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+
+/// <summary>
+/// Wire response for <c>get-calendar</c>.
+/// </summary>
+/// <remarks>
+/// The wire envelope is flat across kinds — only the populated event list depends
+/// on <see cref="Kind"/>. v1 carries <see cref="EarningsEvents"/> only; follow-up
+/// stories add IPO and economic event lists alongside it.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public sealed class GetCalendarResponse
+{
+    /// <summary>Echo of the dispatched calendar kind.</summary>
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+
+    /// <summary>Inclusive start of the requested window.</summary>
+    [JsonPropertyName("from")]
+    public required DateOnly From { get; init; }
+
+    /// <summary>Inclusive end of the requested window.</summary>
+    [JsonPropertyName("to")]
+    public required DateOnly To { get; init; }
+
+    /// <summary>Echo of the symbol filter, when one was requested.</summary>
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; init; }
+
+    /// <summary>Number of events in the response.</summary>
+    [JsonPropertyName("total_count")]
+    public int TotalCount { get; init; }
+
+    /// <summary>
+    /// Earnings releases in the requested window, ordered by <see cref="EarningsEvent.Date"/> ascending.
+    /// Populated only when <see cref="Kind"/> is <c>earnings</c>.
+    /// </summary>
+    [JsonPropertyName("earnings_events")]
+    public IReadOnlyList<EarningsEvent>? EarningsEvents { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Services/CalendarService.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Services/CalendarService.cs
@@ -1,0 +1,118 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Calendar.Clients;
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Models;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Application.Calendar.Services;
+
+/// <summary>
+/// Default <see cref="ICalendarService"/> wrapping <see cref="ICalendarApiClient"/> with
+/// hybrid caching (News tier — calendars revise as analysts update estimates) and
+/// exception-to-result translation.
+/// </summary>
+public sealed class CalendarService(
+    ICalendarApiClient apiClient,
+    IFinnHubCache cache,
+    ILogger<CalendarService> logger)
+    : ICalendarService
+{
+    /// <inheritdoc />
+    public async Task<Result<GetCalendarResponse>> GetCalendarAsync(
+        GetCalendarQuery query,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        try
+        {
+            return query.Kind switch
+            {
+                CalendarKind.Earnings => await this.GetEarningsAsync(query, cancellationToken),
+                _ => Result<GetCalendarResponse>.Failure(
+                    $"Calendar kind '{query.Kind}' is not yet supported.",
+                    ResultErrorType.InvalidQuery)
+            };
+        }
+        catch (ApiClientPremiumRequiredException ex)
+        {
+            logger.LogWarning(ex, "Calendar endpoint is premium-locked (kind={Kind})", query.Kind);
+            return Result<GetCalendarResponse>.Failure(ex.Message, ResultErrorType.PremiumRequired);
+        }
+        catch (ApiClientHttpException ex)
+        {
+            logger.LogError(ex, "HTTP error fetching calendar (kind={Kind}, status={Status})", query.Kind, ex.StatusCode);
+            return Result<GetCalendarResponse>.Failure(ex.Message, ResultErrorType.ServiceUnavailable);
+        }
+        catch (ApiClientTimeoutException ex)
+        {
+            logger.LogWarning(ex, "Calendar request timed out (kind={Kind})", query.Kind);
+            return Result<GetCalendarResponse>.Failure("Request timed out", ResultErrorType.Timeout);
+        }
+        catch (ApiClientDeserializationException ex)
+        {
+            logger.LogError(ex, "Failed to deserialize calendar response (kind={Kind})", query.Kind);
+            return Result<GetCalendarResponse>.Failure("Invalid response from service", ResultErrorType.InvalidResponse);
+        }
+        catch (ApiClientCancelledException)
+        {
+            throw;
+        }
+        catch (ApiClientException ex)
+        {
+            logger.LogError(ex, "Unexpected calendar failure (kind={Kind})", query.Kind);
+            return Result<GetCalendarResponse>.Failure("Calendar lookup failed unexpectedly");
+        }
+    }
+
+    private async Task<Result<GetCalendarResponse>> GetEarningsAsync(
+        GetCalendarQuery query,
+        CancellationToken cancellationToken)
+    {
+        var symbolKey = query.Symbol is null ? "all" : query.Symbol.ToUpperInvariant();
+        var cacheKey = string.Create(
+            CultureInfo.InvariantCulture,
+            $"calendar-earnings:s={symbolKey}:f={query.From:yyyy-MM-dd}:t={query.To:yyyy-MM-dd}");
+
+        var events = await cache.GetOrCreateAsync(
+            cacheKey,
+            CacheTier.News,
+            async ct => await apiClient.GetEarningsCalendarAsync(query.From, query.To, query.Symbol, ct),
+            cancellationToken);
+
+        var ordered = events
+            .OrderBy(e => e.Date)
+            .ThenBy(e => e.Symbol, StringComparer.Ordinal)
+            .ToList()
+            .AsReadOnly();
+
+        logger.LogInformation(
+            "Earnings calendar for {Symbol} ({From}..{To}): {Count} event(s)",
+            symbolKey, query.From, query.To, ordered.Count);
+
+        var response = new GetCalendarResponse
+        {
+            Kind = "earnings",
+            From = query.From,
+            To = query.To,
+            Symbol = query.Symbol,
+            TotalCount = ordered.Count,
+            EarningsEvents = ordered
+        };
+
+        return ordered.Count == 0
+            ? Result<GetCalendarResponse>.Failure(
+                $"No earnings events found for the requested window ({query.From}..{query.To}).",
+                ResultErrorType.NotFound)
+            : Result<GetCalendarResponse>.Success(response);
+    }
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Services/ICalendarService.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Services/ICalendarService.cs
@@ -1,0 +1,23 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Application.Calendar.Services;
+
+/// <summary>
+/// Application-level entry point for calendar lookups. Dispatches by
+/// <see cref="GetCalendarQuery.Kind"/> to the appropriate upstream feed.
+/// </summary>
+public interface ICalendarService
+{
+    /// <summary>Executes the dispatched calendar lookup and returns a categorised result.</summary>
+    Task<Result<GetCalendarResponse>> GetCalendarAsync(
+        GetCalendarQuery query,
+        CancellationToken cancellationToken = default);
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Calendar/FinnHubCalendarApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Calendar/FinnHubCalendarApiClient.cs
@@ -1,0 +1,174 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Calendar.Clients;
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Dtos;
+using FinnHub.MCP.Server.Infrastructure.Serialization;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Calendar;
+
+/// <summary>HTTP client for the Finnhub <c>/calendar/*</c> endpoint family.</summary>
+public sealed class FinnHubCalendarApiClient : ICalendarApiClient
+{
+    private const string EarningsEndpointName = "calendar-earnings";
+
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubOptions _options;
+    private readonly ILogger<FinnHubCalendarApiClient> _logger;
+
+    /// <summary>Initialises a new <see cref="FinnHubCalendarApiClient"/>.</summary>
+    public FinnHubCalendarApiClient(
+        HttpClient httpClient,
+        IOptions<FinnHubOptions> options,
+        ILogger<FinnHubCalendarApiClient> logger)
+    {
+        ArgumentNullException.ThrowIfNull(httpClient);
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(logger);
+
+        this._httpClient = httpClient;
+        this._options = options.Value ?? throw new ArgumentException("FinnHub options cannot be null.", nameof(options));
+        this._logger = logger;
+    }
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyList<EarningsEvent>> GetEarningsCalendarAsync(
+        DateOnly from,
+        DateOnly to,
+        string? symbol,
+        CancellationToken cancellationToken)
+    {
+        var endpoint = this._options.EndPoints.FirstOrDefault(e => e is { IsActive: true, Name: EarningsEndpointName })?.Url
+                       ?? throw new ArgumentException("Calendar earnings endpoint is not configured or inactive");
+
+        var requestUri = BuildEarningsUri(endpoint, from, to, symbol);
+
+        this._logger.LogInformation("Requesting earnings calendar from FinnHub: {RequestUri}", requestUri);
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Get, requestUri);
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await this._httpClient.SendAsync(requestMessage, cancellationToken).ConfigureAwait(false);
+        }
+        catch (HttpRequestException ex)
+        {
+            this._logger.LogError(ex, "HTTP request to FinnHub earnings calendar failed: {Uri}", requestUri);
+            throw new ApiClientHttpException(
+                $"HTTP request to FinnHub earnings calendar failed: {requestUri}",
+                HttpStatusCode.ServiceUnavailable,
+                innerException: ex);
+        }
+        catch (TaskCanceledException ex) when (ex.InnerException is TimeoutException)
+        {
+            this._logger.LogError(ex, "Earnings calendar request timed out: {Uri}", requestUri);
+            throw new ApiClientTimeoutException($"Earnings calendar request timed out: {requestUri}", ex);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            this._logger.LogWarning("Earnings calendar request cancelled: {Uri}", requestUri);
+            throw new ApiClientCancelledException($"Earnings calendar request cancelled: {requestUri}");
+        }
+
+        await using var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+        }
+
+        FinnHubEarningsCalendarResponse? dto;
+        try
+        {
+            dto = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.FinnHubEarningsCalendarResponse, cancellationToken)
+                .ConfigureAwait(false);
+        }
+        catch (JsonException ex)
+        {
+            this._logger.LogError(ex, "Failed to deserialize earnings calendar response: {Uri}", requestUri);
+            throw new ApiClientDeserializationException(
+                $"Failed to deserialize earnings calendar response: {requestUri}",
+                innerException: ex);
+        }
+
+        if (dto?.EarningsCalendar is null || dto.EarningsCalendar.Count == 0)
+        {
+            return [];
+        }
+
+        var events = new List<EarningsEvent>(dto.EarningsCalendar.Count);
+        foreach (var entry in dto.EarningsCalendar)
+        {
+            if (string.IsNullOrWhiteSpace(entry.Symbol) || string.IsNullOrWhiteSpace(entry.Date))
+            {
+                continue;
+            }
+
+            if (!DateOnly.TryParseExact(entry.Date, "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var date))
+            {
+                continue;
+            }
+
+            events.Add(new EarningsEvent
+            {
+                Symbol = entry.Symbol,
+                Date = date,
+                Hour = entry.Hour,
+                Quarter = entry.Quarter,
+                Year = entry.Year,
+                EpsActual = entry.EpsActual,
+                EpsEstimate = entry.EpsEstimate,
+                RevenueActual = entry.RevenueActual,
+                RevenueEstimate = entry.RevenueEstimate
+            });
+        }
+
+        return events;
+    }
+
+    private static string BuildEarningsUri(string endpoint, DateOnly from, DateOnly to, string? symbol)
+    {
+        var trimmed = endpoint.TrimStart('/');
+        var fromStr = from.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+        var toStr = to.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
+
+        return string.IsNullOrWhiteSpace(symbol)
+            ? string.Create(CultureInfo.InvariantCulture, $"{trimmed}?from={fromStr}&to={toStr}")
+            : string.Create(CultureInfo.InvariantCulture, $"{trimmed}?from={fromStr}&to={toStr}&symbol={Uri.EscapeDataString(symbol)}");
+    }
+
+    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
+
+        if (statusCode == HttpStatusCode.Forbidden)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            this._logger.LogWarning("Premium-locked calendar endpoint: {Endpoint} - {Content}", endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        this._logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "Calendar API error: {StatusCode} - {Content}", statusCode, errorBody);
+
+        throw new ApiClientHttpException($"FinnHub calendar returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubEarningsCalendarResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubEarningsCalendarResponse.cs
@@ -1,0 +1,22 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>
+/// Wire DTO for the Finnhub <c>/calendar/earnings</c> endpoint envelope.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubEarningsCalendarResponse
+{
+    /// <summary>The list of earnings entries; may be empty when no events match the window.</summary>
+    [JsonPropertyName("earningsCalendar")]
+    public IReadOnlyList<FinnHubEarningsEntry>? EarningsCalendar { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubEarningsEntry.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubEarningsEntry.cs
@@ -1,0 +1,61 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Infrastructure.Dtos;
+
+/// <summary>
+/// Wire DTO for a single entry in Finnhub's <c>/calendar/earnings</c> response.
+/// </summary>
+/// <remarks>
+/// All numeric fields are nullable: Finnhub returns <c>null</c> for
+/// <c>epsActual</c>/<c>revenueActual</c> on future-dated entries and for
+/// <c>epsEstimate</c>/<c>revenueEstimate</c> on symbols with no analyst coverage.
+/// Property names are camelCase on the wire (overriding the snake_case default
+/// in <see cref="Serialization.FinnHubJsonContext"/>) to match the upstream shape.
+/// </remarks>
+[ExcludeFromCodeCoverage]
+public sealed class FinnHubEarningsEntry
+{
+    /// <summary>Reporting ticker.</summary>
+    [JsonPropertyName("symbol")]
+    public string? Symbol { get; init; }
+
+    /// <summary>Scheduled report date as ISO <c>yyyy-MM-dd</c>.</summary>
+    [JsonPropertyName("date")]
+    public string? Date { get; init; }
+
+    /// <summary>Session timing: <c>bmo</c>, <c>amc</c>, <c>dmh</c>, or <c>null</c>.</summary>
+    [JsonPropertyName("hour")]
+    public string? Hour { get; init; }
+
+    /// <summary>Fiscal quarter (1–4).</summary>
+    [JsonPropertyName("quarter")]
+    public int? Quarter { get; init; }
+
+    /// <summary>Fiscal year.</summary>
+    [JsonPropertyName("year")]
+    public int? Year { get; init; }
+
+    /// <summary>Reported EPS; <c>null</c> for future entries.</summary>
+    [JsonPropertyName("epsActual")]
+    public double? EpsActual { get; init; }
+
+    /// <summary>Analyst-consensus EPS estimate; <c>null</c> when no coverage.</summary>
+    [JsonPropertyName("epsEstimate")]
+    public double? EpsEstimate { get; init; }
+
+    /// <summary>Reported revenue; <c>null</c> for future entries.</summary>
+    [JsonPropertyName("revenueActual")]
+    public double? RevenueActual { get; init; }
+
+    /// <summary>Analyst-consensus revenue estimate; <c>null</c> when no coverage.</summary>
+    [JsonPropertyName("revenueEstimate")]
+    public double? RevenueEstimate { get; init; }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -10,6 +10,8 @@ using System.Net;
 using System.Net.Http.Headers;
 using System.Net.Mime;
 using FinnHub.MCP.Server.Application.Caching;
+using FinnHub.MCP.Server.Application.Calendar.Clients;
+using FinnHub.MCP.Server.Application.Calendar.Services;
 using FinnHub.MCP.Server.Application.Financials.Clients;
 using FinnHub.MCP.Server.Application.Financials.Services;
 using FinnHub.MCP.Server.Application.News.Clients;
@@ -26,6 +28,7 @@ using FinnHub.MCP.Server.Application.Quotes.Services;
 using FinnHub.MCP.Server.Application.RateLimiting;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Infrastructure.Caching;
+using FinnHub.MCP.Server.Infrastructure.Clients.Calendar;
 using FinnHub.MCP.Server.Infrastructure.Clients.Financials;
 using FinnHub.MCP.Server.Infrastructure.Clients.News;
 using FinnHub.MCP.Server.Infrastructure.Clients.Peers;
@@ -138,6 +141,14 @@ public static class ServiceCollectionExtension
             .AddHttpMessageHandler<RateLimitHeaderHandler>()
             .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubProfilesApiClient>>()))
             .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubProfilesApiClient>>()))
+            .SetHandlerLifetime(TimeSpan.FromMinutes(5));
+
+        services.AddSingleton<ICalendarService, CalendarService>();
+        services.AddHttpClient<ICalendarApiClient, FinnHubCalendarApiClient>("FinnHub-Calendar-Client", ConfigureFinnHubClient)
+            .ConfigurePrimaryHttpMessageHandler(BuildPrimaryHandler)
+            .AddHttpMessageHandler<RateLimitHeaderHandler>()
+            .AddPolicyHandler((provider, _) => GetRetryPolicy(provider.GetRequiredService<ILogger<FinnHubCalendarApiClient>>()))
+            .AddPolicyHandler((provider, _) => GetCircuitBreakerPolicy(provider.GetRequiredService<ILogger<FinnHubCalendarApiClient>>()))
             .SetHandlerLifetime(TimeSpan.FromMinutes(5));
     }
 

--- a/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Serialization/FinnHubJsonContext.cs
@@ -7,6 +7,7 @@
 
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
 using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
@@ -75,4 +76,9 @@ namespace FinnHub.MCP.Server.Infrastructure.Serialization;
 [JsonSerializable(typeof(FinnHubProfileResponse))]
 [JsonSerializable(typeof(GetCompanyProfileResponse))]
 [JsonSerializable(typeof(ToolResponseEnvelope<GetCompanyProfileResponse>))]
+[JsonSerializable(typeof(FinnHubEarningsCalendarResponse))]
+[JsonSerializable(typeof(FinnHubEarningsEntry))]
+[JsonSerializable(typeof(EarningsEvent))]
+[JsonSerializable(typeof(GetCalendarResponse))]
+[JsonSerializable(typeof(ToolResponseEnvelope<GetCalendarResponse>))]
 public partial class FinnHubJsonContext : JsonSerializerContext;

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -464,6 +464,85 @@ public static class Constants
                 """;
         }
 
+        /// <summary>Constants for the <c>get-calendar</c> tool — parameter-dispatched calendar lookup.</summary>
+        public static class Calendar
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "get-calendar";
+
+            /// <summary>The human-readable tool title.</summary>
+            public const string Title = "Get Calendar";
+
+            /// <summary>Parameter names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Kind parameter name.</summary>
+                public const string KindName = "kind";
+
+                /// <summary>Kind parameter description.</summary>
+                public const string KindDescription =
+                    "Calendar feed to dispatch to: earnings. (IPO and economic are added by follow-up releases.)";
+
+                /// <summary>Symbol parameter name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol parameter description.</summary>
+                public const string SymbolDescription =
+                    "Optional uppercase ticker filter, e.g. 'AAPL'. Omit to retrieve the full calendar for the window.";
+
+                /// <summary>From-date parameter name.</summary>
+                public const string FromName = "from";
+
+                /// <summary>From-date parameter description.</summary>
+                public const string FromDescription =
+                    "Inclusive start of the date window as ISO yyyy-MM-dd, e.g. '2026-05-01'. Defaults to today (UTC).";
+
+                /// <summary>To-date parameter name.</summary>
+                public const string ToName = "to";
+
+                /// <summary>To-date parameter description.</summary>
+                public const string ToDescription =
+                    "Inclusive end of the date window as ISO yyyy-MM-dd, e.g. '2026-08-01'. Defaults to from+90d. Maximum window: 90 days.";
+
+                /// <summary>View parameter name.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>View parameter description.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>Tool description registered with the MCP server.</summary>
+            public const string Description =
+                """
+                Get the dispatched calendar for a date window — currently earnings releases (IPO and economic are upcoming).
+
+                ## Example:
+                - kind='earnings', symbol='AAPL', from='2026-05-01', to='2026-08-01'
+                - kind='earnings', from='2026-05-26', to='2026-06-02'   (full week, all symbols)
+
+                ## Request Parameters:
+                - kind (string, required): 'earnings'
+                - symbol (string, optional): uppercase ticker filter
+                - from (string, optional, ISO yyyy-MM-dd): inclusive start; defaults to today (UTC)
+                - to (string, optional, ISO yyyy-MM-dd): inclusive end; defaults to from+90d; max window 90 days
+
+                ## Response Fields:
+                - kind (string): echo of the dispatched feed
+                - from, to (ISO date): echo of the window
+                - symbol (string, nullable): echo of the symbol filter
+                - total_count (int)
+                - earnings_events (array, populated when kind='earnings'):
+                  - symbol, date (ISO), hour (bmo|amc|dmh|null), quarter, year
+                  - eps_actual, eps_estimate, revenue_actual, revenue_estimate (all nullable doubles)
+
+                ## Notes:
+                - summary view caps at the next 10 events by date; standard and full return the complete window.
+                - Cached at the News tier — calendars revise as analysts update estimates.
+
+                Approx tokens: summary ~250, standard varies with event count (~1000 at 25 events), full no ceiling.
+                """;
+        }
+
         /// <summary>Constants for the <c>get-company-profile</c> tool — company snapshot.</summary>
         public static class CompanyProfile
         {

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -16,6 +16,7 @@ using FinnHub.MCP.Server.Infrastructure.Extensions;
 using FinnHub.MCP.Server.Middleware;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
+using FinnHub.MCP.Server.Tools.Calendar;
 using FinnHub.MCP.Server.Tools.Financials;
 using FinnHub.MCP.Server.Tools.News;
 using FinnHub.MCP.Server.Tools.Peers;
@@ -118,6 +119,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithWrappedTools<GetNewsPulseTool>()
 .WithWrappedTools<GetQuoteTool>()
 .WithWrappedTools<GetCompanyProfileTool>()
+.WithWrappedTools<GetCalendarTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>();
 

--- a/src/FinnHub.MCP.Server/Tools/Calendar/CalendarInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Calendar/CalendarInputValidator.cs
@@ -1,0 +1,117 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Globalization;
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Tools.Calendar;
+
+/// <summary>Validation helpers for the <c>get-calendar</c> tool parameters.</summary>
+internal static partial class CalendarInputValidator
+{
+    /// <summary>Maximum window the upstream serves reliably for a single call (90 days).</summary>
+    internal const int MaxWindowDays = 90;
+
+    [GeneratedRegex(@"^[A-Z][A-Z0-9.\-]{0,19}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    public static CalendarKind ValidateKind(string? kind)
+    {
+        if (string.IsNullOrWhiteSpace(kind))
+        {
+            throw new ArgumentException("Kind cannot be empty.", nameof(kind));
+        }
+
+        return kind.Trim().ToLowerInvariant() switch
+        {
+            "earnings" => CalendarKind.Earnings,
+            "ipo" or "economic" => throw new ArgumentException(
+                $"Calendar kind '{kind}' is not yet supported. Only 'earnings' is available in this release.",
+                nameof(kind)),
+            _ => throw new ArgumentException(
+                "Kind must be one of: earnings.",
+                nameof(kind))
+        };
+    }
+
+    public static string? ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            return null;
+        }
+
+        var normalised = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(normalised))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-20 chars, start with A-Z, and contain only A-Z, 0-9, '.', '-'.",
+                nameof(symbol));
+        }
+
+        return normalised;
+    }
+
+    public static (DateOnly From, DateOnly To) ValidateWindow(string? from, string? to, DateOnly today)
+    {
+        var fromDate = ParseOrDefault(from, today, nameof(from));
+        var toDate = ParseOrDefault(to, fromDate.AddDays(MaxWindowDays), nameof(to));
+
+        if (toDate < fromDate)
+        {
+            throw new ArgumentException(
+                $"'to' ({toDate:yyyy-MM-dd}) must be on or after 'from' ({fromDate:yyyy-MM-dd}).",
+                nameof(to));
+        }
+
+        var span = toDate.DayNumber - fromDate.DayNumber;
+        if (span > MaxWindowDays)
+        {
+            throw new ArgumentException(
+                $"Window must not exceed {MaxWindowDays} days (requested {span}).",
+                nameof(to));
+        }
+
+        return (fromDate, toDate);
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException("View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+
+    private static DateOnly ParseOrDefault(string? raw, DateOnly fallback, string paramName)
+    {
+        if (string.IsNullOrWhiteSpace(raw))
+        {
+            return fallback;
+        }
+
+        if (!DateOnly.TryParseExact(raw.Trim(), "yyyy-MM-dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+        {
+            throw new ArgumentException(
+                $"'{paramName}' must be an ISO date in 'yyyy-MM-dd' format (received: '{raw}').",
+                paramName);
+        }
+
+        return parsed;
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Calendar/GetCalendarTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Calendar/GetCalendarTool.cs
@@ -1,0 +1,178 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Calendar.Services;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Calendar;
+
+/// <summary>
+/// MCP tool exposing the Finnhub <c>/calendar/*</c> endpoint family as a single
+/// parameter-dispatched lookup. v1 ships earnings; IPO and economic kinds are
+/// added by follow-up stories.
+/// </summary>
+[McpServerToolType]
+public sealed class GetCalendarTool(
+    ICalendarService calendarService,
+    ILogger<GetCalendarTool> logger)
+{
+    /// <summary>
+    /// Dispatched calendar lookup. Returns the events for <paramref name="kind"/> within
+    /// the supplied window, optionally filtered to a single ticker.
+    /// </summary>
+    [McpServerTool(
+        Name = Constants.Tools.Calendar.Name,
+        Title = Constants.Tools.Calendar.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = true)]
+    [Description(Constants.Tools.Calendar.Description)]
+    public async Task<ToolResponseEnvelope<GetCalendarResponse>> GetCalendarAsync(
+        [Description(Constants.Tools.Calendar.Parameters.KindDescription)]
+        string kind,
+        [Description(Constants.Tools.Calendar.Parameters.SymbolDescription)]
+        string? symbol = null,
+        [Description(Constants.Tools.Calendar.Parameters.FromDescription)]
+        string? from = null,
+        [Description(Constants.Tools.Calendar.Parameters.ToDescription)]
+        string? to = null,
+        [Description(Constants.Tools.Calendar.Parameters.ViewDescription)]
+        string? view = null,
+        CancellationToken cancellationToken = default)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        const string ToolName = Constants.Tools.Calendar.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", ToolName);
+
+            var validatedKind = CalendarInputValidator.ValidateKind(kind);
+            var validatedSymbol = CalendarInputValidator.ValidateSymbol(symbol);
+            var (validatedFrom, validatedTo) = CalendarInputValidator.ValidateWindow(
+                from, to, DateOnly.FromDateTime(DateTime.UtcNow));
+            var validatedView = CalendarInputValidator.ValidateView(view);
+
+            var query = new GetCalendarQuery
+            {
+                QueryId = Guid.NewGuid().ToString("N"),
+                Kind = validatedKind,
+                Symbol = validatedSymbol,
+                From = validatedFrom,
+                To = validatedTo
+            };
+
+            var result = await calendarService.GetCalendarAsync(query, cancellationToken);
+
+            var projected = ProjectForView(result, validatedView);
+
+            logger.LogInformation(
+                "Calendar completed for kind={Kind} symbol={Symbol} ({From}..{To}) in {ElapsedMs}ms",
+                validatedKind, validatedSymbol ?? "(all)", validatedFrom, validatedTo, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.FromResult(
+                projected,
+                validatedView,
+                nextActions: BuildNextActions(projected, validatedSymbol),
+                explanation: BuildExplanation(projected, validatedFrom, validatedTo));
+        }
+        catch (OperationCanceledException ex)
+        {
+            logger.LogError(ex, "'{Tool}' was cancelled.", ToolName);
+            throw;
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", ToolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", ToolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished '{Tool}' in {ElapsedMs}ms.", ToolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    /// <summary>Cap on events returned in summary view.</summary>
+    internal const int SummaryEventCap = 10;
+
+    /// <summary>Cap on events returned in standard view.</summary>
+    internal const int StandardEventCap = 25;
+
+    private static Result<GetCalendarResponse> ProjectForView(Result<GetCalendarResponse> source, ToolView view)
+    {
+        if (!source.IsSuccess || source.Data is null || source.Data.EarningsEvents is null)
+        {
+            return source;
+        }
+
+        var cap = view switch
+        {
+            ToolView.Summary => SummaryEventCap,
+            ToolView.Standard => StandardEventCap,
+            _ => int.MaxValue
+        };
+
+        if (source.Data.EarningsEvents.Count <= cap)
+        {
+            return source;
+        }
+
+        var capped = source.Data.EarningsEvents.Take(cap).ToList().AsReadOnly();
+
+        return Result<GetCalendarResponse>.Success(new GetCalendarResponse
+        {
+            Kind = source.Data.Kind,
+            From = source.Data.From,
+            To = source.Data.To,
+            Symbol = source.Data.Symbol,
+            TotalCount = capped.Count,
+            EarningsEvents = capped
+        });
+    }
+
+    private static IReadOnlyList<NextAction> BuildNextActions(Result<GetCalendarResponse> result, string? symbol)
+    {
+        if (!result.IsSuccess || result.Data is null || string.IsNullOrEmpty(symbol))
+        {
+            return [];
+        }
+
+        var args = new Dictionary<string, string>(StringComparer.Ordinal) { ["symbol"] = symbol };
+
+        return
+        [
+            new NextAction("get-financials-snapshot", args, "compare upcoming estimates with the last reported KPIs"),
+            new NextAction("get-news-pulse", args, "check the news pulse heading into the release date")
+        ];
+    }
+
+    private static string BuildExplanation(Result<GetCalendarResponse> result, DateOnly from, DateOnly to)
+    {
+        if (!result.IsSuccess || result.Data is null)
+        {
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                $"No earnings events in {from:yyyy-MM-dd}..{to:yyyy-MM-dd}.");
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Found {result.Data.TotalCount} earnings event(s) in {from:yyyy-MM-dd}..{to:yyyy-MM-dd}.");
+    }
+}

--- a/src/FinnHub.MCP.Server/appsettings.json
+++ b/src/FinnHub.MCP.Server/appsettings.json
@@ -73,6 +73,13 @@
         "IsActive": true,
         "group": "stock",
         "Description": "Returns company profile snapshot for a symbol."
+      },
+      {
+        "Name": "calendar-earnings",
+        "Url": "/calendar/earnings",
+        "IsActive": true,
+        "group": "calendar",
+        "Description": "Returns scheduled corporate-earnings releases within a date window, optionally filtered by symbol."
       }
     ]
   },

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Calendar/Services/CalendarServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/Calendar/Services/CalendarServiceTests.cs
@@ -1,0 +1,194 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Calendar.Clients;
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Calendar.Services;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Tests.Unit.TestDoubles;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Application.Features.Calendar.Services;
+
+public sealed class CalendarServiceTests
+{
+    private readonly ICalendarApiClient _apiClient = Substitute.For<ICalendarApiClient>();
+    private readonly FakeFinnHubCache _cache = new();
+    private readonly CalendarService _sut;
+
+    public CalendarServiceTests()
+    {
+        this._sut = new CalendarService(this._apiClient, this._cache, NullLogger<CalendarService>.Instance);
+    }
+
+    private static GetCalendarQuery EarningsQuery(string? symbol = "AAPL") => new()
+    {
+        QueryId = "q1",
+        Kind = CalendarKind.Earnings,
+        From = new DateOnly(2026, 5, 1),
+        To = new DateOnly(2026, 6, 1),
+        Symbol = symbol
+    };
+
+    private static EarningsEvent Event(string symbol, int dayOffset) => new()
+    {
+        Symbol = symbol,
+        Date = new DateOnly(2026, 5, 1).AddDays(dayOffset),
+        EpsEstimate = 1.0
+    };
+
+    [Fact]
+    public async Task GetCalendarAsync_NullQuery_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => this._sut.GetCalendarAsync(null!));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_EarningsWithEvents_ReturnsSuccess()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns([Event("AAPL", 1)]);
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.True(result.IsSuccess);
+        Assert.Equal("earnings", result.Data!.Kind);
+        Assert.Equal(1, result.Data.TotalCount);
+        Assert.Single(result.Data.EarningsEvents!);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_EarningsEmpty_ReturnsNotFound()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns([]);
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("NotFound", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_OrdersEventsByDateThenSymbol()
+    {
+        EarningsEvent[] unordered =
+        [
+            Event("AAPL", 5),
+            Event("MSFT", 1),
+            Event("GOOG", 1)
+        ];
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns(unordered);
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery(symbol: null));
+
+        Assert.True(result.IsSuccess);
+        var events = result.Data!.EarningsEvents!;
+        Assert.Equal("GOOG", events[0].Symbol);
+        Assert.Equal("MSFT", events[1].Symbol);
+        Assert.Equal("AAPL", events[2].Symbol);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_TwoIdenticalCalls_HitsApiClientExactlyOnce()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .Returns([Event("AAPL", 1)]);
+
+        var query = EarningsQuery();
+        await this._sut.GetCalendarAsync(query);
+        await this._sut.GetCalendarAsync(query);
+
+        Assert.Equal(1, this._cache.FactoryInvocationCount);
+        await this._apiClient.Received(1).GetEarningsCalendarAsync(
+            Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_HttpError_MapsToServiceUnavailable()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientHttpException("boom", HttpStatusCode.BadGateway));
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("ServiceUnavailable", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_Premium_MapsToPremiumRequired()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientPremiumRequiredException("/calendar/earnings", "premium"));
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("PremiumRequired", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_Timeout_MapsToTimeout()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientTimeoutException("slow"));
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Timeout", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_InvalidResponse_MapsToInvalidResponse()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientDeserializationException("bad json"));
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("InvalidResponse", result.ErrorType);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_Cancelled_RethrowsTypedException()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientCancelledException("cancelled"));
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetCalendarAsync(EarningsQuery()));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_UnknownApiClientException_MapsToUnknown()
+    {
+        this._apiClient
+            .GetEarningsCalendarAsync(Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<string?>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new ApiClientUnexpectedException("weird"));
+
+        var result = await this._sut.GetCalendarAsync(EarningsQuery());
+
+        Assert.False(result.IsSuccess);
+        Assert.Equal("Unknown", result.ErrorType);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Calendar/FinnHubCalendarApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Calendar/FinnHubCalendarApiClientTests.cs
@@ -1,0 +1,203 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Calendar;
+using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Calendar;
+
+public sealed class FinnHubCalendarApiClientTests : IDisposable
+{
+    private readonly MockHttpMessageHandler _handler = new();
+    private readonly HttpClient _httpClient;
+    private readonly FinnHubCalendarApiClient _sut;
+
+    public FinnHubCalendarApiClientTests()
+    {
+        this._httpClient = new HttpClient(this._handler) { BaseAddress = new Uri("https://finnhub.io/api/v1/") };
+
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1",
+            ApiKey = "test-key",
+            EndPoints = [new FinnHubEndPoint { Name = "calendar-earnings", Url = "calendar/earnings", IsActive = true }]
+        });
+
+        this._sut = new FinnHubCalendarApiClient(this._httpClient, options, NullLogger<FinnHubCalendarApiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_RealAaplResponse_MapsAllFields()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, Fixture.LoadFinnHub("calendar-earnings-aapl"));
+
+        var events = await this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 8, 1), "AAPL", CancellationToken.None);
+
+        var only = Assert.Single(events);
+        Assert.Equal("AAPL", only.Symbol);
+        Assert.Equal(new DateOnly(2026, 7, 29), only.Date);
+        Assert.Equal("amc", only.Hour);
+        Assert.Equal(3, only.Quarter);
+        Assert.Equal(2026, only.Year);
+        Assert.Null(only.EpsActual);
+        Assert.Equal(1.9316, only.EpsEstimate);
+        Assert.Null(only.RevenueActual);
+        Assert.Equal(110771401872d, only.RevenueEstimate);
+    }
+
+    /// <summary>
+    /// Regression: catches future URL-construction drift for the symbol-filtered path.
+    /// See FinnHubProfilesApiClientTests for the bug class this protects against.
+    /// </summary>
+    [Fact]
+    public async Task GetEarningsCalendarAsync_WithSymbol_HitsApiV1CalendarEarningsEndpoint()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        await this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None);
+
+        Assert.NotNull(this._handler.LastRequest?.RequestUri);
+        Assert.Equal(
+            "https://finnhub.io/api/v1/calendar/earnings?from=2026-05-01&to=2026-06-01&symbol=AAPL",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_WithoutSymbol_OmitsSymbolParameter()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{}");
+
+        await this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), null, CancellationToken.None);
+
+        Assert.Equal(
+            "https://finnhub.io/api/v1/calendar/earnings?from=2026-05-01&to=2026-06-01",
+            this._handler.LastRequest!.RequestUri!.AbsoluteUri);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_EmptyEnvelope_ReturnsEmptyList()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "{\"earningsCalendar\":[]}");
+
+        var events = await this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None);
+
+        Assert.Empty(events);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_EntryWithMalformedDate_IsSkipped()
+    {
+        this._handler.SetResponse(
+            HttpStatusCode.OK,
+            "{\"earningsCalendar\":[{\"symbol\":\"AAPL\",\"date\":\"not-a-date\"},{\"symbol\":\"MSFT\",\"date\":\"2026-06-15\"}]}");
+
+        var events = await this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 8, 1), null, CancellationToken.None);
+
+        Assert.Single(events);
+        Assert.Equal("MSFT", events[0].Symbol);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_EntryWithMissingSymbol_IsSkipped()
+    {
+        this._handler.SetResponse(
+            HttpStatusCode.OK,
+            "{\"earningsCalendar\":[{\"date\":\"2026-06-15\"},{\"symbol\":\"AAPL\",\"date\":\"2026-07-29\"}]}");
+
+        var events = await this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 8, 1), null, CancellationToken.None);
+
+        Assert.Single(events);
+        Assert.Equal("AAPL", events[0].Symbol);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_Forbidden_ThrowsPremiumRequired()
+    {
+        this._handler.SetResponse(HttpStatusCode.Forbidden, "premium");
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() => this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_InvalidJson_ThrowsDeserialization()
+    {
+        this._handler.SetResponse(HttpStatusCode.OK, "not-json");
+
+        await Assert.ThrowsAsync<ApiClientDeserializationException>(() => this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_HttpRequestException_PreservesInnerExceptionAndUsesServiceUnavailable()
+    {
+        var network = new HttpRequestException("DNS resolution failed");
+        this._handler.SetException(network);
+
+        var ex = await Assert.ThrowsAsync<ApiClientHttpException>(() => this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None));
+
+        Assert.Same(network, ex.InnerException);
+        Assert.Equal(HttpStatusCode.ServiceUnavailable, ex.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_TaskCanceledWithTimeout_ThrowsTimeoutException()
+    {
+        this._handler.SetException(new TaskCanceledException("slow", new TimeoutException()));
+
+        await Assert.ThrowsAsync<ApiClientTimeoutException>(() => this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_TokenAlreadyCancelled_ThrowsCancelledException()
+    {
+        using var cts = new CancellationTokenSource();
+        await cts.CancelAsync();
+
+        await Assert.ThrowsAsync<ApiClientCancelledException>(() => this._sut.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", cts.Token));
+    }
+
+    [Fact]
+    public async Task GetEarningsCalendarAsync_NoConfiguredEndpoint_Throws()
+    {
+        var options = Substitute.For<IOptions<FinnHubOptions>>();
+        options.Value.Returns(new FinnHubOptions
+        {
+            BaseUrl = "https://finnhub.io/api/v1/",
+            ApiKey = "test-key",
+            EndPoints = []
+        });
+
+        var client = new FinnHubCalendarApiClient(this._httpClient, options, NullLogger<FinnHubCalendarApiClient>.Instance);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => client.GetEarningsCalendarAsync(
+            new DateOnly(2026, 5, 1), new DateOnly(2026, 6, 1), "AAPL", CancellationToken.None));
+    }
+
+    public void Dispose()
+    {
+        this._handler.Dispose();
+        this._httpClient.Dispose();
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.LiveSmoke/ToolSmokeTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.LiveSmoke/ToolSmokeTests.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using FinnHub.MCP.Server.Application.Calendar.Services;
 using FinnHub.MCP.Server.Application.Financials.Services;
 using FinnHub.MCP.Server.Application.News.Services;
 using FinnHub.MCP.Server.Application.Peers.Services;
@@ -13,6 +14,7 @@ using FinnHub.MCP.Server.Application.Profiles.Services;
 using FinnHub.MCP.Server.Application.Quotes.Services;
 using FinnHub.MCP.Server.Application.Search.Services;
 using FinnHub.MCP.Server.Application.Symbols;
+using FinnHub.MCP.Server.Tools.Calendar;
 using FinnHub.MCP.Server.Tools.Financials;
 using FinnHub.MCP.Server.Tools.News;
 using FinnHub.MCP.Server.Tools.Peers;
@@ -150,6 +152,21 @@ public sealed class ToolSmokeTests : IClassFixture<LiveSmokeFactory>
         var envelope = await tool.GetPeersAsync(Symbol);
 
         AssertSuccessOrPremium(envelope.IsSuccess, envelope.ErrorType, envelope.ErrorMessage);
+    }
+
+    [Fact]
+    public async Task GetCalendar_EarningsAapl_ReturnsScheduleOrDegrades()
+    {
+        // AAPL has scheduled earnings most quarters but the next event can be
+        // outside a 90-day window depending on when this runs; tolerate NotFound
+        // alongside Success/PremiumRequired so the smoke doesn't flap.
+        var tool = new GetCalendarTool(
+            this._services.GetRequiredService<ICalendarService>(),
+            NullLogger<GetCalendarTool>.Instance);
+
+        var envelope = await tool.GetCalendarAsync("earnings", symbol: Symbol);
+
+        AssertGracefulDegradation(envelope.IsSuccess, envelope.ErrorType, envelope.ErrorMessage);
     }
 
     [Fact]

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Calendar/CalendarInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Calendar/CalendarInputValidatorTests.cs
@@ -1,0 +1,151 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Calendar;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Calendar;
+
+public sealed class CalendarInputValidatorTests
+{
+    private static readonly DateOnly s_today = new(2026, 5, 27);
+
+    [Theory]
+    [InlineData("earnings")]
+    [InlineData("EARNINGS")]
+    [InlineData("  Earnings  ")]
+    public void ValidateKind_AcceptsEarningsCaseInsensitive(string kind)
+    {
+        Assert.Equal(CalendarKind.Earnings, CalendarInputValidator.ValidateKind(kind));
+    }
+
+    [Theory]
+    [InlineData("ipo")]
+    [InlineData("economic")]
+    public void ValidateKind_UnsupportedKnownKinds_ThrowsWithUpgradeHint(string kind)
+    {
+        var ex = Assert.Throws<ArgumentException>(() => CalendarInputValidator.ValidateKind(kind));
+        Assert.Contains("not yet supported", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    [InlineData(null)]
+    public void ValidateKind_Empty_Throws(string? kind)
+    {
+        Assert.Throws<ArgumentException>(() => CalendarInputValidator.ValidateKind(kind));
+    }
+
+    [Fact]
+    public void ValidateKind_UnknownToken_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CalendarInputValidator.ValidateKind("dividends"));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateSymbol_NullOrWhitespace_ReturnsNull(string? symbol)
+    {
+        Assert.Null(CalendarInputValidator.ValidateSymbol(symbol));
+    }
+
+    [Theory]
+    [InlineData("aapl", "AAPL")]
+    [InlineData("BRK.A", "BRK.A")]
+    [InlineData("rds-a", "RDS-A")]
+    public void ValidateSymbol_Valid_NormalisesToUppercase(string input, string expected)
+    {
+        Assert.Equal(expected, CalendarInputValidator.ValidateSymbol(input));
+    }
+
+    [Theory]
+    [InlineData("!!!")]
+    [InlineData("1AAPL")]
+    [InlineData("WAY-TOO-LONG-A-SYMBOL")]
+    public void ValidateSymbol_Invalid_Throws(string symbol)
+    {
+        Assert.Throws<ArgumentException>(() => CalendarInputValidator.ValidateSymbol(symbol));
+    }
+
+    [Fact]
+    public void ValidateWindow_BothNull_DefaultsToTodayAndPlus90Days()
+    {
+        var (from, to) = CalendarInputValidator.ValidateWindow(null, null, s_today);
+        Assert.Equal(s_today, from);
+        Assert.Equal(s_today.AddDays(CalendarInputValidator.MaxWindowDays), to);
+    }
+
+    [Fact]
+    public void ValidateWindow_OnlyFromProvided_DefaultsToToFromPlusMax()
+    {
+        var (from, to) = CalendarInputValidator.ValidateWindow("2026-06-01", null, s_today);
+        Assert.Equal(new DateOnly(2026, 6, 1), from);
+        Assert.Equal(new DateOnly(2026, 6, 1).AddDays(CalendarInputValidator.MaxWindowDays), to);
+    }
+
+    [Fact]
+    public void ValidateWindow_ValidPair_Returned()
+    {
+        var (from, to) = CalendarInputValidator.ValidateWindow("2026-05-01", "2026-06-01", s_today);
+        Assert.Equal(new DateOnly(2026, 5, 1), from);
+        Assert.Equal(new DateOnly(2026, 6, 1), to);
+    }
+
+    [Fact]
+    public void ValidateWindow_ToBeforeFrom_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            CalendarInputValidator.ValidateWindow("2026-06-01", "2026-05-01", s_today));
+        Assert.Contains("must be on or after", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ValidateWindow_ExceedsMaxSpan_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() =>
+            CalendarInputValidator.ValidateWindow("2026-05-01", "2026-09-01", s_today));
+        Assert.Contains("must not exceed", ex.Message, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("2026/05/01")]
+    [InlineData("01-05-2026")]
+    [InlineData("not-a-date")]
+    public void ValidateWindow_BadFromFormat_Throws(string from)
+    {
+        Assert.Throws<ArgumentException>(() => CalendarInputValidator.ValidateWindow(from, "2026-06-01", s_today));
+    }
+
+    [Fact]
+    public void ValidateWindow_SameDay_IsValid()
+    {
+        var (from, to) = CalendarInputValidator.ValidateWindow("2026-05-27", "2026-05-27", s_today);
+        Assert.Equal(from, to);
+    }
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("", ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("Standard", ToolView.Standard)]
+    [InlineData("FULL", ToolView.Full)]
+    public void ValidateView_AcceptsKnownValuesCaseInsensitive(string? view, ToolView expected)
+    {
+        Assert.Equal(expected, CalendarInputValidator.ValidateView(view));
+    }
+
+    [Fact]
+    public void ValidateView_Unknown_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => CalendarInputValidator.ValidateView("brief"));
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Calendar/GetCalendarToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Calendar/GetCalendarToolTests.cs
@@ -1,0 +1,197 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
+using FinnHub.MCP.Server.Application.Calendar.Services;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Calendar;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using NSubstitute.ExceptionExtensions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Calendar;
+
+public sealed class GetCalendarToolTests
+{
+    private readonly ICalendarService _service = Substitute.For<ICalendarService>();
+    private readonly GetCalendarTool _sut;
+
+    public GetCalendarToolTests()
+    {
+        this._sut = new GetCalendarTool(this._service, NullLogger<GetCalendarTool>.Instance);
+    }
+
+    private static GetCalendarResponse Response(int events, string? symbol = "AAPL") => new()
+    {
+        Kind = "earnings",
+        From = new DateOnly(2026, 5, 1),
+        To = new DateOnly(2026, 6, 1),
+        Symbol = symbol,
+        TotalCount = events,
+        EarningsEvents = Enumerable.Range(1, events)
+            .Select(i => new EarningsEvent
+            {
+                Symbol = symbol ?? "AAPL",
+                Date = new DateOnly(2026, 5, 1).AddDays(i),
+                EpsEstimate = i
+            })
+            .ToList()
+            .AsReadOnly()
+    };
+
+    [Fact]
+    public async Task GetCalendarAsync_InvalidKind_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetCalendarAsync("dividends"));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_UnsupportedKind_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetCalendarAsync("ipo"));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_InvalidSymbol_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() => this._sut.GetCalendarAsync("earnings", symbol: "!!!"));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_InvalidView_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._sut.GetCalendarAsync("earnings", view: "brief"));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_ToBeforeFrom_Throws()
+    {
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            this._sut.GetCalendarAsync("earnings", from: "2026-06-01", to: "2026-05-01"));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_LowercaseSymbol_NormalisesToUppercase()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(1)));
+
+        await this._sut.GetCalendarAsync("earnings", symbol: "aapl", from: "2026-05-01", to: "2026-06-01");
+
+        await this._service.Received(1).GetCalendarAsync(
+            Arg.Is<GetCalendarQuery>(q => q.Symbol == "AAPL"),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_OmittedSymbol_PassesNullToService()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(1, symbol: null)));
+
+        await this._sut.GetCalendarAsync("earnings", from: "2026-05-01", to: "2026-06-01");
+
+        await this._service.Received(1).GetCalendarAsync(
+            Arg.Is<GetCalendarQuery>(q => q.Symbol == null),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_SummaryView_CapsAtTenEvents()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(30)));
+
+        var envelope = await this._sut.GetCalendarAsync(
+            "earnings", symbol: "AAPL", from: "2026-05-01", to: "2026-06-01", view: "summary");
+
+        Assert.True(envelope.IsSuccess);
+        Assert.Equal(GetCalendarTool.SummaryEventCap, envelope.Data!.TotalCount);
+        Assert.Equal(GetCalendarTool.SummaryEventCap, envelope.Data.EarningsEvents!.Count);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_StandardView_CapsAtTwentyFiveEvents()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(40)));
+
+        var envelope = await this._sut.GetCalendarAsync(
+            "earnings", symbol: "AAPL", from: "2026-05-01", to: "2026-06-01", view: "standard");
+
+        Assert.Equal(GetCalendarTool.StandardEventCap, envelope.Data!.TotalCount);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_FullView_ReturnsAll()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(40)));
+
+        var envelope = await this._sut.GetCalendarAsync(
+            "earnings", symbol: "AAPL", from: "2026-05-01", to: "2026-06-01", view: "full");
+
+        Assert.Equal(40, envelope.Data!.TotalCount);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_SuccessWithSymbol_PopulatesNextActions()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(1)));
+
+        var envelope = await this._sut.GetCalendarAsync("earnings", symbol: "AAPL");
+
+        Assert.Equal(2, envelope.NextActions.Count);
+        Assert.Equal("get-financials-snapshot", envelope.NextActions[0].Tool);
+        Assert.Equal("get-news-pulse", envelope.NextActions[1].Tool);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_SuccessWithoutSymbol_ReturnsEmptyNextActions()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Success(Response(1, symbol: null)));
+
+        var envelope = await this._sut.GetCalendarAsync("earnings");
+
+        Assert.Empty(envelope.NextActions);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_FailureResult_ReturnsEmptyNextActions()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .Returns(Result<GetCalendarResponse>.Failure("upstream-error"));
+
+        var envelope = await this._sut.GetCalendarAsync("earnings", symbol: "AAPL");
+
+        Assert.Empty(envelope.NextActions);
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_Cancelled_PropagatesOperationCanceled()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new OperationCanceledException());
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() =>
+            this._sut.GetCalendarAsync("earnings", symbol: "AAPL"));
+    }
+
+    [Fact]
+    public async Task GetCalendarAsync_UnexpectedFailure_PropagatesException()
+    {
+        this._service.GetCalendarAsync(Arg.Any<GetCalendarQuery>(), Arg.Any<CancellationToken>())
+            .ThrowsAsync(new InvalidOperationException("downstream broke"));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            this._sut.GetCalendarAsync("earnings", symbol: "AAPL"));
+    }
+}

--- a/tests/Fixtures/finnhub/calendar-earnings-aapl.json
+++ b/tests/Fixtures/finnhub/calendar-earnings-aapl.json
@@ -1,0 +1,1 @@
+{"earningsCalendar":[{"date":"2026-07-29","epsActual":null,"epsEstimate":1.9316,"hour":"amc","quarter":3,"revenueActual":null,"revenueEstimate":110771401872,"symbol":"AAPL","year":2026}]}

--- a/tests/Fixtures/finnhub/capture.sh
+++ b/tests/Fixtures/finnhub/capture.sh
@@ -41,3 +41,8 @@ fetch profile-AAPL             "stock/profile2?symbol=AAPL"
 fetch candle-AAPL              "stock/candle?symbol=AAPL&resolution=D&from=$WEEK_AGO&to=$NOW"
 fetch company-news-AAPL        "company-news?symbol=AAPL&from=$FROM&to=$TO"
 fetch news-sentiment-AAPL      "news-sentiment?symbol=AAPL"
+# Calendar (parameter-dispatched tool: kind=earnings|ipo|economic).
+# Earnings fixture: AAPL-scoped, current quarter window.
+CAL_FROM=$(date -u +%Y-%m-01)
+CAL_TO=$(date -u -v+3m +%Y-%m-%d 2>/dev/null || date -u -d '+3 months' +%Y-%m-%d)
+fetch calendar-earnings-aapl   "calendar/earnings?from=$CAL_FROM&to=$CAL_TO&symbol=AAPL"


### PR DESCRIPTION
## Summary
- Adds the `get-calendar` MCP tool with parameter-dispatched routing (v1 ships `kind=earnings`; IPO and economic kinds land in follow-up stories that extend the validator + service switch).
- Earnings dispatch covers `/calendar/earnings` with optional symbol filter, ISO date window (max 90 days), defensive entry parsing (skips malformed dates / missing symbols), and summary/standard view caps (10/25 events).
- Real captured fixture at `tests/Fixtures/finnhub/calendar-earnings-aapl.json` (AAPL Q3 2026) drives the client test; on-wire URL is pinned for both symbol-filtered and unfiltered paths.
- `next_actions` cross-link to `get-financials-snapshot` and `get-news-pulse` when a symbol is supplied.

Closes #214

## Test plan
- [x] `dotnet build` — clean (TreatWarningsAsErrors)
- [x] `dotnet format --verify-no-changes` — clean
- [x] `dotnet test --filter "Category!=LiveSmoke"` — 520 passed (110 infra + 146 app + 264 server)
- [x] LiveSmoke `GetCalendar_EarningsAapl_ReturnsScheduleOrDegrades` — passed against real Finnhub
- [x] Full LiveSmoke suite — 9 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)