### PR TITLE
feat(tools): add search-tools meta-tool for intent-based discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,8 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 
 ### ✅ Currently Available
 
-**Tools (10):**
+**Tools (11):**
+- **`search-tools`** — intent-based tool discovery: pass a natural-language `intent` (max 200 chars) and get back the most relevant tools, ranked by a pure-C# BM25 keyword index over each tool's name, title, description, and curated example intents. Keeps full tool schemas off the wire until a tool is actually needed. `summary` view omits per-tool descriptions to stay token-light; `standard`/`full` include them.
 - **`search-symbol`** — search for financial symbols by ticker, company name, ISIN, or CUSIP, optionally filtered by exchange code (limit 1–100, default 10). On a high-confidence exact match, suggests `get-quote`, `get-company-profile`, `get-news-pulse`, `get-financials-snapshot`, `get-price-summary`, and `get-peers` as next actions.
 - **`get-quote`** — real-time price snapshot (current, change, percent change, session high/low/open, prev close, timestamp). Cached at the 10-second Quote tier.
 - **`get-company-profile`** — company snapshot (name, ticker, country, currency, exchange, IPO, market cap, shares outstanding, industry). `view=summary` drops the cosmetic fields (logo, phone, weburl); `standard` and `full` include them.
@@ -55,7 +56,6 @@ Every tool returns the standard token-budgeted envelope with cross-linked `next_
 - **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
 ### 📋 Planned
-- `search-tools` meta-tool for intent-based discovery (P7)
 - Technical indicators (RSI, MACD, moving averages)
 - WebSocket transport for streaming Finnhub feeds
 
@@ -170,6 +170,15 @@ Example STDIO entry for Claude Desktop's `claude_desktop_config.json`:
   }
 }
 ```
+
+### Tool: `search-tools`
+
+Parameters:
+
+- `intent` *(string, required)* — natural-language description of the task, 1–200 chars (letters/digits/space and `- _ . , ' ? & / ( )`). Over 200 chars or other characters are rejected as a validation error.
+- `view` *(string, optional)* — `summary` (default) omits per-tool descriptions; `standard`/`full` include them.
+
+Returns the ranked matches (`name`, `title`, `score`, `category`, `premium`, and — outside `summary` — `description`) plus `total_matches`. Ranking is a pure-C# BM25 keyword index over name + title + description + curated example intents (no embeddings, no external dependency); examples are weighted above the description so curated intents drive the match. The `search-tools` entry itself is excluded from its own results. A drift test fails the build if a tool is registered on the server without a catalog descriptor.
 
 ### Tool: `search-symbol`
 

--- a/src/FinnHub.MCP.Server.Application/Discovery/IToolRegistry.cs
+++ b/src/FinnHub.MCP.Server.Application/Discovery/IToolRegistry.cs
@@ -1,0 +1,32 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Discovery;
+
+/// <summary>
+/// In-memory index of MCP tool descriptors that ranks tools by a natural-language intent.
+/// Lets a client discover the right tool without loading every tool schema up front.
+/// </summary>
+/// <remarks>
+/// v1 ranking is a pure-C# BM25 keyword index over name + title + description + examples —
+/// no embeddings, no external dependency (per spec §3 P7). A future v2 can swap the
+/// implementation behind this interface.
+/// </remarks>
+public interface IToolRegistry
+{
+    /// <summary>All registered tool descriptors, in registration order.</summary>
+    IReadOnlyList<ToolDescriptor> Descriptors { get; }
+
+    /// <summary>
+    /// Ranks the registered tools against <paramref name="intent"/> and returns the
+    /// best matches, most-relevant first. Tools that share no terms with the intent are omitted.
+    /// </summary>
+    /// <param name="intent">The natural-language intent (e.g. <c>"is apple stock up this week"</c>).</param>
+    /// <param name="topN">Maximum number of matches to return.</param>
+    /// <returns>Up to <paramref name="topN"/> matches ordered by descending relevance; empty when the intent matches nothing.</returns>
+    IReadOnlyList<ToolMatch> Search(string intent, int topN = 5);
+}

--- a/src/FinnHub.MCP.Server.Application/Discovery/ToolDescriptor.cs
+++ b/src/FinnHub.MCP.Server.Application/Discovery/ToolDescriptor.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Discovery;
+
+/// <summary>
+/// A curated, indexable descriptor for a single MCP tool. The <see cref="IToolRegistry"/>
+/// ranks these by intent using a keyword index over
+/// <see cref="Name"/> + <see cref="Title"/> + <see cref="Description"/> + <see cref="Examples"/>.
+/// </summary>
+/// <remarks>
+/// Descriptors are assembled in the Server layer from the tool definitions in
+/// <c>Constants.Tools</c> so the registry stays decoupled from the host (the Application
+/// project must not reference Server). <see cref="Examples"/> are natural-language intents
+/// curated to make ranking match how a user actually phrases a request.
+/// </remarks>
+public sealed record ToolDescriptor
+{
+    /// <summary>The MCP tool name (e.g. <c>get-price-summary</c>).</summary>
+    public required string Name { get; init; }
+
+    /// <summary>The human-readable title (e.g. <c>Get Price Summary</c>).</summary>
+    public required string Title { get; init; }
+
+    /// <summary>The full tool description indexed for keyword ranking.</summary>
+    public required string Description { get; init; }
+
+    /// <summary>Natural-language example intents a user would type to reach this tool.</summary>
+    public IReadOnlyList<string> Examples { get; init; } = [];
+
+    /// <summary>Coarse grouping for catalog presentation (e.g. <c>Pricing</c>, <c>Fundamentals</c>).</summary>
+    public string? Category { get; init; }
+
+    /// <summary>Whether the underlying Finnhub endpoint may require a premium key.</summary>
+    public bool Premium { get; init; }
+
+    /// <summary>
+    /// Whether this tool is a candidate in <see cref="IToolRegistry.Search"/> results. Defaults to
+    /// <c>true</c>; the <c>search-tools</c> meta-tool sets it <c>false</c> so it never returns itself,
+    /// while still appearing in <see cref="IToolRegistry.Descriptors"/> for catalog and drift purposes.
+    /// </summary>
+    public bool Searchable { get; init; } = true;
+}

--- a/src/FinnHub.MCP.Server.Application/Discovery/ToolMatch.cs
+++ b/src/FinnHub.MCP.Server.Application/Discovery/ToolMatch.cs
@@ -1,0 +1,14 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Discovery;
+
+/// <summary>
+/// A single ranked search hit: the matched <see cref="ToolDescriptor"/> and its
+/// BM25 relevance <see cref="Score"/> (higher is more relevant).
+/// </summary>
+public sealed record ToolMatch(ToolDescriptor Tool, double Score);

--- a/src/FinnHub.MCP.Server.Application/Discovery/ToolRegistry.cs
+++ b/src/FinnHub.MCP.Server.Application/Discovery/ToolRegistry.cs
@@ -1,0 +1,194 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Collections.Frozen;
+using System.Text.RegularExpressions;
+
+namespace FinnHub.MCP.Server.Application.Discovery;
+
+/// <summary>
+/// BM25 keyword index over a fixed set of <see cref="ToolDescriptor"/>s. Pure C#, no external
+/// dependency and no embeddings (per spec §3 P7). The index is built once at construction;
+/// the descriptor set is supplied by the host so the Application layer stays decoupled from the
+/// tool registrations in <c>Program.cs</c>.
+/// </summary>
+public sealed partial class ToolRegistry : IToolRegistry
+{
+    // Standard BM25 free parameters.
+    private const double K1 = 1.2d;
+    private const double B = 0.75d;
+
+    // Tokens with no discriminating value across short natural-language intents.
+    private static readonly FrozenSet<string> s_stopWords = FrozenSet.Create(
+        StringComparer.Ordinal,
+        "a", "an", "and", "any", "are", "as", "at", "be", "been", "by", "can", "do", "does",
+        "for", "from", "get", "give", "how", "i", "in", "into", "is", "it", "its", "me", "my",
+        "of", "on", "or", "show", "so", "tell", "that", "the", "their", "them", "there", "this",
+        "to", "was", "were", "what", "whats", "when", "where", "which", "who", "will", "with",
+        "would", "you", "your");
+
+    private readonly ToolDescriptor[] _descriptors;
+    private readonly Dictionary<string, int>[] _termFrequencies;
+    private readonly int[] _docLengths;
+    private readonly Dictionary<string, int> _documentFrequency;
+    private readonly double _averageDocLength;
+
+    /// <summary>
+    /// Builds the index over <paramref name="descriptors"/>.
+    /// </summary>
+    /// <param name="descriptors">The tool descriptors to index. Order is preserved as the tie-break for equal scores.</param>
+    public ToolRegistry(IEnumerable<ToolDescriptor> descriptors)
+    {
+        ArgumentNullException.ThrowIfNull(descriptors);
+
+        this._descriptors = [.. descriptors];
+        this._termFrequencies = new Dictionary<string, int>[this._descriptors.Length];
+        this._docLengths = new int[this._descriptors.Length];
+        this._documentFrequency = new Dictionary<string, int>(StringComparer.Ordinal);
+
+        long totalLength = 0;
+
+        for (var i = 0; i < this._descriptors.Length; i++)
+        {
+            var tokens = Tokenize(BuildDocument(this._descriptors[i]));
+            var termFrequency = new Dictionary<string, int>(StringComparer.Ordinal);
+
+            foreach (var token in tokens)
+            {
+                termFrequency[token] = termFrequency.GetValueOrDefault(token) + 1;
+            }
+
+            this._termFrequencies[i] = termFrequency;
+            this._docLengths[i] = tokens.Count;
+            totalLength += tokens.Count;
+
+            foreach (var term in termFrequency.Keys)
+            {
+                this._documentFrequency[term] = this._documentFrequency.GetValueOrDefault(term) + 1;
+            }
+        }
+
+        this._averageDocLength = this._descriptors.Length == 0
+            ? 0d
+            : (double)totalLength / this._descriptors.Length;
+    }
+
+    /// <inheritdoc />
+    public IReadOnlyList<ToolDescriptor> Descriptors => this._descriptors;
+
+    /// <inheritdoc />
+    public IReadOnlyList<ToolMatch> Search(string intent, int topN = 5)
+    {
+        if (string.IsNullOrWhiteSpace(intent) || topN <= 0 || this._descriptors.Length == 0)
+        {
+            return [];
+        }
+
+        var queryTerms = Tokenize(intent).Distinct(StringComparer.Ordinal).ToArray();
+
+        if (queryTerms.Length == 0)
+        {
+            return [];
+        }
+
+        var scored = new List<ToolMatch>(this._descriptors.Length);
+
+        for (var i = 0; i < this._descriptors.Length; i++)
+        {
+            if (!this._descriptors[i].Searchable)
+            {
+                continue;
+            }
+
+            var score = this.ScoreDocument(i, queryTerms);
+
+            if (score > 0d)
+            {
+                scored.Add(new ToolMatch(this._descriptors[i], score));
+            }
+        }
+
+        // Descending score; OrderBy is stable, so descriptor order breaks ties.
+        return [.. scored.OrderByDescending(m => m.Score).Take(topN)];
+    }
+
+    private double ScoreDocument(int docIndex, IEnumerable<string> queryTerms)
+    {
+        var termFrequency = this._termFrequencies[docIndex];
+        var docLength = this._docLengths[docIndex];
+        var score = 0d;
+
+        foreach (var term in queryTerms)
+        {
+            if (!termFrequency.TryGetValue(term, out var tf))
+            {
+                continue;
+            }
+
+            var df = this._documentFrequency.GetValueOrDefault(term);
+            var idf = Math.Log(1d + ((this._descriptors.Length - df + 0.5d) / (df + 0.5d)));
+
+            var denominator = tf + (K1 * (1d - B + (B * docLength / this._averageDocLength)));
+            score += idf * (tf * (K1 + 1d)) / denominator;
+        }
+
+        return score;
+    }
+
+    // Field weights, applied as token repetition (a simple BM25F). Identifying fields (name,
+    // title) and the curated example intents carry more signal for intent matching than the
+    // auto-generated description, which contains incidental tokens (tickers, ISINs, parameter
+    // names) that would otherwise let a stray word dominate the ranking.
+    private const int NameTitleWeight = 2;
+    private const int ExampleWeight = 4;
+
+    private static string BuildDocument(ToolDescriptor descriptor)
+    {
+        var examples = string.Join(' ', descriptor.Examples);
+        var parts = new List<string>();
+
+        for (var i = 0; i < NameTitleWeight; i++)
+        {
+            parts.Add(descriptor.Name);
+            parts.Add(descriptor.Title);
+        }
+
+        parts.Add(descriptor.Description);
+
+        for (var i = 0; i < ExampleWeight; i++)
+        {
+            parts.Add(examples);
+        }
+
+        return string.Join(' ', parts);
+    }
+
+    private static List<string> Tokenize(string text)
+    {
+        var tokens = new List<string>();
+
+        foreach (var raw in TokenSplitter().Split(text))
+        {
+            if (raw.Length < 2)
+            {
+                continue;
+            }
+
+            var token = raw.ToLowerInvariant();
+
+            if (!s_stopWords.Contains(token))
+            {
+                tokens.Add(token);
+            }
+        }
+
+        return tokens;
+    }
+
+    [GeneratedRegex(@"[^a-zA-Z0-9]+", RegexOptions.Compiled)]
+    private static partial Regex TokenSplitter();
+}

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -193,6 +193,71 @@ public static class Constants
         }
 
         /// <summary>
+        /// Constants for the <c>search-tools</c> meta-tool — intent-based tool discovery
+        /// that keeps full tool schemas off the wire until a tool is actually needed.
+        /// </summary>
+        public static class SearchTools
+        {
+            /// <summary>The unique tool identifier.</summary>
+            public const string Name = "search-tools";
+
+            /// <summary>The human-readable title.</summary>
+            public const string Title = "Search Tools";
+
+            /// <summary>Parameter definitions for the search-tools meta-tool.</summary>
+            public static class Parameters
+            {
+                /// <summary>The parameter name for the natural-language intent.</summary>
+                public const string IntentName = "intent";
+
+                /// <summary>Human-readable description of the intent parameter.</summary>
+                public const string IntentDescription =
+                    "Natural-language description of what you want to do (max 200 characters), e.g. " +
+                    "'is apple stock up this week' or 'upcoming earnings'. Returns the most relevant tools, ranked.";
+
+                /// <summary>The parameter name for the response detail level.</summary>
+                public const string ViewName = "view";
+
+                /// <summary>Human-readable description of the view parameter.</summary>
+                public const string ViewDescription = Envelope.ViewParameterDescription;
+            }
+
+            /// <summary>
+            /// Documentation for the <c>search-tools</c> meta-tool used at registration time.
+            /// </summary>
+            public const string Description =
+                """
+                Discover the right Finnhub tool by intent, without loading every tool schema up front.
+                Describe what you want in plain language and get back the best-matching tools, ranked by relevance.
+
+                ## Example Queries:
+                - intent='find the right tool for a question'
+                - intent='which tool should I use'
+                - intent='list tools for a topic'
+
+                ## Request Parameters:
+                - intent (string, required): natural-language intent, max 200 characters
+
+                ## Response Fields:
+                - intent (string): the echoed intent
+                - matches (array, ranked most-relevant first):
+                  - name (string): the tool name to invoke next
+                  - title (string): human-readable title
+                  - score (float): relevance score
+                  - category (string, nullable): coarse grouping
+                  - premium (bool): whether the tool's upstream endpoint may require a premium key
+                  - description (string, nullable): full tool description (standard and full views only)
+                - total_matches (int)
+
+                ## Notes:
+                - Ranking is a BM25 keyword index over each tool's name, title, description, and example intents.
+                - summary view omits per-tool descriptions to stay token-light; standard and full include them.
+
+                Approx tokens: summary ~150, standard ~700, full ~700.
+                """;
+        }
+
+        /// <summary>
         /// Constants for the <c>get-peers</c> tool — peer ticker lookup for a symbol.
         /// </summary>
         public static class Peers

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -7,6 +7,7 @@
 
 using System.Reflection;
 using DotNetEnv;
+using FinnHub.MCP.Server.Application.Discovery;
 using FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Services;
@@ -18,6 +19,7 @@ using FinnHub.MCP.Server.Middleware;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
 using FinnHub.MCP.Server.Tools.Calendar;
+using FinnHub.MCP.Server.Tools.Discovery;
 using FinnHub.MCP.Server.Tools.Financials;
 using FinnHub.MCP.Server.Tools.Insiders;
 using FinnHub.MCP.Server.Tools.News;
@@ -106,6 +108,7 @@ builder.Services.AddTransient<ISearchService, SearchService>();
 builder.Services.AddTransient<ISymbolResolver, SymbolResolver>();
 builder.Services.AddSingleton<ITokenEstimator, CharCountTokenEstimator>();
 builder.Services.AddSingleton<IExchangeCatalog, ExchangeCatalog>();
+builder.Services.AddSingleton<IToolRegistry>(_ => new ToolRegistry(ToolCatalog.Descriptors));
 
 var mcpBuilder = builder.Services.AddMcpServer(options =>
 {
@@ -116,6 +119,7 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
         Version = version
     };
 })
+.WithWrappedTools<SearchToolsTool>()
 .WithWrappedTools<SearchSymbolTool>()
 .WithWrappedTools<GetPeersTool>()
 .WithWrappedTools<GetFinancialsSnapshotTool>()

--- a/src/FinnHub.MCP.Server/Tools/Discovery/SearchToolsInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Tools/Discovery/SearchToolsInputValidator.cs
@@ -1,0 +1,65 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+using FinnHub.MCP.Server.Application.Models;
+
+namespace FinnHub.MCP.Server.Tools.Discovery;
+
+/// <summary>
+/// Static validation helpers for the <c>search-tools</c> meta-tool parameters.
+/// </summary>
+internal static partial class SearchToolsInputValidator
+{
+    private const int MaxIntentLength = 200;
+
+    // Natural-language intent: letters, digits, spaces and a small set of safe punctuation.
+    [GeneratedRegex(@"^[a-zA-Z0-9\s\-_.,'?&/()]{1,200}$", RegexOptions.Compiled)]
+    private static partial Regex IntentRegex();
+
+    public static string ValidateIntent(string? intent)
+    {
+        if (string.IsNullOrWhiteSpace(intent))
+        {
+            throw new ArgumentException("Intent cannot be empty or whitespace.", nameof(intent));
+        }
+
+        intent = intent.Trim();
+
+        if (intent.Length > MaxIntentLength)
+        {
+            throw new ArgumentException(
+                $"Intent must be at most {MaxIntentLength} characters long.", nameof(intent));
+        }
+
+        if (!IntentRegex().IsMatch(intent))
+        {
+            throw new ArgumentException(
+                "Intent contains invalid characters. Allowed: letters, numbers, spaces and the punctuation - _ . , ' ? & / ( ).",
+                nameof(intent));
+        }
+
+        return intent;
+    }
+
+    public static ToolView ValidateView(string? view)
+    {
+        if (string.IsNullOrWhiteSpace(view))
+        {
+            return ToolView.Summary;
+        }
+
+        return view.Trim().ToLowerInvariant() switch
+        {
+            "summary" => ToolView.Summary,
+            "standard" => ToolView.Standard,
+            "full" => ToolView.Full,
+            _ => throw new ArgumentException(
+                "View must be one of: summary, standard, full.", nameof(view))
+        };
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Discovery/SearchToolsResponse.cs
+++ b/src/FinnHub.MCP.Server/Tools/Discovery/SearchToolsResponse.cs
@@ -1,0 +1,59 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Tools.Discovery;
+
+/// <summary>
+/// Wire payload for the <c>search-tools</c> meta-tool: the echoed intent and the ranked matches.
+/// </summary>
+public sealed class SearchToolsResponse
+{
+    /// <summary>The natural-language intent that was searched.</summary>
+    [JsonPropertyName("intent")]
+    public required string Intent { get; init; }
+
+    /// <summary>Matching tools, most-relevant first.</summary>
+    [JsonPropertyName("matches")]
+    public required IReadOnlyList<ToolMatchView> Matches { get; init; }
+
+    /// <summary>Number of matches returned.</summary>
+    [JsonPropertyName("total_matches")]
+    public int TotalMatches => this.Matches.Count;
+}
+
+/// <summary>
+/// A single ranked tool match projected for the wire. <see cref="Description"/> is populated
+/// only in the <c>standard</c> and <c>full</c> views to keep the <c>summary</c> view token-light.
+/// </summary>
+public sealed class ToolMatchView
+{
+    /// <summary>The MCP tool name to invoke next.</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>The human-readable title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>BM25 relevance score (higher is more relevant), rounded for the wire.</summary>
+    [JsonPropertyName("score")]
+    public required double Score { get; init; }
+
+    /// <summary>Coarse grouping for presentation.</summary>
+    [JsonPropertyName("category")]
+    public string? Category { get; init; }
+
+    /// <summary>Whether the tool's upstream Finnhub endpoint may require a premium key.</summary>
+    [JsonPropertyName("premium")]
+    public bool Premium { get; init; }
+
+    /// <summary>Full tool description; <c>null</c> in the summary view.</summary>
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+}

--- a/src/FinnHub.MCP.Server/Tools/Discovery/SearchToolsTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Discovery/SearchToolsTool.cs
@@ -1,0 +1,122 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using FinnHub.MCP.Server.Application.Discovery;
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Discovery;
+
+/// <summary>
+/// MCP meta-tool that discovers the right Finnhub tool from a natural-language intent, so a client
+/// keeps full tool schemas off the wire until a tool is actually needed.
+/// </summary>
+[McpServerToolType]
+public sealed class SearchToolsTool(
+    IToolRegistry registry,
+    ILogger<SearchToolsTool> logger)
+{
+    private const int MaxResults = 5;
+
+    /// <summary>
+    /// Ranks the registered tools against <paramref name="intent"/> and returns the best matches.
+    /// </summary>
+    /// <remarks>
+    /// Synchronous and in-process: the registry is an in-memory BM25 index, so there is no I/O.
+    /// Validation failures throw <see cref="ArgumentException"/>, which the MCP runtime surfaces
+    /// as a tool error. <c>next_actions</c> is intentionally empty — the ranked <c>matches</c>
+    /// payload is itself the set of suggested follow-up tools.
+    /// </remarks>
+    /// <param name="intent">Natural-language description of the task (max 200 chars).</param>
+    /// <param name="view">Response detail level. <c>summary</c> omits per-tool descriptions.</param>
+    /// <returns>A <see cref="ToolResponseEnvelope{T}"/> wrapping the ranked <see cref="SearchToolsResponse"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when <paramref name="intent"/> or <paramref name="view"/> fails validation.</exception>
+    [McpServerTool(
+        Name = Constants.Tools.SearchTools.Name,
+        Title = Constants.Tools.SearchTools.Title,
+        ReadOnly = true,
+        Idempotent = true,
+        Destructive = false,
+        OpenWorld = false)]
+    [Description(Constants.Tools.SearchTools.Description)]
+    public ToolResponseEnvelope<SearchToolsResponse> SearchTools(
+        [Description(Constants.Tools.SearchTools.Parameters.IntentDescription)]
+        string intent,
+        [Description(Constants.Tools.SearchTools.Parameters.ViewDescription)]
+        string? view = null)
+    {
+        var stopwatch = Stopwatch.StartNew();
+        var toolName = Constants.Tools.SearchTools.Name;
+
+        try
+        {
+            logger.LogTrace("Starting execution of '{Tool}'.", toolName);
+
+            var validatedIntent = SearchToolsInputValidator.ValidateIntent(intent);
+            var validatedView = SearchToolsInputValidator.ValidateView(view);
+
+            var matches = registry.Search(validatedIntent, MaxResults);
+
+            var response = new SearchToolsResponse
+            {
+                Intent = validatedIntent,
+                Matches = [.. matches.Select(match => ProjectMatch(match, validatedView))]
+            };
+
+            logger.LogInformation(
+                "search-tools matched {Count} tool(s) in {ElapsedMs}ms",
+                matches.Count, stopwatch.ElapsedMilliseconds);
+
+            return EnvelopeFactory.Success(
+                response,
+                validatedView,
+                explanation: BuildExplanation(validatedIntent, matches));
+        }
+        catch (ArgumentException ex)
+        {
+            logger.LogError(ex, "Validation error in '{Tool}': {Message}", toolName, ex.Message);
+            throw;
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "An exception occurred running '{Tool}'.", toolName);
+            throw;
+        }
+        finally
+        {
+            stopwatch.Stop();
+            logger.LogTrace("Finished executing '{Tool}' in {ElapsedMs}ms.", toolName, stopwatch.ElapsedMilliseconds);
+        }
+    }
+
+    private static ToolMatchView ProjectMatch(ToolMatch match, ToolView view) => new()
+    {
+        Name = match.Tool.Name,
+        Title = match.Tool.Title,
+        Score = Math.Round(match.Score, 3, MidpointRounding.AwayFromZero),
+        Category = match.Tool.Category,
+        Premium = match.Tool.Premium,
+        Description = view == ToolView.Summary ? null : match.Tool.Description
+    };
+
+    private static string BuildExplanation(string intent, IReadOnlyList<ToolMatch> matches)
+    {
+        if (matches.Count == 0)
+        {
+            return string.Create(
+                CultureInfo.InvariantCulture,
+                $"No tools matched '{intent}'. Try rephrasing the intent.");
+        }
+
+        return string.Create(
+            CultureInfo.InvariantCulture,
+            $"Top {matches.Count} tool(s) for '{intent}': {string.Join(", ", matches.Select(m => m.Tool.Name))}.");
+    }
+}

--- a/src/FinnHub.MCP.Server/Tools/Discovery/ToolCatalog.cs
+++ b/src/FinnHub.MCP.Server/Tools/Discovery/ToolCatalog.cs
@@ -1,0 +1,181 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Discovery;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Tools.Discovery;
+
+/// <summary>
+/// The curated set of <see cref="ToolDescriptor"/>s the <see cref="ToolRegistry"/> ranks over.
+/// Names, titles and descriptions come from <see cref="Constants.Tools"/> (the single source of
+/// truth shared with each tool's <c>[McpServerTool]</c> registration); the <c>Examples</c> are
+/// curated natural-language intents that align ranking with how users actually phrase requests.
+/// </summary>
+/// <remarks>
+/// Lives in the Server layer because <see cref="Constants"/> does — the Application
+/// <see cref="ToolRegistry"/> stays host-agnostic and receives these descriptors via DI. Every
+/// tool registered with <c>WithWrappedTools&lt;&gt;</c> in <c>Program.cs</c> must have an entry
+/// here; the drift test enforces that parity. <c>Premium</c> stays <c>false</c> — the runtime
+/// envelope's <c>premium</c> flag is the authoritative per-call signal.
+/// </remarks>
+internal static class ToolCatalog
+{
+    public static IReadOnlyList<ToolDescriptor> Descriptors { get; } =
+    [
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.SearchTools.Name,
+            Title = Constants.Tools.SearchTools.Title,
+            Description = Constants.Tools.SearchTools.Description,
+            Category = "Discovery",
+            Searchable = false,
+            Examples =
+            [
+                "find the right tool for a task",
+                "which tool should i use",
+                "discover tools by intent"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.SearchSymbols.Name,
+            Title = Constants.Tools.SearchSymbols.Title,
+            Description = Constants.Tools.SearchSymbols.Description,
+            Category = "Discovery",
+            Examples =
+            [
+                "find a ticker by company name",
+                "look for a ticker by symbol",
+                "resolve a company by name, ISIN or CUSIP"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.Quote.Name,
+            Title = Constants.Tools.Quote.Title,
+            Description = Constants.Tools.Quote.Description,
+            Category = "Pricing",
+            Examples =
+            [
+                "current stock price right now",
+                "latest real-time quote",
+                "what is a stock trading at now"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.CompanyProfile.Name,
+            Title = Constants.Tools.CompanyProfile.Title,
+            Description = Constants.Tools.CompanyProfile.Description,
+            Category = "Company",
+            Examples =
+            [
+                "company profile and what it does",
+                "industry, country and market cap",
+                "company headquarters and IPO date"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.Peers.Name,
+            Title = Constants.Tools.Peers.Title,
+            Description = Constants.Tools.Peers.Description,
+            Category = "Comparison",
+            Examples =
+            [
+                "industry peers and competitors",
+                "companies in the same sector",
+                "comparable companies to compare against"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.FinancialsSnapshot.Name,
+            Title = Constants.Tools.FinancialsSnapshot.Title,
+            Description = Constants.Tools.FinancialsSnapshot.Description,
+            Category = "Fundamentals",
+            Examples =
+            [
+                "valuation ratios and fundamentals",
+                "price-to-earnings ratio and market cap",
+                "fundamental financial metrics and margins"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.PriceSummary.Name,
+            Title = Constants.Tools.PriceSummary.Title,
+            Description = Constants.Tools.PriceSummary.Description,
+            Category = "Pricing",
+            Examples =
+            [
+                "is the stock up this week",
+                "stock price up or down this week",
+                "price movement and return over the week",
+                "how the price has performed recently",
+                "price range and volatility"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.NewsPulse.Name,
+            Title = Constants.Tools.NewsPulse.Title,
+            Description = Constants.Tools.NewsPulse.Description,
+            Category = "News",
+            Examples =
+            [
+                "latest news this week",
+                "news headlines and market sentiment",
+                "week over week news and sentiment",
+                "what is moving a stock on news this week",
+                "what is the news saying"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.Calendar.Name,
+            Title = Constants.Tools.Calendar.Title,
+            Description = Constants.Tools.Calendar.Description,
+            Category = "Events",
+            Examples =
+            [
+                "upcoming earnings dates",
+                "upcoming earnings this season",
+                "upcoming ipo listings",
+                "economic release schedule",
+                "when a company reports earnings"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.InsiderSignal.Name,
+            Title = Constants.Tools.InsiderSignal.Title,
+            Description = Constants.Tools.InsiderSignal.Description,
+            Category = "Insider",
+            Examples =
+            [
+                "are insiders buying or selling",
+                "insider transactions activity",
+                "insider trading signal"
+            ]
+        },
+        new ToolDescriptor
+        {
+            Name = Constants.Tools.Recommendations.Name,
+            Title = Constants.Tools.Recommendations.Title,
+            Description = Constants.Tools.Recommendations.Description,
+            Category = "Analyst",
+            Examples =
+            [
+                "what analysts recommend",
+                "analyst consensus and ratings",
+                "is analyst sentiment turning bullish or bearish"
+            ]
+        },
+    ];
+}

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Discovery/ToolRegistryTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Discovery/ToolRegistryTests.cs
@@ -1,0 +1,141 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Discovery;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Discovery;
+
+public sealed class ToolRegistryTests
+{
+    private static ToolDescriptor Descriptor(string name, string description, params string[] examples) => new()
+    {
+        Name = name,
+        Title = name,
+        Description = description,
+        Examples = examples
+    };
+
+    private static ToolRegistry BuildRegistry() => new(
+    [
+        Descriptor("price-tool", "current price movement and percent return over a period", "is the stock up", "price performance"),
+        Descriptor("news-tool", "latest news headlines and sentiment for a company", "company news", "what is the sentiment"),
+        Descriptor("earnings-tool", "upcoming earnings calendar and scheduled report dates", "upcoming earnings", "earnings season"),
+    ]);
+
+    [Fact]
+    public void Search_RanksDocumentContainingQueryTermFirst()
+    {
+        var registry = BuildRegistry();
+
+        var results = registry.Search("price return movement");
+
+        Assert.NotEmpty(results);
+        Assert.Equal("price-tool", results[0].Tool.Name);
+    }
+
+    [Fact]
+    public void Search_DistinctIntent_SelectsTheRightTool()
+    {
+        var registry = BuildRegistry();
+
+        Assert.Equal("news-tool", registry.Search("news headlines sentiment")[0].Tool.Name);
+        Assert.Equal("earnings-tool", registry.Search("upcoming earnings calendar")[0].Tool.Name);
+    }
+
+    [Fact]
+    public void Search_OrdersResultsByDescendingScore()
+    {
+        var registry = BuildRegistry();
+
+        var results = registry.Search("upcoming earnings");
+
+        for (var i = 1; i < results.Count; i++)
+        {
+            Assert.True(results[i - 1].Score >= results[i].Score);
+        }
+    }
+
+    [Fact]
+    public void Search_RespectsTopN()
+    {
+        var registry = BuildRegistry();
+
+        // A term shared by every document so all three match, then cap at 2.
+        var results = registry.Search("company price news earnings", topN: 2);
+
+        Assert.True(results.Count <= 2);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void Search_BlankIntent_ReturnsEmpty(string intent)
+    {
+        Assert.Empty(BuildRegistry().Search(intent));
+    }
+
+    [Fact]
+    public void Search_IntentMatchingNothing_ReturnsEmpty()
+    {
+        Assert.Empty(BuildRegistry().Search("cryptocurrency mining rig"));
+    }
+
+    [Fact]
+    public void Search_NonPositiveTopN_ReturnsEmpty()
+    {
+        Assert.Empty(BuildRegistry().Search("price", topN: 0));
+    }
+
+    [Fact]
+    public void Descriptors_PreservesConstructionOrder()
+    {
+        var registry = BuildRegistry();
+
+        Assert.Equal(
+            ["price-tool", "news-tool", "earnings-tool"],
+            registry.Descriptors.Select(d => d.Name));
+    }
+
+    [Fact]
+    public void Search_OnlyMatchingScoresAreReturned()
+    {
+        var registry = BuildRegistry();
+
+        var results = registry.Search("sentiment");
+
+        Assert.All(results, m => Assert.True(m.Score > 0d));
+        Assert.Equal("news-tool", Assert.Single(results).Tool.Name);
+    }
+
+    [Fact]
+    public void Search_ExcludesNonSearchableDescriptors_ButDescriptorsStillListsThem()
+    {
+        var registry = new ToolRegistry(
+        [
+            new ToolDescriptor
+            {
+                Name = "meta-tool",
+                Title = "meta",
+                Description = "discover price news earnings tools by intent",
+                Searchable = false
+            },
+            new ToolDescriptor
+            {
+                Name = "price-tool",
+                Title = "price",
+                Description = "price movement and return"
+            },
+        ]);
+
+        var results = registry.Search("price");
+
+        Assert.DoesNotContain(results, m => m.Tool.Name == "meta-tool");
+        Assert.Equal("price-tool", Assert.Single(results).Tool.Name);
+        Assert.Contains(registry.Descriptors, d => d.Name == "meta-tool");
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/SearchToolsInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/SearchToolsInputValidatorTests.cs
@@ -1,0 +1,63 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Tools.Discovery;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Discovery;
+
+public sealed class SearchToolsInputValidatorTests
+{
+    [Theory]
+    [InlineData("is apple stock up this week", "is apple stock up this week")]
+    [InlineData("  upcoming earnings  ", "upcoming earnings")]
+    public void ValidateIntent_Valid_Normalises(string input, string expected) =>
+        Assert.Equal(expected, SearchToolsInputValidator.ValidateIntent(input));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateIntent_EmptyOrWhitespace_Throws(string? input) =>
+        Assert.Throws<ArgumentException>(() => SearchToolsInputValidator.ValidateIntent(input));
+
+    [Fact]
+    public void ValidateIntent_Over200Chars_Throws()
+    {
+        var tooLong = new string('a', 201);
+
+        Assert.Throws<ArgumentException>(() => SearchToolsInputValidator.ValidateIntent(tooLong));
+    }
+
+    [Fact]
+    public void ValidateIntent_Exactly200Chars_Allowed()
+    {
+        var atLimit = new string('a', 200);
+
+        Assert.Equal(atLimit, SearchToolsInputValidator.ValidateIntent(atLimit));
+    }
+
+    [Theory]
+    [InlineData("price <script>")]
+    [InlineData("earnings;DROP TABLE")]
+    [InlineData("emoji 🚀 intent")]
+    public void ValidateIntent_InvalidCharacters_Throws(string input) =>
+        Assert.Throws<ArgumentException>(() => SearchToolsInputValidator.ValidateIntent(input));
+
+    [Theory]
+    [InlineData(null, ToolView.Summary)]
+    [InlineData("summary", ToolView.Summary)]
+    [InlineData("standard", ToolView.Standard)]
+    [InlineData("FULL", ToolView.Full)]
+    public void ValidateView_KnownValues_MapToEnum(string? input, ToolView expected) =>
+        Assert.Equal(expected, SearchToolsInputValidator.ValidateView(input));
+
+    [Fact]
+    public void ValidateView_Unknown_Throws() =>
+        Assert.Throws<ArgumentException>(() => SearchToolsInputValidator.ValidateView("brief"));
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/SearchToolsRankingTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/SearchToolsRankingTests.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Discovery;
+using FinnHub.MCP.Server.Tools.Discovery;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Discovery;
+
+/// <summary>
+/// Acceptance-criteria rankings (spec §3 P7 / issue #219) exercised against the real
+/// <see cref="ToolCatalog"/> — the descriptors and curated examples actually shipped.
+/// </summary>
+public sealed class SearchToolsRankingTests
+{
+    private static ToolRegistry RealRegistry() => new(ToolCatalog.Descriptors);
+
+    [Fact]
+    public void UpcomingEarningsTechSector_RanksCalendarOrFinancialsInTopThree()
+    {
+        var top3 = RealRegistry()
+            .Search("upcoming earnings tech sector", topN: 3)
+            .Select(m => m.Tool.Name)
+            .ToList();
+
+        Assert.True(
+            top3.Contains("get-calendar") || top3.Contains("get-financials-snapshot"),
+            $"Expected get-calendar or get-financials-snapshot in top 3, got: {string.Join(", ", top3)}");
+    }
+
+    [Fact]
+    public void IsAppleStockUpThisWeek_RanksPriceSummaryFirstNewsPulseSecond()
+    {
+        var ranked = RealRegistry()
+            .Search("is apple stock up this week", topN: 5)
+            .Select(m => m.Tool.Name)
+            .ToList();
+
+        Assert.True(ranked.Count >= 2, $"Expected at least 2 matches, got: {string.Join(", ", ranked)}");
+        Assert.Equal("get-price-summary", ranked[0]);
+        Assert.Equal("get-news-pulse", ranked[1]);
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/SearchToolsToolTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/SearchToolsToolTests.cs
@@ -1,0 +1,93 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Discovery;
+using FinnHub.MCP.Server.Tools.Discovery;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Discovery;
+
+public sealed class SearchToolsToolTests
+{
+    private readonly IToolRegistry _registry = Substitute.For<IToolRegistry>();
+    private readonly SearchToolsTool _sut;
+
+    public SearchToolsToolTests() =>
+        this._sut = new SearchToolsTool(this._registry, NullLogger<SearchToolsTool>.Instance);
+
+    private static ToolDescriptor Descriptor(string name) => new()
+    {
+        Name = name,
+        Title = name,
+        Description = $"description for {name}",
+        Category = "Pricing"
+    };
+
+    [Fact]
+    public void SearchTools_ValidIntent_ReturnsRankedMatchesInEnvelope()
+    {
+        this._registry.Search("price now", Arg.Any<int>()).Returns(
+        [
+            new ToolMatch(Descriptor("get-price-summary"), 3.2d),
+            new ToolMatch(Descriptor("get-quote"), 1.1d)
+        ]);
+
+        var envelope = this._sut.SearchTools("price now");
+
+        Assert.True(envelope.IsSuccess);
+        Assert.NotNull(envelope.Data);
+        Assert.Equal("price now", envelope.Data!.Intent);
+        Assert.Equal(2, envelope.Data.TotalMatches);
+        Assert.Equal("get-price-summary", envelope.Data.Matches[0].Name);
+        Assert.Equal("get-quote", envelope.Data.Matches[1].Name);
+    }
+
+    [Fact]
+    public void SearchTools_SummaryView_OmitsDescription()
+    {
+        this._registry.Search(Arg.Any<string>(), Arg.Any<int>()).Returns([new ToolMatch(Descriptor("get-quote"), 2d)]);
+
+        var envelope = this._sut.SearchTools("price", view: "summary");
+
+        Assert.Null(envelope.Data!.Matches[0].Description);
+    }
+
+    [Fact]
+    public void SearchTools_StandardView_IncludesDescription()
+    {
+        this._registry.Search(Arg.Any<string>(), Arg.Any<int>()).Returns([new ToolMatch(Descriptor("get-quote"), 2d)]);
+
+        var envelope = this._sut.SearchTools("price", view: "standard");
+
+        Assert.Equal("description for get-quote", envelope.Data!.Matches[0].Description);
+    }
+
+    [Fact]
+    public void SearchTools_NoMatches_ReturnsEmptyMatchesSuccess()
+    {
+        this._registry.Search(Arg.Any<string>(), Arg.Any<int>()).Returns([]);
+
+        var envelope = this._sut.SearchTools("nonsense");
+
+        Assert.True(envelope.IsSuccess);
+        Assert.Empty(envelope.Data!.Matches);
+    }
+
+    [Fact]
+    public void SearchTools_IntentOver200Chars_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => this._sut.SearchTools(new string('a', 201)));
+    }
+
+    [Fact]
+    public void SearchTools_EmptyIntent_Throws()
+    {
+        Assert.Throws<ArgumentException>(() => this._sut.SearchTools(""));
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/ToolRegistryDriftTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Discovery/ToolRegistryDriftTests.cs
@@ -1,0 +1,63 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using FinnHub.MCP.Server.Tools.Discovery;
+using ModelContextProtocol.Server;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Tools.Discovery;
+
+/// <summary>
+/// Guards parity between the tools actually registered on the server (every
+/// <c>[McpServerTool]</c> method on a <c>[McpServerToolType]</c> class in the Server assembly)
+/// and the <see cref="ToolCatalog"/> the discovery index ranks over. A tool added to the server
+/// without a catalog descriptor would be undiscoverable via <c>search-tools</c> — this fails first.
+/// </summary>
+public sealed class ToolRegistryDriftTests
+{
+    private static HashSet<string> RegisteredToolNames() =>
+        typeof(SearchToolsTool).Assembly
+            .GetTypes()
+            .Where(type => type.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => !string.IsNullOrEmpty(attribute?.Name))
+            .Select(attribute => attribute!.Name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+    [Fact]
+    public void EveryRegisteredTool_HasACatalogDescriptor()
+    {
+        var registered = RegisteredToolNames();
+        Assert.NotEmpty(registered);
+
+        var catalog = ToolCatalog.Descriptors.Select(d => d.Name).ToHashSet(StringComparer.Ordinal);
+
+        var missing = registered.Except(catalog).Order().ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"Tools registered with [McpServerTool] but missing a ToolCatalog descriptor: {string.Join(", ", missing)}");
+    }
+
+    [Fact]
+    public void EveryCatalogDescriptor_MapsToARegisteredTool()
+    {
+        var registered = RegisteredToolNames();
+
+        var orphans = ToolCatalog.Descriptors
+            .Select(d => d.Name)
+            .Where(name => !registered.Contains(name))
+            .Order()
+            .ToList();
+
+        Assert.True(
+            orphans.Count == 0,
+            $"ToolCatalog descriptors with no registered tool: {string.Join(", ", orphans)}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds the **`search-tools` meta-tool** — the spec's headline "80–95% schema-token win" (§3 P7). A client passes a natural-language `intent` and gets back the most relevant tools, ranked by a pure-C# BM25 keyword index, so full tool schemas stay off the wire until a tool is actually needed. Closes #219.

```
search-tools(intent="is apple stock up this week")
  → get-price-summary (6.16), get-news-pulse (3.67), search-symbol (3.46), ...
search-tools(intent="upcoming earnings tech sector")
  → get-calendar (7.03), get-peers (3.95), get-financials-snapshot (2.71)
```

## What's here

- **`Application/Discovery`** — `ToolDescriptor`, `ToolMatch`, `IToolRegistry`, `ToolRegistry`. Pure-C# BM25 over name + title + description + examples; no embeddings, no external dependency. Curated examples are weighted above the description (a simple BM25F) so incidental description tokens — a literal `query='apple'`, ISINs, parameter names — don't dominate.
- **`Server/Tools/Discovery`** — `ToolCatalog` (descriptors from `Constants.Tools` + curated example intents), `SearchToolsTool`, `SearchToolsResponse`, `SearchToolsInputValidator` (regex + 200-char bound).
- **Drift test** — reflects over `[McpServerToolType]` tools and fails the build if any registered tool lacks a catalog descriptor (both directions).
- **Program.cs** — `IToolRegistry` singleton + `WithWrappedTools<SearchToolsTool>`.

## Design notes

- **Curated catalog, not pure reflection.** The spec sketched "reflect over `[McpServerToolType]`", but the drift-detection AC is only meaningful if the index is *separable* from registration — a reflection-derived index can't drift. So the index is a curated `ToolCatalog`, and the drift test enforces parity. This also supplies `examples`/`category`, which MCP attributes don't carry.
- **Layering.** Ranking logic is host-agnostic (`Application`); the catalog data + tool live in `Server` (it references `Constants`). The registry is built from the catalog at DI time, so `Application` keeps no `Server` reference.
- **`search-tools` excludes itself** from results (`Searchable=false`) but stays in `Descriptors` for the drift check and the capabilities resource (#220, sibling story — out of scope here).

## Testing

- 0-warning build · `dotnet format --verify-no-changes` clean · **full suite green (769 tests)** — Application Discovery (BM25 + registry integrity), Server Discovery (tool, validator, real-catalog ranking ACs, drift parity).
- **Live STDIO MCP smoke**: `tools/list` exposes `search-tools` (11 tools); both AC intents rank as required end-to-end; summary view omits descriptions (`approx_tokens` 214, under the 500 ceiling); standard view includes them (1256, under 2000); a >200-char intent returns a tool error.

No Finnhub endpoint, DTO, fixture or HTTP client — `search-tools` is entirely in-process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
