### PR TITLE
feat(resource): add capabilities catalog resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 
 Every tool returns the standard token-budgeted envelope with cross-linked `next_actions` and the most-recent observed Finnhub rate-limit headers.
 
-**Resources (2):**
+**Resources (3):**
+- **`finnhub://resources/capabilities`** — the full machine-readable catalog of every registered tool (`name`, `title`, `description`, `category`, `examples`, `premium`) plus `total_count`. Enumerate the whole surface in one read instead of issuing repeated `search-tools` calls; backed by the same `IToolRegistry` the meta-tool ranks over.
 - **`finnhub://resources/exchanges`** — the full catalog of stock venues Finnhub supports (79 exchanges: code, name, country, MIC, timezone, market hours). `url` is `null` for the few venues Finnhub lists without a reference link.
 - **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
@@ -257,6 +258,26 @@ Every MCP tool returns the same envelope shape so consuming models get a predict
 | `premium` | bool | Whether the underlying upstream endpoint required a premium key. |
 
 A response that exceeds its declared view's token ceiling is rebuilt by the tool invocation middleware as a `BudgetExceeded` failure envelope; retry with a broader `view` or a sparser `fields` projection.
+
+### Resource: `finnhub://resources/capabilities`
+
+Returns the full tool catalog as `application/json` — one entry per registered tool (`name`, `title`, `description`, `category`, `examples`, `premium`) plus `total_count`. It reads from the same `IToolRegistry` the `search-tools` meta-tool ranks over, so the catalog and the ranker never disagree; a `CapabilitiesResourceTests` drift test fails the build if a registered tool is missing from the payload.
+
+```json
+{
+  "tools": [
+    {
+      "name": "get-quote",
+      "title": "Get Quote",
+      "description": "…",
+      "category": "Pricing",
+      "examples": ["current stock price right now", "latest real-time quote"],
+      "premium": false
+    }
+  ],
+  "total_count": 11
+}
+```
 
 ### Resource: `finnhub://resources/exchanges`
 

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -16,6 +16,7 @@ using FinnHub.MCP.Server.Application.Tokens;
 using FinnHub.MCP.Server.Common;
 using FinnHub.MCP.Server.Infrastructure.Extensions;
 using FinnHub.MCP.Server.Middleware;
+using FinnHub.MCP.Server.Resources.Capabilities;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
 using FinnHub.MCP.Server.Tools.Calendar;
@@ -131,7 +132,8 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithWrappedTools<GetInsiderSignalTool>()
 .WithWrappedTools<GetRecommendationsTool>()
 .WithResources<ExchangesResource>()
-.WithResources<ApiStatusResource>();
+.WithResources<ApiStatusResource>()
+.WithResources<CapabilitiesResource>();
 
 if (isStdio)
 {

--- a/src/FinnHub.MCP.Server/Resources/Capabilities/CapabilitiesPayload.cs
+++ b/src/FinnHub.MCP.Server/Resources/Capabilities/CapabilitiesPayload.cs
@@ -1,0 +1,59 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Serialization;
+
+namespace FinnHub.MCP.Server.Resources.Capabilities;
+
+/// <summary>
+/// Wire shape for <c>finnhub://resources/capabilities</c>: the full machine-readable catalog of
+/// every registered MCP tool, so a client can enumerate the surface without issuing N
+/// <c>search-tools</c> calls.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class CapabilitiesPayload
+{
+    /// <summary>Every registered tool, in registration order.</summary>
+    [JsonPropertyName("tools")]
+    public required IReadOnlyList<CapabilityEntry> Tools { get; init; }
+
+    /// <summary>Number of tools in the catalog.</summary>
+    [JsonPropertyName("total_count")]
+    public int TotalCount => this.Tools.Count;
+}
+
+/// <summary>
+/// A single tool's entry in the capabilities catalog.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public sealed class CapabilityEntry
+{
+    /// <summary>The MCP tool name (e.g. <c>get-price-summary</c>).</summary>
+    [JsonPropertyName("name")]
+    public required string Name { get; init; }
+
+    /// <summary>The human-readable title.</summary>
+    [JsonPropertyName("title")]
+    public required string Title { get; init; }
+
+    /// <summary>The full tool description.</summary>
+    [JsonPropertyName("description")]
+    public required string Description { get; init; }
+
+    /// <summary>Coarse grouping (e.g. <c>Pricing</c>, <c>Fundamentals</c>).</summary>
+    [JsonPropertyName("category")]
+    public string? Category { get; init; }
+
+    /// <summary>Natural-language example intents that map to this tool.</summary>
+    [JsonPropertyName("examples")]
+    public IReadOnlyList<string> Examples { get; init; } = [];
+
+    /// <summary>Whether the tool's upstream Finnhub endpoint may require a premium key.</summary>
+    [JsonPropertyName("premium")]
+    public bool Premium { get; init; }
+}

--- a/src/FinnHub.MCP.Server/Resources/Capabilities/CapabilitiesResource.cs
+++ b/src/FinnHub.MCP.Server/Resources/Capabilities/CapabilitiesResource.cs
@@ -1,0 +1,62 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Net.Mime;
+using FinnHub.MCP.Server.Application.Discovery;
+
+namespace FinnHub.MCP.Server.Resources.Capabilities;
+
+/// <summary>
+/// MCP resource that exposes the full machine-readable catalog of registered tools.
+/// </summary>
+/// <remarks>
+/// Reads from the same <see cref="IToolRegistry"/> the <c>search-tools</c> meta-tool ranks over,
+/// so the catalog and the ranker can never disagree. A client can enumerate the whole tool surface
+/// — name, title, description, category, premium flag and example intents — from one read instead
+/// of issuing repeated <c>search-tools</c> calls.
+/// </remarks>
+[McpServerResourceType]
+public sealed class CapabilitiesResource(IToolRegistry registry)
+{
+    /// <summary>
+    /// Returns the tool catalog serialized as JSON for the
+    /// <c>finnhub://resources/capabilities</c> resource.
+    /// </summary>
+    /// <remarks>
+    /// The MCP SDK accepts only a fixed set of return types for resource handlers
+    /// (<c>ResourceContents</c>, <c>string</c>, <c>IEnumerable&lt;...&gt;</c>); a
+    /// <see cref="string"/> is wrapped in a <c>TextResourceContents</c> using the
+    /// declared <see cref="MediaTypeNames.Application.Json"/> mime type.
+    /// </remarks>
+    [McpServerResource(
+        UriTemplate = "finnhub://resources/capabilities",
+        Name = "get-capabilities",
+        Title = "Capabilities",
+        MimeType = MediaTypeNames.Application.Json)]
+    [Description("Lists every Finnhub MCP tool with its title, description, category, premium flag, and example intents.")]
+    public string GetCapabilities()
+    {
+        var payload = new CapabilitiesPayload
+        {
+            Tools =
+            [
+                .. registry.Descriptors.Select(descriptor => new CapabilityEntry
+                {
+                    Name = descriptor.Name,
+                    Title = descriptor.Title,
+                    Description = descriptor.Description,
+                    Category = descriptor.Category,
+                    Examples = descriptor.Examples,
+                    Premium = descriptor.Premium
+                })
+            ]
+        };
+
+        return JsonSerializer.Serialize(payload, ResourceJsonContext.Default.CapabilitiesPayload);
+    }
+}

--- a/src/FinnHub.MCP.Server/Resources/ResourceJsonContext.cs
+++ b/src/FinnHub.MCP.Server/Resources/ResourceJsonContext.cs
@@ -8,6 +8,7 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using FinnHub.MCP.Server.Application.Exchanges.Features.GetAllExchanges;
+using FinnHub.MCP.Server.Resources.Capabilities;
 using FinnHub.MCP.Server.Resources.Status;
 
 namespace FinnHub.MCP.Server.Resources;
@@ -26,4 +27,5 @@ namespace FinnHub.MCP.Server.Resources;
 [JsonSourceGenerationOptions(WriteIndented = true)]
 [JsonSerializable(typeof(ApiStatusSnapshot))]
 [JsonSerializable(typeof(ExchangesResponse))]
+[JsonSerializable(typeof(CapabilitiesPayload))]
 internal sealed partial class ResourceJsonContext : JsonSerializerContext;

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Resources/CapabilitiesResourceTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Resources/CapabilitiesResourceTests.cs
@@ -1,0 +1,96 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Text.Json;
+using FinnHub.MCP.Server.Application.Discovery;
+using FinnHub.MCP.Server.Resources.Capabilities;
+using FinnHub.MCP.Server.Tools.Discovery;
+using ModelContextProtocol.Server;
+using NSubstitute;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Resources;
+
+public sealed class CapabilitiesResourceTests
+{
+    private static CapabilitiesResource RealResource() => new(new ToolRegistry(ToolCatalog.Descriptors));
+
+    private static HashSet<string> RegisteredToolNames() =>
+        typeof(CapabilitiesResource).Assembly
+            .GetTypes()
+            .Where(type => type.GetCustomAttribute<McpServerToolTypeAttribute>() is not null)
+            .SelectMany(type => type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.Static))
+            .Select(method => method.GetCustomAttribute<McpServerToolAttribute>())
+            .Where(attribute => !string.IsNullOrEmpty(attribute?.Name))
+            .Select(attribute => attribute!.Name!)
+            .ToHashSet(StringComparer.Ordinal);
+
+    [Fact]
+    public void GetCapabilities_EnumeratesEveryRegisteredTool()
+    {
+        var json = RealResource().GetCapabilities();
+
+        using var document = JsonDocument.Parse(json);
+        var names = document.RootElement
+            .GetProperty("tools")
+            .EnumerateArray()
+            .Select(tool => tool.GetProperty("name").GetString()!)
+            .ToHashSet(StringComparer.Ordinal);
+
+        var missing = RegisteredToolNames().Except(names).Order().ToList();
+
+        Assert.True(
+            missing.Count == 0,
+            $"Tools registered with [McpServerTool] but missing from the capabilities catalog: {string.Join(", ", missing)}");
+    }
+
+    [Fact]
+    public void GetCapabilities_TotalCountMatchesToolArrayLength()
+    {
+        var json = RealResource().GetCapabilities();
+
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+
+        Assert.Equal(
+            root.GetProperty("tools").GetArrayLength(),
+            root.GetProperty("total_count").GetInt32());
+    }
+
+    [Fact]
+    public void GetCapabilities_ProjectsAllDescriptorFields()
+    {
+        var registry = Substitute.For<IToolRegistry>();
+        IReadOnlyList<ToolDescriptor> descriptors =
+        [
+            new ToolDescriptor
+            {
+                Name = "get-quote",
+                Title = "Get Quote",
+                Description = "real-time price snapshot",
+                Category = "Pricing",
+                Examples = ["current price right now"],
+                Premium = false
+            }
+        ];
+        registry.Descriptors.Returns(descriptors);
+
+        var json = new CapabilitiesResource(registry).GetCapabilities();
+
+        using var document = JsonDocument.Parse(json);
+        var tool = document.RootElement.GetProperty("tools")[0];
+
+        Assert.Equal("get-quote", tool.GetProperty("name").GetString());
+        Assert.Equal("Get Quote", tool.GetProperty("title").GetString());
+        Assert.Equal("real-time price snapshot", tool.GetProperty("description").GetString());
+        Assert.Equal("Pricing", tool.GetProperty("category").GetString());
+        Assert.False(tool.GetProperty("premium").GetBoolean());
+        Assert.Equal("current price right now", tool.GetProperty("examples")[0].GetString());
+        Assert.Equal(1, document.RootElement.GetProperty("total_count").GetInt32());
+    }
+}


### PR DESCRIPTION
## Summary

Adds **`finnhub://resources/capabilities`** — the full machine-readable catalog of every registered MCP tool (`name`, `title`, `description`, `category`, `examples`, `premium`) plus `total_count`. A client can enumerate the whole tool surface in one read instead of issuing repeated `search-tools` calls. Closes #220.

This is the second half of Feature 1.4 (#196): #219 shipped the `search-tools` meta-tool; this reuses the same `IToolRegistry`.

## What's here

- **`CapabilitiesResource`** (`Server/Resources/Capabilities`) — injects `IToolRegistry`, projects `Descriptors` into the wire payload, serializes via source-gen. Mirrors `ExchangesResource`'s string-return shape.
- **`CapabilitiesPayload` / `CapabilityEntry`** — wire DTOs registered in `ResourceJsonContext` (`[JsonSerializable]`, source-gen — no reflection, per CLAUDE.md).
- **`Program.cs`** — `WithResources<CapabilitiesResource>()`.
- **`CapabilitiesResourceTests`** — field projection, `total_count` parity, and a **reflection drift test** that fails the build if a tool registered with `[McpServerTool]` is missing from the payload (the #220 AC).

## Why one registry for both

The catalog reads from the same `IToolRegistry` the `search-tools` ranker uses, so the two can never drift apart — discover-by-intent and enumerate-everything stay consistent by construction.

## Testing

- 0-warning build · `dotnet format --verify-no-changes` clean · **full suite green (772 tests)**.
- **Live STDIO MCP smoke**: `resources/list` exposes the resource; the read returns `application/json`, `total_count: 11`, all 11 tools with complete fields (e.g. `get-quote` → category `Pricing`, `premium: false`, 3 examples).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
