### PR TITLE
feat(prompt): add /news-pulse slash command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ Every tool returns the standard token-budgeted envelope with cross-linked `next_
 - **`finnhub://resources/exchanges`** — the full catalog of stock venues Finnhub supports (79 exchanges: code, name, country, MIC, timezone, market hours). `url` is `null` for the few venues Finnhub lists without a reference link.
 - **`finnhub://resources/api-status`** — latest observed Finnhub upstream quota: `remaining`, `reset_at`, and a rolling 429 count
 
-**Prompts (2):**
+**Prompts (3):**
 - **`/research-ticker {symbol}`** — Claude Desktop slash command that renders a deterministic research workflow: resolve the symbol (via `search-symbol`), then pull `get-price-summary`, `get-financials-snapshot`, and `get-news-pulse`, and synthesise a brief. A pure template — no server-side LLM calls, so the same symbol always renders byte-identical text.
 - **`/compare-peers {symbol}`** — peer-comparison workflow: find the peer set via `get-peers`, fan out per peer to `get-financials-snapshot`, and build a side-by-side comparison. Also a pure deterministic template.
+- **`/news-pulse {symbol}`** — news-sentiment workflow: pull `get-news-pulse`, compare against last week, and write a sentiment narrative. Also a pure deterministic template.
 
 ### 📋 Planned
 - Technical indicators (RSI, MACD, moving averages)

--- a/src/FinnHub.MCP.Server/Common/Constants.cs
+++ b/src/FinnHub.MCP.Server/Common/Constants.cs
@@ -917,5 +917,31 @@ public static class Constants
                     "Ticker symbol to compare against its peers, e.g. 'AAPL'. 1-32 characters: letters, digits, dots, or dashes.";
             }
         }
+
+        /// <summary>Constants for the <c>news-pulse</c> prompt — a templated news-sentiment workflow.</summary>
+        public static class NewsPulse
+        {
+            /// <summary>The unique prompt identifier (the slash-command name).</summary>
+            public const string Name = "news-pulse";
+
+            /// <summary>The human-readable prompt title.</summary>
+            public const string Title = "News Pulse";
+
+            /// <summary>Prompt description shown in the client's prompt picker.</summary>
+            public const string Description =
+                "Templated news-sentiment workflow for a ticker: pull the news pulse, compare against "
+                + "last week, and write a sentiment narrative.";
+
+            /// <summary>Argument names and descriptions.</summary>
+            public static class Parameters
+            {
+                /// <summary>Symbol argument name.</summary>
+                public const string SymbolName = "symbol";
+
+                /// <summary>Symbol argument description.</summary>
+                public const string SymbolDescription =
+                    "Ticker symbol to read the news pulse for, e.g. 'AAPL'. 1-32 characters: letters, digits, dots, or dashes.";
+            }
+        }
     }
 }

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -139,7 +139,8 @@ var mcpBuilder = builder.Services.AddMcpServer(options =>
 .WithResources<ApiStatusResource>()
 .WithResources<CapabilitiesResource>()
 .WithPrompts<ResearchTickerPrompt>()
-.WithPrompts<ComparePeersPrompt>();
+.WithPrompts<ComparePeersPrompt>()
+.WithPrompts<NewsPulsePrompt>();
 
 if (isStdio)
 {

--- a/src/FinnHub.MCP.Server/Prompts/NewsPulsePrompt.cs
+++ b/src/FinnHub.MCP.Server/Prompts/NewsPulsePrompt.cs
@@ -1,0 +1,58 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.ComponentModel;
+using FinnHub.MCP.Server.Common;
+
+namespace FinnHub.MCP.Server.Prompts;
+
+/// <summary>
+/// MCP prompt exposing <c>/news-pulse {symbol}</c> as a Claude Desktop slash command — a
+/// deterministic, templated news-sentiment workflow over the existing tools.
+/// </summary>
+/// <remarks>
+/// The render is a pure string template: no server-side LLM calls and no non-deterministic content,
+/// so the same <c>symbol</c> always produces byte-identical text. The template instructs the client
+/// to call <c>get-news-pulse</c> and then frame a sentiment narrative comparing the current week
+/// against the prior week.
+/// </remarks>
+[McpServerPromptType]
+public sealed class NewsPulsePrompt
+{
+    /// <summary>
+    /// Renders the news-pulse workflow prompt for <paramref name="symbol"/>.
+    /// </summary>
+    /// <param name="symbol">The ticker symbol to read the news pulse for.</param>
+    /// <returns>The templated news-sentiment instructions as a single user prompt message.</returns>
+    [McpServerPrompt(
+        Name = Constants.Prompts.NewsPulse.Name,
+        Title = Constants.Prompts.NewsPulse.Title)]
+    [Description(Constants.Prompts.NewsPulse.Description)]
+    public static string NewsPulse(
+        [Description(Constants.Prompts.NewsPulse.Parameters.SymbolDescription)]
+        string symbol)
+    {
+        var validated = PromptInputValidator.ValidateSymbol(symbol);
+
+        return $"""
+            You are reading the news pulse for the company behind the ticker "{validated}". Work
+            through this workflow and summarise as you go — do not invent headlines or sentiment that
+            the tool does not return.
+
+            1. Pull the news pulse — call `get-news-pulse` for {validated} to get the latest
+               headlines, the sentiment score, and the week-over-week change.
+            2. Compare against last week — use the week-over-week delta from `get-news-pulse` to judge
+               whether sentiment and news volume are rising, falling, or steady versus the prior week.
+
+            Then write a short sentiment narrative for {validated}: what the headlines are saying,
+            where sentiment sits now, and how that compares to last week (improving, deteriorating, or
+            flat). If the sentiment score is unavailable (the upstream sentiment endpoint can be
+            premium-gated), say so and base the read on the headlines alone instead of guessing a
+            score.
+            """;
+    }
+}

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/NewsPulsePromptTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Prompts/NewsPulsePromptTests.cs
@@ -1,0 +1,67 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+using FinnHub.MCP.Server.Prompts;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Tests.Unit.Prompts;
+
+public sealed class NewsPulsePromptTests
+{
+    [Fact]
+    public void NewsPulse_RenderedTwice_IsByteIdentical()
+    {
+        var first = NewsPulsePrompt.NewsPulse("AAPL");
+        var second = NewsPulsePrompt.NewsPulse("AAPL");
+
+        // The AC requires byte-identical output, so assert at the UTF-8 byte level explicitly.
+        Assert.Equal(Encoding.UTF8.GetBytes(first), Encoding.UTF8.GetBytes(second));
+    }
+
+    [Fact]
+    public void NewsPulse_ReferencesNewsPulseToolAndFramesWeekOverWeekSentiment()
+    {
+        var text = NewsPulsePrompt.NewsPulse("AAPL");
+
+        Assert.Contains("get-news-pulse", text, StringComparison.Ordinal);
+        // The AC requires a comparison vs last week plus a sentiment narrative.
+        Assert.Contains("last week", text, StringComparison.OrdinalIgnoreCase);
+        Assert.Contains("sentiment", text, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void NewsPulse_LowercaseSymbol_NormalisesToUppercase()
+    {
+        var text = NewsPulsePrompt.NewsPulse("aapl");
+
+        Assert.Contains("\"AAPL\"", text, StringComparison.Ordinal);
+        Assert.DoesNotContain("aapl", text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("AAPL")]
+    [InlineData("BRK.A")]
+    [InlineData("RDS-A")]
+    public void NewsPulse_ValidSymbol_EmbedsTheSymbol(string symbol)
+    {
+        var text = NewsPulsePrompt.NewsPulse(symbol);
+
+        Assert.Contains(symbol, text, StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("A B")]
+    [InlineData("A/B")]
+    [InlineData("AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")] // 40 chars — exceeds the 32-char bound
+    public void NewsPulse_InvalidSymbol_Throws(string? symbol)
+    {
+        Assert.Throws<ArgumentException>(() => NewsPulsePrompt.NewsPulse(symbol!));
+    }
+}


### PR DESCRIPTION
## Summary

Implements **#223** (User Story 1.5.3) — the third and final MCP prompt for Feature 1.5, completing the slash-command surface.

`/news-pulse {symbol}` renders a deterministic, templated news-sentiment workflow: pull `get-news-pulse`, compare against last week, and write a sentiment narrative.

## Design

- **Pure template** — `NewsPulsePrompt` is `[McpServerPromptType]` with a static `[McpServerPrompt]` method returning a `string`. No LLM calls, no non-deterministic content → byte-identical render for a given symbol.
- **Reuses the shared `PromptInputValidator`** unchanged.
- `Constants.Prompts.NewsPulse` + `.WithPrompts<NewsPulsePrompt>()`; README bumped to 3 prompts.

## Validation

- ✅ Build clean (0 warnings), `dotnet format` clean
- ✅ **868 unit tests pass** (+11) — byte-level deterministic render, `get-news-pulse` reference + week-over-week + sentiment framing, case normalisation, validator rejection
- ✅ **STDIO live-smoke green** — `prompts/list` now lists all three prompts (`research-ticker`, `compare-peers`, `news-pulse`); `prompts/get news-pulse` renders correctly through the full MCP pipeline
- 🔍 Adversarial review of the diff → **CLEAN**, no defects (no copy-paste drift, correct tool reference + week-over-week framing)

With this, **Feature 1.5 (P8 MCP Prompts) is complete** — all three slash commands shipped.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)