### PR TITLE
chore(deps): bump ModelContextProtocol to 1.4.0

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>false</CentralPackageTransitivePinningEnabled>
-    <ModelContextProtocolVersion>1.3.0</ModelContextProtocolVersion>
+    <ModelContextProtocolVersion>1.4.0</ModelContextProtocolVersion>
   </PropertyGroup>
 
   <ItemGroup Label="ModelContextProtocol">

--- a/Packages.props
+++ b/Packages.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-    <ModelContextProtocolVersion>0.2.0-preview.1</ModelContextProtocolVersion>
+    <ModelContextProtocolVersion>1.4.0</ModelContextProtocolVersion>
     <MicrosoftDependencyInjectionVersion>7.0.0</MicrosoftDependencyInjectionVersion>
     <MicrosoftLoggingVersion>7.0.0</MicrosoftLoggingVersion>
     <MicrosoftOptionsVersion>8.0.0</MicrosoftOptionsVersion>


### PR DESCRIPTION
## Summary

Bumps **`ModelContextProtocol` + `ModelContextProtocol.AspNetCore` 1.3.0 → 1.4.0** (latest). 1.4.0 adds enterprise SSO (ID-JAG) and HTTP security hardening — **no breaking API changes** affecting this codebase.

Two files: the effective pin in `Directory.Packages.props`, plus the shadowed duplicate in `Packages.props` (which is overridden at import time — synced from a misleading `0.2.0-preview.1` to `1.4.0`; full removal of the dead `Packages.props` properties remains tracked under the M27 cleanup).

## Verification under 1.4.0
- ✅ `dotnet build` — **0 warnings / 0 errors** (`TreatWarningsAsErrors`)
- ✅ `dotnet format --verify-no-changes` — clean
- ✅ `dotnet test` (excl. LiveSmoke) — **769 tests pass**
- ✅ Live STDIO MCP smoke — `initialize` handshake, `tools/list` (11 tools), `resources/list`, and a `search-tools` call (ranking intact) all pass

## Context
This is a routine currency bump and a small step toward the future MCP Apps work — though note 1.4.0 itself ships **no** MCP Apps helpers; the ergonomic `ModelContextProtocol.Extensions.Apps` layer is still in-flight upstream ([csharp-sdk PR #1484](https://github.com/modelcontextprotocol/csharp-sdk/pull/1484)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
