### PR TITLE
feat(resource): serve full exchanges catalog from curated reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 
 - ✅ **MCP Tools and Resources** wired to the official `ModelContextProtocol` and `ModelContextProtocol.AspNetCore` packages
 - ✅ **Symbol Search Tool** with input validation and sanitization (regex-based length and character constraints)
-- ✅ **Exchanges Resource** exposed at `finnhub://resources/exchanges` for venue metadata (currently a stub pending the live Finnhub `/stock/exchange` wiring)
+- ✅ **Exchanges Resource** exposed at `finnhub://resources/exchanges` — the full catalog of stock venues Finnhub supports (79 exchanges), served from Finnhub's published reference list
 - ✅ **Resilient HTTP Communication** — typed `HttpClient` with retry, timeout, and circuit-breaker policies via `Microsoft.Extensions.Http.Resilience` and Polly
 - ✅ **Source-generated JSON** through `System.Text.Json` `JsonSerializerContext` for low-allocation, AOT-friendly (de)serialization
 - ✅ **Strongly-typed configuration** — `FinnHubOptions` bound from `appsettings.json` with data-annotation validation on startup
@@ -51,11 +51,8 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 Every tool returns the standard token-budgeted envelope with cross-linked `next_actions` and the most-recent observed Finnhub rate-limit headers.
 
 **Resources (2):**
-- **`finnhub://resources/exchanges`** — catalog of stock exchanges (code, name, country, MIC, timezone, trading hours)
+- **`finnhub://resources/exchanges`** — the full catalog of stock venues Finnhub supports (79 exchanges: code, name, country, MIC, timezone, market hours). `url` is `null` for the few venues Finnhub lists without a reference link.
 - **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
-
-### 🔄 In Development
-- Wire `ExchangesResource` to the live Finnhub `/stock/exchange` endpoint
 
 ### 📋 Planned
 - `search-tools` meta-tool for intent-based discovery (P7)
@@ -254,7 +251,31 @@ A response that exceeds its declared view's token ceiling is rebuilt by the tool
 
 ### Resource: `finnhub://resources/exchanges`
 
-Returns the list of stock exchanges available through the provider as `application/json`.
+Returns the full catalog of stock venues Finnhub supports (79 exchanges) as `application/json`. Finnhub exposes no `/stock/exchange` API endpoint — the supported-exchange list is published only as a reference document — so the catalog ships as in-process reference data captured from Finnhub's published "Supported Exchanges" sheet rather than a live upstream call.
+
+```json
+{
+  "exchanges": [
+    {
+      "code": "US",
+      "name": "US exchanges (NYSE, Nasdaq)",
+      "mic": "XNYS,XASE,BATS,ARCX,XNMS,XNCM,XNGS,IEXG,XNAS, OTCM, OOTC",
+      "time_zone": "America/New_York",
+      "pre_market_hours": "04:00-09:30",
+      "trading_hours": "09:30-16:00",
+      "post_market_hours": "16:00-20:00",
+      "close_date": "7,0",
+      "country_code": "US",
+      "country_name": "US",
+      "url": "https://www.tradinghours.com/exchanges/nyse"
+    }
+  ],
+  "total_count": 79,
+  "has_results": true
+}
+```
+
+`url` is `null` for the few venues Finnhub lists without a reference link.
 
 ### Resource: `finnhub://resources/api-status`
 

--- a/src/FinnHub.MCP.Server.Application/Exchanges/Exchange.cs
+++ b/src/FinnHub.MCP.Server.Application/Exchanges/Exchange.cs
@@ -77,8 +77,9 @@ public sealed class Exchange
     public required string CountryName { get; init; }
 
     /// <summary>
-    /// Gets the URL for more information about the exchange.
+    /// Gets the URL for more information about the exchange, or <c>null</c> when
+    /// Finnhub publishes no reference link for the venue.
     /// </summary>
     [JsonPropertyName("url")]
-    public required string Url { get; init; }
+    public string? Url { get; init; }
 }

--- a/src/FinnHub.MCP.Server.Application/Exchanges/Features/GetAllExchanges/ExchangeCatalog.Data.cs
+++ b/src/FinnHub.MCP.Server.Application/Exchanges/Features/GetAllExchanges/ExchangeCatalog.Data.cs
@@ -1,0 +1,1132 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
+
+/// <content>
+/// The verbatim catalog data backing <see cref="ExchangeCatalog"/>.
+/// </content>
+/// <remarks>
+/// Generated from Finnhub's public "Supported Exchanges" reference sheet
+/// (https://docs.google.com/spreadsheets/d/1I3pBxjfXB056-g_JYf_6o3Rns3BV2kMGG1nCatb91ls),
+/// retrieved 2026-05-31. Columns are mapped 1:1 onto <see cref="Exchange"/> and values
+/// are preserved as-published — including the raw <c>close_date</c> weekday encoding and
+/// the absent reference URLs for venues Finnhub lists without one. Do not hand-edit;
+/// re-export the sheet to refresh.
+/// </remarks>
+public sealed partial class ExchangeCatalog
+{
+    private static readonly IReadOnlyList<Exchange> s_all =
+    [
+        new Exchange
+        {
+            ExchangeCode = "AD",
+            ExchangeName = "ABU DHABI SECURITIES EXCHANGE",
+            MicCode = "XADS",
+            TimeZone = "Asia/Dubai",
+            PreMarketHours = null,
+            TradingHours = "10:00-14:44",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "AE",
+            CountryName = "UAE",
+            Url = "https://www.tradinghours.com/markets/adx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "AS",
+            ExchangeName = "NYSE EURONEXT - EURONEXT AMSTERDAM",
+            MicCode = "XAMS",
+            TimeZone = "Europe/Amsterdam",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "NL",
+            CountryName = "Netherlands",
+            Url = "https://www.tradinghours.com/exchanges/euronext"
+        },
+        new Exchange
+        {
+            ExchangeCode = "AT",
+            ExchangeName = "ATHENS EXCHANGE S.A. CASH MARKET",
+            MicCode = "ASEX",
+            TimeZone = "Europe/Athens",
+            PreMarketHours = null,
+            TradingHours = "10:15-17:20",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "GR",
+            CountryName = "Greece",
+            Url = "https://www.tradinghours.com/exchanges/ase-athens"
+        },
+        new Exchange
+        {
+            ExchangeCode = "AX",
+            ExchangeName = "ASX - ALL MARKETS",
+            MicCode = "XASX",
+            TimeZone = "Australia/Sydney",
+            PreMarketHours = "07:00-10:00",
+            TradingHours = "10:00-16:00",
+            PostMarketHours = "16:00-18:50",
+            CloseDate = "7,0",
+            CountryCode = "AU",
+            CountryName = "Australia",
+            Url = "https://www.tradinghours.com/exchanges/asx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BA",
+            ExchangeName = "BOLSA DE COMERCIO DE BUENOS AIRES",
+            MicCode = "XBUE",
+            TimeZone = "America/Argentina/Buenos_Aires",
+            PreMarketHours = null,
+            TradingHours = "10:30-17:15",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "AR",
+            CountryName = "Argentina",
+            Url = "https://www.tradinghours.com/exchanges/bcba"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BC",
+            ExchangeName = "BOLSA DE VALORES DE COLOMBIA",
+            MicCode = "XBOG",
+            TimeZone = "America/Cuiaba",
+            PreMarketHours = null,
+            TradingHours = "09:15-16:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CO",
+            CountryName = "Colombia",
+            Url = "https://www.tradinghours.com/exchanges/bvc"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BD",
+            ExchangeName = "BUDAPEST STOCK EXCHANGE",
+            MicCode = "XBUD",
+            TimeZone = "Europe/Budapest",
+            PreMarketHours = null,
+            TradingHours = "08:15-17:20",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "HU",
+            CountryName = "Hungary",
+            Url = "https://www.tradinghours.com/exchanges/bse-budapest"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BE",
+            ExchangeName = "BOERSE BERLIN",
+            MicCode = "XBER",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/xber"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BH",
+            ExchangeName = "BAHRAIN BOURSE",
+            MicCode = "XBAH",
+            TimeZone = "Asia/Bahrain",
+            PreMarketHours = null,
+            TradingHours = "09:30-13:00",
+            PostMarketHours = null,
+            CloseDate = "6,7",
+            CountryCode = "BH",
+            CountryName = "Bahrain",
+            Url = "https://www.tradinghours.com/markets/bhb"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BK",
+            ExchangeName = "STOCK EXCHANGE OF THAILAND",
+            MicCode = "XBKK",
+            TimeZone = "Asia/Bangkok",
+            PreMarketHours = null,
+            TradingHours = "09:30-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "TH",
+            CountryName = "Thailand",
+            Url = "https://www.tradinghours.com/exchanges/set"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BO",
+            ExchangeName = "BSE LTD",
+            MicCode = "XBOM",
+            TimeZone = "Asia/Kolkata",
+            PreMarketHours = null,
+            TradingHours = "09:00-16:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "IN",
+            CountryName = "India",
+            Url = "https://www.tradinghours.com/exchanges/bse-bombay"
+        },
+        new Exchange
+        {
+            ExchangeCode = "BR",
+            ExchangeName = "NYSE EURONEXT - EURONEXT BRUSSELS",
+            MicCode = "XBRU",
+            TimeZone = "Europe/Brussels",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "BE",
+            CountryName = "Belgium",
+            Url = "https://www.tradinghours.com/exchanges/euronext-brussels"
+        },
+        new Exchange
+        {
+            ExchangeCode = "CA",
+            ExchangeName = "Egyptian Stock Exchange",
+            MicCode = "XCAI",
+            TimeZone = "Africa/Cairo",
+            PreMarketHours = null,
+            TradingHours = "10:00-14:30",
+            PostMarketHours = null,
+            CloseDate = "6,7",
+            CountryCode = "EG",
+            CountryName = "Egypt",
+            Url = "https://www.tradinghours.com/markets/egx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "CN",
+            ExchangeName = "CANADIAN NATIONAL STOCK EXCHANGE",
+            MicCode = "XCNQ",
+            TimeZone = "America/New_York",
+            PreMarketHours = "07:00-09:30",
+            TradingHours = "09:30-16:00",
+            PostMarketHours = "16:00-17:00",
+            CloseDate = "7,0",
+            CountryCode = "CA",
+            CountryName = "Canada",
+            Url = "https://www.tradinghours.com/exchanges/cnsx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "CO",
+            ExchangeName = "OMX NORDIC EXCHANGE COPENHAGEN A/S",
+            MicCode = "XCSE,FNDK",
+            TimeZone = "Europe/Copenhagen",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DK",
+            CountryName = "Denmark",
+            Url = "https://www.tradinghours.com/exchanges/omxc-copenhagen"
+        },
+        new Exchange
+        {
+            ExchangeCode = "CR",
+            ExchangeName = "CARACAS STOCK EXCHANGE",
+            MicCode = "BVCA",
+            TimeZone = "America/Caracas",
+            PreMarketHours = null,
+            TradingHours = "08:30-13:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "VE",
+            CountryName = "Venezuela",
+            Url = "https://www.tradinghours.com/exchanges/bvcc"
+        },
+        new Exchange
+        {
+            ExchangeCode = "CS",
+            ExchangeName = "CASABLANCA STOCK EXCHANGE",
+            MicCode = "XCAS",
+            TimeZone = "Africa/Casablanca",
+            PreMarketHours = null,
+            TradingHours = "09:30-15:20",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "MA",
+            CountryName = "Morroco",
+            Url = "https://www.tradinghours.com/markets/bc"
+        },
+        new Exchange
+        {
+            ExchangeCode = "DB",
+            ExchangeName = "DUBAI FINANCIAL MARKET",
+            MicCode = "XDFM",
+            TimeZone = "Asia/Dubai",
+            PreMarketHours = null,
+            TradingHours = "09:30-14:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "AE",
+            CountryName = "UAE",
+            Url = "https://www.tradinghours.com/exchanges/dfm"
+        },
+        new Exchange
+        {
+            ExchangeCode = "DE",
+            ExchangeName = "XETRA",
+            MicCode = "XETR",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/xetr"
+        },
+        new Exchange
+        {
+            ExchangeCode = "DU",
+            ExchangeName = "BOERSE DUESSELDORF",
+            MicCode = "XDUS",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00:20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/xdus"
+        },
+        new Exchange
+        {
+            ExchangeCode = "F",
+            ExchangeName = "DEUTSCHE BOERSE AG",
+            MicCode = "XFRA",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/fsx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "HE",
+            ExchangeName = "NASDAQ OMX HELSINKI LTD",
+            MicCode = "XHEL,FNFI",
+            TimeZone = "Europe/Helsinki",
+            PreMarketHours = null,
+            TradingHours = "10:00-18:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "FI",
+            CountryName = "Finland",
+            Url = "https://www.tradinghours.com/exchanges/omxh-helsinki"
+        },
+        new Exchange
+        {
+            ExchangeCode = "HK",
+            ExchangeName = "HONG KONG EXCHANGES AND CLEARING LTD",
+            MicCode = "XHKG",
+            TimeZone = "Asia/Hong_Kong",
+            PreMarketHours = null,
+            TradingHours = "09:00-16:10",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "HK",
+            CountryName = "Hong Kong",
+            Url = "https://www.tradinghours.com/exchanges/hkex"
+        },
+        new Exchange
+        {
+            ExchangeCode = "HM",
+            ExchangeName = "HANSEATISCHE WERTPAPIERBOERSE HAMBURG",
+            MicCode = "XHAM",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/xham"
+        },
+        new Exchange
+        {
+            ExchangeCode = "IC",
+            ExchangeName = "NASDAQ OMX ICELAND",
+            MicCode = "XICE,FNIS",
+            TimeZone = "Atlantic/Reykjavik",
+            PreMarketHours = null,
+            TradingHours = "09:30-15:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "IS",
+            CountryName = "Iceland",
+            Url = "https://www.tradinghours.com/exchanges/xice"
+        },
+        new Exchange
+        {
+            ExchangeCode = "IR",
+            ExchangeName = "IRISH STOCK EXCHANGE - ALL MARKET",
+            MicCode = "XDUB",
+            TimeZone = "Europe/Dublin",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "IE",
+            CountryName = "Ireland",
+            Url = "https://www.tradinghours.com/exchanges/ise"
+        },
+        new Exchange
+        {
+            ExchangeCode = "IS",
+            ExchangeName = "BORSA ISTANBUL",
+            MicCode = "XIST",
+            TimeZone = "Europe/Istanbul",
+            PreMarketHours = null,
+            TradingHours = "09:40-18:10",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "TR",
+            CountryName = "Turkey",
+            Url = "https://www.tradinghours.com/exchanges/bist"
+        },
+        new Exchange
+        {
+            ExchangeCode = "JK",
+            ExchangeName = "INDONESIA STOCK EXCHANGE",
+            MicCode = "XIDX",
+            TimeZone = "Asia/Jakarta",
+            PreMarketHours = null,
+            TradingHours = "08:45-15:15",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "ID",
+            CountryName = "Indonesia",
+            Url = "https://www.tradinghours.com/exchanges/idx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "JO",
+            ExchangeName = "JOHANNESBURG STOCK EXCHANGE",
+            MicCode = "XJSE",
+            TimeZone = "Africa/Johannesburg",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "ZA",
+            CountryName = "South Africa",
+            Url = "https://www.tradinghours.com/exchanges/jse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "KL",
+            ExchangeName = "BURSA MALAYSIA",
+            MicCode = "XKLS",
+            TimeZone = "Asia/Kuala_Lumpur",
+            PreMarketHours = null,
+            TradingHours = "08:30-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "MY",
+            CountryName = "Malaysia",
+            Url = "https://www.tradinghours.com/exchanges/myx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "KQ",
+            ExchangeName = "KOREA EXCHANGE (KOSDAQ)",
+            MicCode = "XKOS",
+            TimeZone = "Asia/Seoul",
+            PreMarketHours = null,
+            TradingHours = "09:00-15:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "KP",
+            CountryName = "Korea",
+            Url = "https://www.tradinghours.com/exchanges/kosdaq"
+        },
+        new Exchange
+        {
+            ExchangeCode = "KS",
+            ExchangeName = "KOREA EXCHANGE (STOCK MARKET)",
+            MicCode = "XKRX",
+            TimeZone = "Asia/Seoul",
+            PreMarketHours = null,
+            TradingHours = "08:00-18:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "KP",
+            CountryName = "Korea",
+            Url = "https://www.tradinghours.com/exchanges/krx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "KW",
+            ExchangeName = "Kuwait Stock Exchange",
+            MicCode = "XKUW",
+            TimeZone = "Asia/Kuwait",
+            PreMarketHours = null,
+            TradingHours = "09:00-13:15",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "KW",
+            CountryName = "Kuwait",
+            Url = "https://www.tradinghours.com/markets/xkuw"
+        },
+        new Exchange
+        {
+            ExchangeCode = "L",
+            ExchangeName = "LONDON STOCK EXCHANGE",
+            MicCode = "XLON",
+            TimeZone = "Europe/London",
+            PreMarketHours = null,
+            TradingHours = "08:00-16:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "GB",
+            CountryName = "UK",
+            Url = "https://www.tradinghours.com/exchanges/lse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "LS",
+            ExchangeName = "NYSE EURONEXT - EURONEXT LISBON",
+            MicCode = "XLIS",
+            TimeZone = "Europe/Lisbon",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "PT",
+            CountryName = "Portugal",
+            Url = "https://www.tradinghours.com/exchanges/euronext-lisbon"
+        },
+        new Exchange
+        {
+            ExchangeCode = "MC",
+            ExchangeName = "BOLSA DE MADRID",
+            MicCode = "XMAD",
+            TimeZone = "Europe/Madrid",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "ES",
+            CountryName = "Spain",
+            Url = "https://www.tradinghours.com/exchanges/bme"
+        },
+        new Exchange
+        {
+            ExchangeCode = "ME",
+            ExchangeName = "MOSCOW EXCHANGE",
+            MicCode = "MISX",
+            TimeZone = "Europe/Moscow",
+            PreMarketHours = null,
+            TradingHours = "09:30-19:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "RU",
+            CountryName = "Russia",
+            Url = "https://www.tradinghours.com/exchanges/moex"
+        },
+        new Exchange
+        {
+            ExchangeCode = "MI",
+            ExchangeName = "Italian Stock Exchange",
+            MicCode = "XMIL",
+            TimeZone = "Europe/Rome",
+            PreMarketHours = null,
+            TradingHours = "08:00-17:42",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "IT",
+            CountryName = "Italy",
+            Url = "https://www.tradinghours.com/exchanges/mta"
+        },
+        new Exchange
+        {
+            ExchangeCode = "MT",
+            ExchangeName = "MALTA STOCK EXCHANGE",
+            MicCode = "XMAL",
+            TimeZone = "Europe/Malta",
+            PreMarketHours = null,
+            TradingHours = "09:30-15:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "MT",
+            CountryName = "Malta",
+            Url = "https://www.tradinghours.com/markets/mse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "MU",
+            ExchangeName = "BOERSE MUENCHEN",
+            MicCode = "XMUN",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/xmun"
+        },
+        new Exchange
+        {
+            ExchangeCode = "MX",
+            ExchangeName = "BOLSA MEXICANA DE VALORES (MEXICAN STOCK EXCHANGE)",
+            MicCode = "XMEX",
+            TimeZone = "America/Mexico_City",
+            PreMarketHours = null,
+            TradingHours = "08:00-15:10",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "MX",
+            CountryName = "Mexico",
+            Url = "https://www.tradinghours.com/exchanges/bmv"
+        },
+        new Exchange
+        {
+            ExchangeCode = "NE",
+            ExchangeName = "AEQUITAS NEO EXCHANGE",
+            MicCode = "NEOE",
+            TimeZone = "America/Toronto",
+            PreMarketHours = null,
+            TradingHours = "09:30-16:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CA",
+            CountryName = "Canada",
+            Url = "https://www.tradinghours.com/exchanges/neo"
+        },
+        new Exchange
+        {
+            ExchangeCode = "NL",
+            ExchangeName = "Nigerian Stock Exchange",
+            MicCode = "XNSA",
+            TimeZone = "Africa/Lagos",
+            PreMarketHours = null,
+            TradingHours = "09:30-14:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "NG",
+            CountryName = "Nigeria",
+            Url = "https://www.tradinghours.com/markets/nse-nigeria"
+        },
+        new Exchange
+        {
+            ExchangeCode = "NS",
+            ExchangeName = "NATIONAL STOCK EXCHANGE OF INDIA",
+            MicCode = "XNSE",
+            TimeZone = "Asia/Kolkata",
+            PreMarketHours = null,
+            TradingHours = "09:00-16:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "IN",
+            CountryName = "India",
+            Url = "https://www.tradinghours.com/exchanges/nse-india"
+        },
+        new Exchange
+        {
+            ExchangeCode = "NZ",
+            ExchangeName = "NEW ZEALAND EXCHANGE LTD",
+            MicCode = "XNZE",
+            TimeZone = "Pacific/Auckland",
+            PreMarketHours = null,
+            TradingHours = "10:00-16:45",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "NZ",
+            CountryName = "New Zealand",
+            Url = "https://www.tradinghours.com/exchanges/nzx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "OL",
+            ExchangeName = "OSLO BORS ASA",
+            MicCode = "XOSL",
+            TimeZone = "Europe/Oslo",
+            PreMarketHours = null,
+            TradingHours = "08:15-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "NO",
+            CountryName = "Norway",
+            Url = "https://www.tradinghours.com/exchanges/ose"
+        },
+        new Exchange
+        {
+            ExchangeCode = "OM",
+            ExchangeName = "Muscat Stock Exchange",
+            MicCode = "XMUS",
+            TimeZone = "Asia/Muscat",
+            PreMarketHours = null,
+            TradingHours = "10:00-14:00",
+            PostMarketHours = null,
+            CloseDate = "6,7",
+            CountryCode = "OM",
+            CountryName = "Oman",
+            Url = null
+        },
+        new Exchange
+        {
+            ExchangeCode = "PA",
+            ExchangeName = "NYSE EURONEXT - MARCHE LIBRE PARIS",
+            MicCode = "XPAR",
+            TimeZone = "Europe/Paris",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "FR",
+            CountryName = "France",
+            Url = "https://www.tradinghours.com/exchanges/euronext-paris"
+        },
+        new Exchange
+        {
+            ExchangeCode = "PM",
+            ExchangeName = "Philippine Stock Exchange",
+            MicCode = "XPHS",
+            TimeZone = "Asia/Manila",
+            PreMarketHours = null,
+            TradingHours = "09:30-13:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "PH",
+            CountryName = "Philipppine",
+            Url = "https://www.tradinghours.com/markets/pse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "PR",
+            ExchangeName = "PRAGUE STOCK EXCHANGE",
+            MicCode = "XPRA",
+            TimeZone = "Europe/Prague",
+            PreMarketHours = null,
+            TradingHours = "08:00-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CZ",
+            CountryName = "Czech",
+            Url = "https://www.tradinghours.com/exchanges/xpra"
+        },
+        new Exchange
+        {
+            ExchangeCode = "QA",
+            ExchangeName = "QATAR EXCHANGE",
+            MicCode = "DSMD",
+            TimeZone = "Asia/Qatar",
+            PreMarketHours = null,
+            TradingHours = "09:00-13:15",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "QA",
+            CountryName = "Qatar",
+            Url = "https://www.tradinghours.com/exchanges/qe"
+        },
+        new Exchange
+        {
+            ExchangeCode = "RO",
+            ExchangeName = "BUCHAREST STOCK EXCHANGE",
+            MicCode = "XBSE",
+            TimeZone = "Europe/Bucharest",
+            PreMarketHours = null,
+            TradingHours = "10:00-17:45",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "RO",
+            CountryName = "Romania",
+            Url = "https://www.tradinghours.com/markets/bvb"
+        },
+        new Exchange
+        {
+            ExchangeCode = "RG",
+            ExchangeName = "NASDAQ OMX RIGA",
+            MicCode = "XRIS",
+            TimeZone = "Europe/Riga",
+            PreMarketHours = null,
+            TradingHours = "09:00-16:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "LV",
+            CountryName = "Latvia",
+            Url = "https://www.tradinghours.com/exchanges/omxr-riga"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SA",
+            ExchangeName = "Brazil Bolsa - Sao Paolo",
+            MicCode = "BVMF",
+            TimeZone = "America/Sao_Paulo",
+            PreMarketHours = null,
+            TradingHours = "09:45-18:45",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "BR",
+            CountryName = "Brazil",
+            Url = "https://www.tradinghours.com/exchanges/bovespa"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SG",
+            ExchangeName = "BOERSE STUTTGART",
+            MicCode = "XSTU",
+            TimeZone = "Asia/Amman",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = "https://www.tradinghours.com/exchanges/xstu"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SI",
+            ExchangeName = "SINGAPORE EXCHANGE",
+            MicCode = "XSES",
+            TimeZone = "Asia/Singapore",
+            PreMarketHours = null,
+            TradingHours = "08:30-17:16",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "SG",
+            CountryName = "Singapore",
+            Url = "https://www.tradinghours.com/exchanges/sgx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SN",
+            ExchangeName = "SANTIAGO STOCK EXCHANGE",
+            MicCode = "XSGO",
+            TimeZone = "America/Santiago",
+            PreMarketHours = null,
+            TradingHours = "09:30-16:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CL",
+            CountryName = "Chile",
+            Url = "https://www.tradinghours.com/exchanges/bvs"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SR",
+            ExchangeName = "SAUDI STOCK EXCHANGE",
+            MicCode = "XSAU",
+            TimeZone = "Asia/Riyadh",
+            PreMarketHours = null,
+            TradingHours = "10:00-15:10",
+            PostMarketHours = null,
+            CloseDate = "6,7",
+            CountryCode = "SA",
+            CountryName = "Saudi",
+            Url = "https://www.tradinghours.com/exchanges/tadawul"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SS",
+            ExchangeName = "SHANGHAI STOCK EXCHANGE",
+            MicCode = "XSHG",
+            TimeZone = "Asia/Shanghai",
+            PreMarketHours = null,
+            TradingHours = "09:15-15:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CN",
+            CountryName = "China",
+            Url = "https://www.tradinghours.com/exchanges/sse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "ST",
+            ExchangeName = "NASDAQ OMX NORDIC STOCKHOLM",
+            MicCode = "XSTO,FNSE",
+            TimeZone = "Europe/Stockholm",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:30",
+            PostMarketHours = "17:30-18:00",
+            CloseDate = "7,0",
+            CountryCode = "SE",
+            CountryName = "Sweden",
+            Url = "https://www.tradinghours.com/exchanges/xngm"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SW",
+            ExchangeName = "SWISS EXCHANGE",
+            MicCode = "XSWX",
+            TimeZone = "Europe/Zurich",
+            PreMarketHours = null,
+            TradingHours = "09:30-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CH",
+            CountryName = "Switzerland",
+            Url = "https://www.tradinghours.com/exchanges/six"
+        },
+        new Exchange
+        {
+            ExchangeCode = "SZ",
+            ExchangeName = "SHENZHEN STOCK EXCHANGE",
+            MicCode = "XSHE",
+            TimeZone = "Asia/Shanghai",
+            PreMarketHours = null,
+            TradingHours = "09:15-15:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "CN",
+            CountryName = "China",
+            Url = "https://www.tradinghours.com/exchanges/szse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "T",
+            ExchangeName = "TOKYO STOCK EXCHANGE-TOKYO PRO MARKET",
+            MicCode = "XJPX",
+            TimeZone = "Asia/Tokyo",
+            PreMarketHours = null,
+            TradingHours = "09:00-15:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "JP",
+            CountryName = "Japan",
+            Url = "https://www.tradinghours.com/exchanges/jpx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "TA",
+            ExchangeName = "TEL AVIV STOCK EXCHANGE",
+            MicCode = "XTAE",
+            TimeZone = "Asia/Jerusalem",
+            PreMarketHours = null,
+            TradingHours = "09:45-17:14",
+            PostMarketHours = null,
+            CloseDate = "6,7",
+            CountryCode = "IL",
+            CountryName = "Israel",
+            Url = "https://www.tradinghours.com/exchanges/tase"
+        },
+        new Exchange
+        {
+            ExchangeCode = "TL",
+            ExchangeName = "NASDAQ OMX TALLINN",
+            MicCode = "XTAL",
+            TimeZone = "Europe/Tallinn",
+            PreMarketHours = null,
+            TradingHours = "09:00-16:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "EE",
+            CountryName = "Estonia",
+            Url = "https://www.tradinghours.com/exchanges/omxt-tallinn"
+        },
+        new Exchange
+        {
+            ExchangeCode = "TO",
+            ExchangeName = "TORONTO STOCK EXCHANGE",
+            MicCode = "XTSE",
+            TimeZone = "America/Toronto",
+            PreMarketHours = "07:00-09:30",
+            TradingHours = "09:30-16:00",
+            PostMarketHours = "16:00-17:00",
+            CloseDate = "7,0",
+            CountryCode = "CA",
+            CountryName = "Canada",
+            Url = "https://www.tradinghours.com/exchanges/tsx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "TW",
+            ExchangeName = "TAIWAN STOCK EXCHANGE",
+            MicCode = "XTAI",
+            TimeZone = "Asia/Taipei",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "TW",
+            CountryName = "Taiwan",
+            Url = "https://www.tradinghours.com/exchanges/twse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "TWO",
+            ExchangeName = "TPEx",
+            MicCode = "ROCO",
+            TimeZone = "Asia/Taipei",
+            PreMarketHours = null,
+            TradingHours = "09:00-17:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "TW",
+            CountryName = "Taiwan",
+            Url = null
+        },
+        new Exchange
+        {
+            ExchangeCode = "US",
+            ExchangeName = "US exchanges (NYSE, Nasdaq)",
+            MicCode = "XNYS,XASE,BATS,ARCX,XNMS,XNCM,XNGS,IEXG,XNAS, OTCM, OOTC",
+            TimeZone = "America/New_York",
+            PreMarketHours = "04:00-09:30",
+            TradingHours = "09:30-16:00",
+            PostMarketHours = "16:00-20:00",
+            CloseDate = "7,0",
+            CountryCode = "US",
+            CountryName = "US",
+            Url = "https://www.tradinghours.com/exchanges/nyse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "V",
+            ExchangeName = "TSX VENTURE EXCHANGE - NEX",
+            MicCode = "XTSX",
+            TimeZone = "America/Toronto",
+            PreMarketHours = "07:00-09:30",
+            TradingHours = "09:30-16:15",
+            PostMarketHours = "16:00-17:00",
+            CloseDate = "7,0",
+            CountryCode = "CA",
+            CountryName = "Canada",
+            Url = "https://www.tradinghours.com/exchanges/xtsx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "VI",
+            ExchangeName = "Vienna Stock Exchange",
+            MicCode = "XWBO",
+            TimeZone = "Europe/Vienna",
+            PreMarketHours = null,
+            TradingHours = "09:04-17:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "AT",
+            CountryName = "Austria",
+            Url = "https://www.tradinghours.com/exchanges/vse"
+        },
+        new Exchange
+        {
+            ExchangeCode = "VN",
+            ExchangeName = "Vietnam exchanges including HOSE, HNX and UPCOM",
+            MicCode = "HSTC, XSTC,XHNX",
+            TimeZone = "Asia/Bangkok",
+            PreMarketHours = null,
+            TradingHours = "09:00-15:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "VN",
+            CountryName = "Vietnam",
+            Url = "https://www.tradinghours.com/exchanges/hose"
+        },
+        new Exchange
+        {
+            ExchangeCode = "VS",
+            ExchangeName = "NASDAQ OMX VILNIUS",
+            MicCode = "XLIT",
+            TimeZone = "Europe/Vilnius",
+            PreMarketHours = null,
+            TradingHours = "09:00-16:30",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "LT",
+            CountryName = "Lithuania",
+            Url = "https://www.tradinghours.com/exchanges/omxv-vilnius"
+        },
+        new Exchange
+        {
+            ExchangeCode = "WA",
+            ExchangeName = "WARSAW STOCK EXCHANGE/EQUITIES/MAIN MARKET",
+            MicCode = "XWAR",
+            TimeZone = "Europe/Warsaw",
+            PreMarketHours = null,
+            TradingHours = "08:30-17:05",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "PL",
+            CountryName = "Poland",
+            Url = "https://www.tradinghours.com/exchanges/gpw"
+        },
+        new Exchange
+        {
+            ExchangeCode = "PK",
+            ExchangeName = "Pakistan Stock Exchange",
+            MicCode = "XKAR",
+            TimeZone = "Asia/Karachi",
+            PreMarketHours = "09:15-09:30",
+            TradingHours = "09:30-15:30",
+            PostMarketHours = "15:30-15:50",
+            CloseDate = "7,0",
+            CountryCode = "PK",
+            CountryName = "Pakistan",
+            Url = "https://www.tradinghours.com/markets/psx"
+        },
+        new Exchange
+        {
+            ExchangeCode = "HA",
+            ExchangeName = "Hanover Stock Exchange",
+            MicCode = "XHAN",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = null
+        },
+        new Exchange
+        {
+            ExchangeCode = "SX",
+            ExchangeName = "DEUTSCHE BOERSE Stoxx",
+            MicCode = null,
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = null
+        },
+        new Exchange
+        {
+            ExchangeCode = "TG",
+            ExchangeName = "DEUTSCHE BOERSE TradeGate",
+            MicCode = "XGAT",
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-22:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = null
+        },
+        new Exchange
+        {
+            ExchangeCode = "SC",
+            ExchangeName = "BOERSE_FRANKFURT_ZERTIFIKATE",
+            MicCode = null,
+            TimeZone = "Europe/Berlin",
+            PreMarketHours = null,
+            TradingHours = "08:00-20:00",
+            PostMarketHours = null,
+            CloseDate = "7,0",
+            CountryCode = "DE",
+            CountryName = "Germany",
+            Url = null
+        },
+    ];
+}

--- a/src/FinnHub.MCP.Server.Application/Exchanges/Features/GetAllExchanges/ExchangeCatalog.cs
+++ b/src/FinnHub.MCP.Server.Application/Exchanges/Features/GetAllExchanges/ExchangeCatalog.cs
@@ -1,0 +1,24 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
+
+/// <summary>
+/// In-memory catalog of the stock exchanges Finnhub supports.
+/// </summary>
+/// <remarks>
+/// Finnhub exposes no <c>/stock/exchange</c> API endpoint — the supported-exchange list
+/// is published only as a reference document, so the catalog ships in-process rather than
+/// behind an HTTP client and cache. The backing data lives in the <c>ExchangeCatalog.Data.cs</c>
+/// partial and is a verbatim capture of Finnhub's public "Supported Exchanges" sheet; see that
+/// file for provenance and refresh instructions.
+/// </remarks>
+public sealed partial class ExchangeCatalog : IExchangeCatalog
+{
+    /// <inheritdoc />
+    public IReadOnlyList<Exchange> Exchanges => s_all;
+}

--- a/src/FinnHub.MCP.Server.Application/Exchanges/Features/GetAllExchanges/IExchangeCatalog.cs
+++ b/src/FinnHub.MCP.Server.Application/Exchanges/Features/GetAllExchanges/IExchangeCatalog.cs
@@ -1,0 +1,19 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
+
+/// <summary>
+/// Provides the catalog of stock exchanges Finnhub supports.
+/// </summary>
+public interface IExchangeCatalog
+{
+    /// <summary>
+    /// Gets the full list of supported stock exchanges.
+    /// </summary>
+    IReadOnlyList<Exchange> Exchanges { get; }
+}

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -7,6 +7,7 @@
 
 using System.Reflection;
 using DotNetEnv;
+using FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Services;
 using FinnHub.MCP.Server.Application.Symbols;
@@ -104,6 +105,7 @@ builder.Services.RegisterInfrastructure();
 builder.Services.AddTransient<ISearchService, SearchService>();
 builder.Services.AddTransient<ISymbolResolver, SymbolResolver>();
 builder.Services.AddSingleton<ITokenEstimator, CharCountTokenEstimator>();
+builder.Services.AddSingleton<IExchangeCatalog, ExchangeCatalog>();
 
 var mcpBuilder = builder.Services.AddMcpServer(options =>
 {

--- a/src/FinnHub.MCP.Server/Resources/Exchanges/ExchangesResource.cs
+++ b/src/FinnHub.MCP.Server/Resources/Exchanges/ExchangesResource.cs
@@ -7,16 +7,15 @@
 
 using System.ComponentModel;
 using System.Net.Mime;
-using FinnHub.MCP.Server.Application.Exchanges;
 using FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
 
 namespace FinnHub.MCP.Server.Resources.Exchanges;
 
 /// <summary>
-/// MCP resource that provides stock exchange listings from Finnhub.
+/// MCP resource that provides the catalog of stock exchanges Finnhub supports.
 /// </summary>
 [McpServerResourceType]
-public sealed class ExchangesResource
+public sealed class ExchangesResource(IExchangeCatalog catalog)
 {
     /// <summary>
     /// Returns the catalog of stock exchanges serialized as JSON for the
@@ -29,8 +28,9 @@ public sealed class ExchangesResource
     /// populate dropdowns or filter symbol searches by venue.
     /// </para>
     /// <para>
-    /// The current implementation returns a static stub (London Stock Exchange only)
-    /// pending wiring to the Finnhub <c>/stock/exchange</c> endpoint.
+    /// The catalog is sourced from <see cref="IExchangeCatalog"/>. Finnhub has no
+    /// <c>/stock/exchange</c> endpoint, so the list ships as in-process reference
+    /// data rather than a live upstream call.
     /// </para>
     /// <para>
     /// Returns a JSON <see cref="string"/> rather than the typed response because
@@ -45,27 +45,12 @@ public sealed class ExchangesResource
         Name = "get-exchanges",
         Title = "Exchanges",
         MimeType = MediaTypeNames.Application.Json)]
-    [Description("Gets all the exchanges listed on Finnhub.")]
+    [Description("Gets the catalog of stock exchanges Finnhub supports.")]
     public string GetExchanges()
     {
-        // TODO: Replace stub data with real Finnhub API call logic.
         var responsePayload = new ExchangesResponse
         {
-            Exchanges =
-            [
-                new Exchange
-                {
-                    ExchangeCode = "L",
-                    ExchangeName = "London Stock Exchange",
-                    CountryCode = "GB",
-                    CountryName = "United Kingdom",
-                    MicCode = "XLON",
-                    TimeZone = "Europe/London",
-                    TradingHours = "08:00-16:30",
-                    Url = "https://www.tradinghours.com/exchanges/lse",
-                    CloseDate = string.Empty
-                }
-            ]
+            Exchanges = catalog.Exchanges
         };
 
         return JsonSerializer.Serialize(responsePayload, ResourceJsonContext.Default.ExchangesResponse);

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Exchanges/ExchangeCatalogTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Exchanges/ExchangeCatalogTests.cs
@@ -1,0 +1,64 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Exchanges;
+
+public sealed class ExchangeCatalogTests
+{
+    [Fact]
+    public void Exchanges_ContainsFullMultiVenueCatalog_NotTheSingleStub()
+    {
+        var catalog = new ExchangeCatalog().Exchanges;
+
+        Assert.True(
+            catalog.Count >= 70,
+            $"Expected the full Finnhub venue catalog (70+ exchanges), but got {catalog.Count}.");
+
+        var codes = catalog.Select(e => e.ExchangeCode).ToHashSet();
+        Assert.Contains("US", codes);
+        Assert.Contains("L", codes);
+        Assert.Contains("T", codes);
+        Assert.Contains("HK", codes);
+    }
+
+    [Fact]
+    public void Exchanges_HaveUniqueCodes()
+    {
+        var codes = new ExchangeCatalog().Exchanges.Select(e => e.ExchangeCode).ToList();
+
+        Assert.Equal(codes.Count, codes.Distinct().Count());
+    }
+
+    [Fact]
+    public void Exchanges_EveryEntry_HasRequiredFieldsPopulated()
+    {
+        var catalog = new ExchangeCatalog().Exchanges;
+
+        Assert.All(catalog, exchange =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(exchange.ExchangeCode));
+            Assert.False(string.IsNullOrWhiteSpace(exchange.ExchangeName));
+            Assert.False(string.IsNullOrWhiteSpace(exchange.CountryCode));
+            Assert.False(string.IsNullOrWhiteSpace(exchange.CountryName));
+        });
+    }
+
+    [Fact]
+    public void LondonStockExchange_IsPresent_AmongManyVenues()
+    {
+        var catalog = new ExchangeCatalog().Exchanges;
+
+        var london = catalog.Single(e => e.ExchangeCode == "L");
+
+        Assert.Equal("XLON", london.MicCode);
+        Assert.Equal("GB", london.CountryCode);
+        Assert.True(catalog.Count > 1, "Catalog must no longer be the single-venue stub.");
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Resources/ExchangesResourceTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Resources/ExchangesResourceTests.cs
@@ -6,30 +6,71 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Text.Json;
+using FinnHub.MCP.Server.Application.Exchanges;
+using FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
 using FinnHub.MCP.Server.Resources.Exchanges;
+using NSubstitute;
 using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Resources;
 
 public sealed class ExchangesResourceTests
 {
-    [Fact]
-    public void GetExchanges_ReturnsStubPayloadWithLondonStockExchange()
+    private static Exchange MakeExchange(string code, string name, string? url) => new()
     {
-        var json = new ExchangesResource().GetExchanges();
+        ExchangeCode = code,
+        ExchangeName = name,
+        MicCode = "XTST",
+        TimeZone = "Europe/London",
+        TradingHours = "08:00-16:30",
+        CountryCode = "GB",
+        CountryName = "United Kingdom",
+        Url = url
+    };
+
+    [Fact]
+    public void GetExchanges_SerializesCatalogEntries_WithEnvelopeCounts()
+    {
+        var catalog = Substitute.For<IExchangeCatalog>();
+        IReadOnlyList<Exchange> data =
+        [
+            MakeExchange("L", "London Stock Exchange", "https://example.com/lse"),
+            MakeExchange("US", "US exchanges", url: null)
+        ];
+        catalog.Exchanges.Returns(data);
+
+        var json = new ExchangesResource(catalog).GetExchanges();
 
         using var document = JsonDocument.Parse(json);
-        var exchanges = document.RootElement.GetProperty("exchanges");
+        var root = document.RootElement;
+        var exchanges = root.GetProperty("exchanges");
 
         Assert.Equal(JsonValueKind.Array, exchanges.ValueKind);
-        Assert.Equal(1, exchanges.GetArrayLength());
+        Assert.Equal(2, exchanges.GetArrayLength());
+        Assert.Equal(2, root.GetProperty("total_count").GetInt32());
+        Assert.True(root.GetProperty("has_results").GetBoolean());
 
-        var lse = exchanges[0];
-        Assert.Equal("L", lse.GetProperty("code").GetString());
-        Assert.Equal("London Stock Exchange", lse.GetProperty("name").GetString());
-        Assert.Equal("XLON", lse.GetProperty("mic").GetString());
-        Assert.Equal("GB", lse.GetProperty("country_code").GetString());
-        Assert.Equal("Europe/London", lse.GetProperty("time_zone").GetString());
-        Assert.Equal("08:00-16:30", lse.GetProperty("trading_hours").GetString());
+        Assert.Equal("L", exchanges[0].GetProperty("code").GetString());
+        Assert.Equal("London Stock Exchange", exchanges[0].GetProperty("name").GetString());
+        Assert.Equal("https://example.com/lse", exchanges[0].GetProperty("url").GetString());
+
+        // Venues Finnhub lists without a reference URL serialize url as null, not omitted.
+        Assert.Equal(JsonValueKind.Null, exchanges[1].GetProperty("url").ValueKind);
+    }
+
+    [Fact]
+    public void GetExchanges_EmptyCatalog_ReturnsEmptyArrayAndFalseHasResults()
+    {
+        var catalog = Substitute.For<IExchangeCatalog>();
+        catalog.Exchanges.Returns([]);
+
+        var json = new ExchangesResource(catalog).GetExchanges();
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal(0, root.GetProperty("exchanges").GetArrayLength());
+        Assert.Equal(0, root.GetProperty("total_count").GetInt32());
+        Assert.False(root.GetProperty("has_results").GetBoolean());
     }
 }


### PR DESCRIPTION
## Summary

Wires `finnhub://resources/exchanges` to the **full catalog of stock venues Finnhub supports** (79 exchanges), replacing the single hardcoded London Stock Exchange stub. Closes #224.

## Why this isn't the originally-specced live `/stock/exchange` wiring

The story was specced against a Finnhub `/stock/exchange` endpoint. **That endpoint does not exist** — verified live against the API with a valid key:

| Probe | Result |
|---|---|
| `/quote?symbol=AAPL` | `200` (key valid) |
| `/stock/exchange` | **`302 → /`** (landing page) |
| `/stock/this-endpoint-does-not-exist` (control) | **`302 → /`** — *byte-for-byte identical* |
| `/forex/exchange`, `/crypto/exchange` | `200` (arrays of names) |

Finnhub publishes the supported **stock**-exchange list only as a reference document, not a JSON endpoint. (The original AC also pinned `?token=<key>`, but this server authenticates via the `X-Finnhub-Token` header.) See #224 for the full write-up; #225 has a related note.

## Approach (Option A — agreed with maintainer)

Serve the resource from a curated, in-process catalog captured **verbatim** from Finnhub's published "Supported Exchanges" sheet — honest about the API reality, and a natural fit for "resources are read-only, cacheable reference data." No fabricated values; provenance (source URL + retrieval date) is recorded in `ExchangeCatalog.Data.cs`.

## Changes

- **`IExchangeCatalog` + `ExchangeCatalog`** (Application) — provider over the 79-venue list; `ExchangeCatalog.Data.cs` is the generated, faithful capture.
- **`ExchangesResource`** now injects `IExchangeCatalog` and serializes the full catalog; the hardcoded LSE stub is gone.
- **`Exchange.Url` → nullable** — 6 venues (OM, TWO, HA, SX, TG, SC) genuinely have no reference URL in Finnhub's source; `null` is truthful.
- **DI**: `AddSingleton<IExchangeCatalog, ExchangeCatalog>()` in `Program.cs`.
- **README** + **issue #224 ACs** updated to match reality.

## Testing

- `dotnet build` — **0 warnings** (TreatWarningsAsErrors)
- `dotnet format --verify-no-changes` — clean
- `dotnet test` (excl. LiveSmoke) — **733 passing**, incl. new resource-serialization tests (NSubstitute-mocked catalog) and catalog data-integrity tests (real catalog: 79 venues, unique codes, required fields populated, known codes US/L/T/HK present)
- **End-to-end**: booted the server over STDIO and read `finnhub://resources/exchanges` via MCP — returns `total_count: 79`, `has_results: true`, mime `application/json`, 6 `url: null` venues correct

No infrastructure client / fixture / on-wire URL pin in this PR — there is no upstream endpoint to call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
