### PR TITLE
fix(transport): bind STDIO Kestrel to an ephemeral port, not 5000

### DIFF
--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -38,8 +38,9 @@ var version = assembly?.GetCustomAttribute<AssemblyInformationalVersionAttribute
 
 var isStdio = args.Contains("--stdio");
 
-// STDIO transport never binds HTTP — skip the default --urls injection so two
-// concurrent stdio instances don't fight over port 8080.
+// HTTP transport listens on 8080. STDIO transport communicates over stdin/stdout; its Kestrel
+// listener is pinned to an ephemeral loopback port after Build() (see below) so concurrent
+// stdio instances never collide on a fixed port.
 if (!isStdio && !args.Contains("--urls"))
 {
     args = args
@@ -171,6 +172,17 @@ builder.Services.AddCors(options =>
 });
 
 var app = builder.Build();
+
+if (isStdio)
+{
+    // STDIO speaks over stdin/stdout, but the WebApplication host still starts Kestrel. Setting
+    // app.Urls explicitly is authoritative — it suppresses the default localhost:5000 binding —
+    // so pin an ephemeral loopback port (0, OS-assigned). Concurrent stdio instances (a reconnect,
+    // a second MCP client, or a lingering process) then each get their own free port instead of
+    // crashing on AddressInUseException for port 5000, which dropped the MCP connection.
+    app.Urls.Clear();
+    app.Urls.Add("http://127.0.0.1:0");
+}
 
 if (app.Environment.IsDevelopment())
 {


### PR DESCRIPTION
## Summary

In `--stdio` mode the server communicates over stdin/stdout, but the `WebApplication` host still starts Kestrel — and with no URL configured it fell through to ASP.NET's **default port 5000**. So a reconnect, a second MCP client, or a lingering instance hit `AddressInUseException` on 5000 and the process crashed **right after the initialize response**, surfacing in clients as **"MCP not connecting" / connection closed**. (macOS AirPlay Receiver also listens on 5000, compounding it.)

## Fix

Pin the stdio listener to an **ephemeral loopback port** via `app.Urls` after `Build()`. Setting `app.Urls` explicitly is authoritative — it suppresses the default 5000 binding (a config-level `--urls` only *added* a listener, leaving 5000 bound). HTTP mode (8080) is unchanged.

```csharp
if (isStdio)
{
    app.Urls.Clear();
    app.Urls.Add("http://127.0.0.1:0"); // OS-assigned free port
}
```

## How it was found / verified

Reproduced the exact MCP launch command and read the actual stderr + `lsof` (a lingering `FinnHub.MCP.Server --stdio` held `:5000`). After the fix, **two concurrent `--stdio` instances both initialize and serve tool calls with zero bind errors**, and `lsof` confirms no 5000 listener.

- 0-warning build (`TreatWarningsAsErrors`) · `dotnet format` clean · 772 unit tests pass

Surfaced while wiring local MCP Apps testing; unrelated to that work and worth landing on its own. Tracked context: Epic #431.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
