### PR TITLE
feat(prompt): add /research-ticker slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,9 @@ Every tool returns the standard token-budgeted envelope with cross-linked `next_
 - **`finnhub://resources/exchanges`** — the full catalog of stock venues Finnhub supports (79 exchanges: code, name, country, MIC, timezone, market hours). `url` is `null` for the few venues Finnhub lists without a reference link.
 - **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
+**Prompts (1):**
+- **`/research-ticker {symbol}`** — Claude Desktop slash command that renders a deterministic research workflow: resolve the symbol (via `search-symbol`), then pull `get-price-summary`, `get-financials-snapshot`, and `get-news-pulse`, and synthesise a brief. A pure template — no server-side LLM calls, so the same symbol always renders byte-identical text.
+
 ### 📋 Planned
 - Technical indicators (RSI, MACD, moving averages)
 - WebSocket transport for streaming Finnhub feeds

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -862,4 +862,34 @@ public static class Constants
                 """;
         }
     }
+
+    /// <summary>Constants for the MCP prompts (Claude Desktop slash commands).</summary>
+    public static class Prompts
+    {
+        /// <summary>Constants for the <c>research-ticker</c> prompt — a templated research workflow.</summary>
+        public static class ResearchTicker
+        {
+            /// <summary>The unique prompt identifier (the slash-command name).</summary>
+            public const string Name = "research-ticker";
+
+            /// <summary>The human-readable prompt title.</summary>
+            public const string Title = "Research Ticker";
+
+            /// <summary>Prompt description shown in the client's prompt picker.</summary>
+            public const string Description =
+                "Templated research workflow for a ticker: resolve the symbol, then pull the price "
+                + "summary, financials snapshot, and news pulse, and synthesise a brief.";
+
+            /// <summary>Argument names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol argument name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol argument description.</summary>
+                public const string SymbolDescription =
+                    "Ticker symbol to research, e.g. 'AAPL'. 1-32 characters: letters, digits, dots, or dashes.";
+            }
+        }
+    }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -16,6 +16,7 @@ using FinnHub.MCP.Server.Application.Tokens;
 using FinnHub.MCP.Server.Common;
 using FinnHub.MCP.Server.Infrastructure.Extensions;
 using FinnHub.MCP.Server.Middleware;
+using FinnHub.MCP.Server.Prompts;
 using FinnHub.MCP.Server.Resources.Capabilities;
 using FinnHub.MCP.Server.Resources.Exchanges;
 using FinnHub.MCP.Server.Resources.Status;
@@ -136,7 +137,8 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithWrappedTools<GetExchangeSymbolsTool>()
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>()
-.WithResources<CapabilitiesResource>();
+.WithResources<CapabilitiesResource>()
+.WithPrompts<ResearchTickerPrompt>();
 
 if (isStdio)
 {

--- a/src/FinnHub.MCP.Server/Prompts/PromptInputValidator.cs
+++ b/src/FinnHub.MCP.Server/Prompts/PromptInputValidator.cs
@@ -1,0 +1,45 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text.RegularExpressions;
+
+namespace FinnHub.MCP.Server.Prompts;
+
+/// <summary>
+/// Shared input validation for the MCP prompts (Claude Desktop slash commands).
+/// </summary>
+internal static partial class PromptInputValidator
+{
+    [GeneratedRegex(@"^[A-Za-z0-9.\-]{1,32}$", RegexOptions.Compiled)]
+    private static partial Regex SymbolRegex();
+
+    /// <summary>
+    /// Validates and normalises a prompt's <c>symbol</c> argument to uppercase.
+    /// </summary>
+    /// <param name="symbol">The raw symbol argument.</param>
+    /// <returns>The trimmed, uppercased symbol.</returns>
+    /// <exception cref="ArgumentException">
+    /// Thrown when the symbol is missing, longer than 32 characters, or contains disallowed characters.
+    /// </exception>
+    public static string ValidateSymbol(string? symbol)
+    {
+        if (string.IsNullOrWhiteSpace(symbol))
+        {
+            throw new ArgumentException("Symbol is required.", nameof(symbol));
+        }
+
+        symbol = symbol.Trim().ToUpperInvariant();
+
+        if (!SymbolRegex().IsMatch(symbol))
+        {
+            throw new ArgumentException(
+                "Symbol must be 1-32 characters: letters, digits, dots, or dashes.", nameof(symbol));
+        }
+
+        return symbol;
+    }
+}

--- a/src/FinnHub.MCP.Server/Prompts/ResearchTickerPrompt.cs
+++ b/src/FinnHub.MCP.Server/Prompts/ResearchTickerPrompt.cs
@@ -1,0 +1,60 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Prompts;
+
+/// <summary>
+/// MCP prompt exposing <c>/research-ticker {symbol}</c> as a Claude Desktop slash command — a
+/// deterministic, templated research workflow over the existing tools.
+/// </summary>
+/// <remarks>
+/// The render is a pure string template: no server-side LLM calls and no non-deterministic content,
+/// so the same <c>symbol</c> always produces byte-identical text. The template instructs the client
+/// to resolve the symbol via <c>search-symbol</c> (the P3 symbol resolver) and then call
+/// <c>get-price-summary</c>, <c>get-financials-snapshot</c>, and <c>get-news-pulse</c>.
+/// </remarks>
+[McpServerPromptType]
+public sealed class ResearchTickerPrompt
+{
+    /// <summary>
+    /// Renders the research-workflow prompt for <paramref name="symbol"/>.
+    /// </summary>
+    /// <param name="symbol">The ticker symbol to research.</param>
+    /// <returns>The templated research instructions as a single user prompt message.</returns>
+    [McpServerPrompt(
+        Name = Constants.Prompts.ResearchTicker.Name,
+        Title = Constants.Prompts.ResearchTicker.Title)]
+    [Description(Constants.Prompts.ResearchTicker.Description)]
+    public static string ResearchTicker(
+        [Description(Constants.Prompts.ResearchTicker.Parameters.SymbolDescription)]
+        string symbol)
+    {
+        var validated = PromptInputValidator.ValidateSymbol(symbol);
+
+        return $"""
+            You are researching the company behind the ticker "{validated}". Work through this
+            workflow, calling each tool and summarising as you go — do not guess values that a tool
+            can provide for you.
+
+            1. Resolve the symbol. If "{validated}" is not a clean, unambiguous ticker, call
+               `search-symbol` (the symbol resolver) to find the canonical ticker before continuing.
+            2. Price action — call `get-price-summary` for {validated} to get the recent price trend,
+               range, and return.
+            3. Fundamentals — call `get-financials-snapshot` for {validated} to get valuation ratios
+               and the key financial metrics.
+            4. News and sentiment — call `get-news-pulse` for {validated} to get the latest headlines
+               and the sentiment read.
+
+            Then write a concise research brief covering what the company does, where the price is,
+            how it is valued, and what the news is saying. Note any data that was unavailable (for
+            example a premium-gated endpoint) instead of guessing.
+            """;
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/PromptInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/PromptInputValidatorTests.cs
@@ -1,0 +1,51 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Prompts;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Prompts;
+
+public sealed class PromptInputValidatorTests
+{
+    [Theory]
+    [InlineData("aapl", "AAPL")]
+    [InlineData("  msft  ", "MSFT")]
+    [InlineData("BRK.A", "BRK.A")]
+    [InlineData("RDS-A", "RDS-A")]
+    public void ValidateSymbol_Valid_NormalisesToUppercase(string input, string expected)
+    {
+        Assert.Equal(expected, PromptInputValidator.ValidateSymbol(input));
+    }
+
+    [Fact]
+    public void ValidateSymbol_MaxLength32_IsAccepted()
+    {
+        var symbol = new string('A', 32);
+
+        Assert.Equal(symbol, PromptInputValidator.ValidateSymbol(symbol));
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ValidateSymbol_Empty_Throws(string? symbol)
+    {
+        Assert.Throws<ArgumentException>(() => PromptInputValidator.ValidateSymbol(symbol));
+    }
+
+    [Theory]
+    [InlineData("AAPL MSFT")] // whitespace
+    [InlineData("A/B")]       // slash
+    [InlineData("A!B")]       // punctuation
+    [InlineData("ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567")] // 33 chars — exceeds the 32-char bound
+    public void ValidateSymbol_Invalid_Throws(string symbol)
+    {
+        Assert.Throws<ArgumentException>(() => PromptInputValidator.ValidateSymbol(symbol));
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/ResearchTickerPromptTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/ResearchTickerPromptTests.cs
@@ -1,0 +1,67 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+using FinnHub.MCP.Server.Prompts;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Prompts;
+
+public sealed class ResearchTickerPromptTests
+{
+    [Fact]
+    public void ResearchTicker_RenderedTwice_IsByteIdentical()
+    {
+        var first = ResearchTickerPrompt.ResearchTicker("AAPL");
+        var second = ResearchTickerPrompt.ResearchTicker("AAPL");
+
+        // The AC requires byte-identical output, so assert at the UTF-8 byte level explicitly.
+        Assert.Equal(Encoding.UTF8.GetBytes(first), Encoding.UTF8.GetBytes(second));
+    }
+
+    [Fact]
+    public void ResearchTicker_ReferencesResolverAndAggregationTools()
+    {
+        var text = ResearchTickerPrompt.ResearchTicker("AAPL");
+
+        Assert.Contains("search-symbol", text, StringComparison.Ordinal);
+        Assert.Contains("get-price-summary", text, StringComparison.Ordinal);
+        Assert.Contains("get-financials-snapshot", text, StringComparison.Ordinal);
+        Assert.Contains("get-news-pulse", text, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ResearchTicker_LowercaseSymbol_NormalisesToUppercase()
+    {
+        var text = ResearchTickerPrompt.ResearchTicker("aapl");
+
+        Assert.Contains("\"AAPL\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("aapl", text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("AAPL")]
+    [InlineData("BRK.A")]
+    [InlineData("RDS-A")]
+    public void ResearchTicker_ValidSymbol_EmbedsTheSymbol(string symbol)
+    {
+        var text = ResearchTickerPrompt.ResearchTicker(symbol);
+
+        Assert.Contains(symbol, text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("A B")]
+    [InlineData("A/B")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")] // 40 chars — exceeds the 32-char bound
+    public void ResearchTicker_InvalidSymbol_Throws(string? symbol)
+    {
+        Assert.Throws<ArgumentException>(() => ResearchTickerPrompt.ResearchTicker(symbol!));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **#221** (User Story 1.5.1) — the first **MCP prompt** (Claude Desktop slash command) and the **shared prompt scaffolding** for Feature 1.5.

`/research-ticker {symbol}` renders a deterministic, templated research workflow that walks the client through: resolve the symbol via `search-symbol` (the P3 resolver) → `get-price-summary` → `get-financials-snapshot` → `get-news-pulse` → synthesise a brief.

## Design

- **Pure template, no server-side intelligence** — `ResearchTickerPrompt` is `[McpServerPromptType]` with a static `[McpServerPrompt]` method returning a `string` (the SDK marshals it to a user-role `PromptMessage`). No LLM calls, no timestamps/GUIDs, so the same symbol always renders **byte-identical** text.
- **`PromptInputValidator`** is shared and reusable by the sibling prompts (#222/#223): rejects symbols > 32 chars or with disallowed characters, normalises case.
- No Finnhub call, no cache, no DTOs → no JSON-context changes (verified correct by review).
- Registered via `.WithPrompts<ResearchTickerPrompt>()`; metadata in `Constants.Prompts.ResearchTicker`.

## SDK note

Verified the C# SDK 1.4.0 prompt API before building (the spec flagged this as a P8 unknown): `[McpServerPromptType]` / `[McpServerPrompt(Name, Title)]` / `.WithPrompts<T>()` all confirmed against the package's public surface.

## Validation

- ✅ Build clean (0 warnings under `TreatWarningsAsErrors`), `dotnet format` clean
- ✅ **846 unit tests pass** (+23 here) — deterministic **byte-level** render, references-all-four-tools, case normalisation, validator rejection (empty / >32 chars / bad chars / 32-char boundary / dotted+dashed tickers)
- ✅ **STDIO live-smoke green** — the real server `prompts/list` lists `research-ticker` (title + required `symbol` arg) and `prompts/get` renders it (all 4 references + uppercased symbol) through the full MCP pipeline — the AC's "listed by Claude Desktop" check
- 🔍 Adversarial multi-agent review → 1 finding (test asserted string equality, not explicit bytes, despite the "byte-identical" AC); fixed by asserting UTF-8 bytes

Closes #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)