### PR TITLE
feat(prompt): add /compare-peers slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ Every tool returns the standard token-budgeted envelope with cross-linked `next_
 - **`finnhub://resources/exchanges`** — the full catalog of stock venues Finnhub supports (79 exchanges: code, name, country, MIC, timezone, market hours). `url` is `null` for the few venues Finnhub lists without a reference link.
 - **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
-**Prompts (1):**
+**Prompts (2):**
 - **`/research-ticker {symbol}`** — Claude Desktop slash command that renders a deterministic research workflow: resolve the symbol (via `search-symbol`), then pull `get-price-summary`, `get-financials-snapshot`, and `get-news-pulse`, and synthesise a brief. A pure template — no server-side LLM calls, so the same symbol always renders byte-identical text.
+- **`/compare-peers {symbol}`** — peer-comparison workflow: find the peer set via `get-peers`, fan out per peer to `get-financials-snapshot`, and build a side-by-side comparison. Also a pure deterministic template.
 
 ### 📋 Planned
 - Technical indicators (RSI, MACD, moving averages)

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -891,5 +891,31 @@ public static class Constants
                     "Ticker symbol to research, e.g. 'AAPL'. 1-32 characters: letters, digits, dots, or dashes.";
             }
         }
+
+        /// <summary>Constants for the <c>compare-peers</c> prompt — a templated peer-comparison workflow.</summary>
+        public static class ComparePeers
+        {
+            /// <summary>The unique prompt identifier (the slash-command name).</summary>
+            public const string Name = "compare-peers";
+
+            /// <summary>The human-readable prompt title.</summary>
+            public const string Title = "Compare Peers";
+
+            /// <summary>Prompt description shown in the client's prompt picker.</summary>
+            public const string Description =
+                "Templated peer-comparison workflow for a ticker: find the peer set, fan out per-peer "
+                + "financials, and build a side-by-side comparison.";
+
+            /// <summary>Argument names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol argument name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol argument description.</summary>
+                public const string SymbolDescription =
+                    "Ticker symbol to compare against its peers, e.g. 'AAPL'. 1-32 characters: letters, digits, dots, or dashes.";
+            }
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -138,7 +138,8 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithResources<ExchangesResource>()
 .WithResources<ApiStatusResource>()
 .WithResources<CapabilitiesResource>()
-.WithPrompts<ResearchTickerPrompt>();
+.WithPrompts<ResearchTickerPrompt>()
+.WithPrompts<ComparePeersPrompt>();
 
 if (isStdio)
 {

--- a/src/FinnHub.MCP.Server/Prompts/ComparePeersPrompt.cs
+++ b/src/FinnHub.MCP.Server/Prompts/ComparePeersPrompt.cs
@@ -1,0 +1,60 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Prompts;
+
+/// <summary>
+/// MCP prompt exposing <c>/compare-peers {symbol}</c> as a Claude Desktop slash command — a
+/// deterministic, templated peer-comparison workflow over the existing tools.
+/// </summary>
+/// <remarks>
+/// The render is a pure string template: no server-side LLM calls and no non-deterministic content,
+/// so the same <c>symbol</c> always produces byte-identical text. The template instructs the client
+/// to find the peer set via <c>get-peers</c> and then fan out per peer to
+/// <c>get-financials-snapshot</c> to build a side-by-side comparison.
+/// </remarks>
+[McpServerPromptType]
+public sealed class ComparePeersPrompt
+{
+    /// <summary>
+    /// Renders the peer-comparison workflow prompt for <paramref name="symbol"/>.
+    /// </summary>
+    /// <param name="symbol">The ticker symbol to compare against its peers.</param>
+    /// <returns>The templated comparison instructions as a single user prompt message.</returns>
+    [McpServerPrompt(
+        Name = Constants.Prompts.ComparePeers.Name,
+        Title = Constants.Prompts.ComparePeers.Title)]
+    [Description(Constants.Prompts.ComparePeers.Description)]
+    public static string ComparePeers(
+        [Description(Constants.Prompts.ComparePeers.Parameters.SymbolDescription)]
+        string symbol)
+    {
+        var validated = PromptInputValidator.ValidateSymbol(symbol);
+
+        return $"""
+            You are comparing the company behind the ticker "{validated}" against its peers. Work
+            through this workflow, calling each tool and summarising as you go — do not guess values
+            that a tool can provide for you.
+
+            1. Find the peer set — call `get-peers` for {validated} to get the comparable companies
+               (use the default industry grouping unless a narrower set is clearly needed).
+            2. Fan out across the peers — for {validated} and each peer returned by `get-peers`, call
+               `get-financials-snapshot` to pull the valuation ratios and key metrics. Keep the set
+               manageable (the top handful of peers) so the comparison stays focused.
+            3. Build a side-by-side comparison of the key metrics (for example market cap, P/E, P/B,
+               and margins) across {validated} and its peers.
+
+            Then write a short read on where {validated} sits relative to the group — cheaper or more
+            expensive, higher or lower growth and margins — and which peers are the closest
+            comparables. Note any peer whose data was unavailable (for example a premium-gated
+            endpoint) instead of guessing.
+            """;
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/ComparePeersPromptTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/ComparePeersPromptTests.cs
@@ -1,0 +1,67 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+using FinnHub.MCP.Server.Prompts;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Prompts;
+
+public sealed class ComparePeersPromptTests
+{
+    [Fact]
+    public void ComparePeers_RenderedTwice_IsByteIdentical()
+    {
+        var first = ComparePeersPrompt.ComparePeers("AAPL");
+        var second = ComparePeersPrompt.ComparePeers("AAPL");
+
+        // The AC requires byte-identical output, so assert at the UTF-8 byte level explicitly.
+        Assert.Equal(Encoding.UTF8.GetBytes(first), Encoding.UTF8.GetBytes(second));
+    }
+
+    [Fact]
+    public void ComparePeers_ReferencesPeersAndFinancialsFanOut()
+    {
+        var text = ComparePeersPrompt.ComparePeers("AAPL");
+
+        Assert.Contains("get-peers", text, StringComparison.Ordinal);
+        Assert.Contains("get-financials-snapshot", text, StringComparison.Ordinal);
+        // The AC requires a per-peer fan-out instruction.
+        Assert.Contains("each peer", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ComparePeers_LowercaseSymbol_NormalisesToUppercase()
+    {
+        var text = ComparePeersPrompt.ComparePeers("aapl");
+
+        Assert.Contains("\"AAPL\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("aapl", text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("AAPL")]
+    [InlineData("BRK.A")]
+    [InlineData("RDS-A")]
+    public void ComparePeers_ValidSymbol_EmbedsTheSymbol(string symbol)
+    {
+        var text = ComparePeersPrompt.ComparePeers(symbol);
+
+        Assert.Contains(symbol, text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("A B")]
+    [InlineData("A/B")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")] // 40 chars — exceeds the 32-char bound
+    public void ComparePeers_InvalidSymbol_Throws(string? symbol)
+    {
+        Assert.Throws<ArgumentException>(() => ComparePeersPrompt.ComparePeers(symbol!));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **#222** (User Story 1.5.2) — the second MCP prompt for Feature 1.5, built on the prompt scaffolding from #221.

`/compare-peers {symbol}` renders a deterministic, templated peer-comparison workflow: find the peer set via `get-peers`, fan out per peer to `get-financials-snapshot`, and build a side-by-side comparison.

## Design

- **Pure template** — `ComparePeersPrompt` is `[McpServerPromptType]` with a static `[McpServerPrompt]` method returning a `string` (marshalled to a user-role `PromptMessage`). No LLM calls, no non-deterministic content → byte-identical render for a given symbol.
- **Reuses the shared `PromptInputValidator`** unchanged (the scaffolding #221 was designed to share).
- `Constants.Prompts.ComparePeers` + `.WithPrompts<ComparePeersPrompt>()`; README bumped to 2 prompts.

## Validation

- ✅ Build clean (0 warnings), `dotnet format` clean
- ✅ **857 unit tests pass** (+11) — byte-level deterministic render, `get-peers` + per-peer fan-out to `get-financials-snapshot` references, case normalisation, validator rejection
- ✅ **STDIO live-smoke green** — `prompts/list` now lists both `compare-peers` and `research-ticker`; `prompts/get compare-peers` renders correctly through the full MCP pipeline
- 🔍 Adversarial review of the diff → **CLEAN**, no defects (no copy-paste drift from #221, correct tool references)

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)