### PR TITLE
chore(security): move dev key to user-secrets and add .env pre-commit guard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,8 @@
-# Configure Finnhub Api Key
+# Legacy local-dev fallback for the Finnhub API key.
+#
+# Prefer dotnet user-secrets — it keeps the key outside the repo tree:
+#   dotnet user-secrets set "FinnHub:ApiKey" "your-finnhub-api-key" --project src/FinnHub.MCP.Server
+#
+# If you do use a .env, copy this file to .env (git-ignored) and fill in the key.
+# A pre-commit hook blocks committing a real .env.
 FINNHUB_API_KEY="your-finnhub-api-key"

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------------------------------------------------
+# Secret-at-rest guard.
+# Refuses to commit a .env file. .gitignore already ignores .env, but `git add -f`
+# bypasses .gitignore — this hook is the backstop so a real FINNHUB_API_KEY in a
+# .env can never be staged into git history. (.env.example is intentionally not matched.)
+# ---------------------------------------------------------------------------------------------------------------------
+
+. "$(dirname "$0")/_/husky.sh"
+
+# Staged adds/copies/modifications only.
+STAGED="$(git diff --cached --name-only --diff-filter=ACM)"
+
+if printf '%s\n' "$STAGED" | grep -qE '(^|/)\.env$'; then
+  echo
+  echo "❌ Refusing to commit a .env file."
+  echo
+  echo "   A .env may hold a live FINNHUB_API_KEY and must never enter git history."
+  echo "   Use dotnet user-secrets for local dev instead:"
+  echo "     dotnet user-secrets set \"FinnHub:ApiKey\" <key> --project src/FinnHub.MCP.Server"
+  echo
+  echo "   (.env.example is fine. To override in a genuine emergency: git commit --no-verify.)"
+  echo
+  exit 1
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ dotnet run --project src/FinnHub.MCP.Server                  # HTTP on :8080
 dotnet run --project src/FinnHub.MCP.Server -- --stdio       # STDIO transport
 ```
 
-The Finnhub API key is read from the `FINNHUB_API_KEY` environment variable, or from a local `.env` (loaded by `DotNetEnv` in `Development` only). Never hardcode the key.
+The Finnhub API key is read from the `FINNHUB_API_KEY` environment variable, or from `dotnet user-secrets` (`FinnHub:ApiKey`) in `Development`. A legacy `.env` (loaded by `DotNetEnv` in `Development`) is still honoured as a fallback, but it is git-ignored and a `pre-commit` hook blocks it from being staged. Never hardcode the key or commit `.env`.
 
 ## Project layout
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,17 +9,28 @@ cd finnhub-mcp
 # Restore .NET tools (currently: Husky.Net for git hooks)
 dotnet tool restore
 
-# Install local git hooks (commit-msg validator + future hooks)
+# Install local git hooks (commit-msg + pre-commit)
 dotnet husky install
+
+# Set your Finnhub dev key — stored in ~/.microsoft/usersecrets, never in the repo
+dotnet user-secrets set "FinnHub:ApiKey" "your_api_key_here" --project src/FinnHub.MCP.Server
 
 # Optional: pull dependencies
 dotnet restore
 ```
 
-The `dotnet tool restore` + `dotnet husky install` steps install a `commit-msg`
-git hook that validates every commit message against the Conventional Commits
-spec — required because `release-please` reads these prefixes to compute
-version bumps and CHANGELOG entries.
+`dotnet husky install` wires two local git hooks:
+
+- `commit-msg` — validates every commit message against the Conventional Commits
+  spec (`release-please` reads these prefixes to compute version bumps and
+  CHANGELOG entries).
+- `pre-commit` — refuses to stage a `.env` file, so a real `FINNHUB_API_KEY` can
+  never enter git history even via `git add -f`.
+
+The Finnhub dev key lives in `dotnet user-secrets` (`FinnHub:ApiKey`), not in a
+working file. A `FINNHUB_API_KEY` environment variable still overrides it when
+set, and a git-ignored `.env` is honoured as a legacy fallback. See
+[API Key Configuration](README.md#-api-key-configuration).
 
 ## Commit message format
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ A **Model Context Protocol (MCP) Server** built on the official [ModelContextPro
 - ✅ **Resilient HTTP communication** — typed `HttpClient` with retry, timeout, and circuit-breaker policies via `Microsoft.Extensions.Http.Resilience` and Polly; premium-locked endpoints surface as typed errors and are never retried
 - ✅ **Source-generated JSON** through `System.Text.Json` `JsonSerializerContext` for low-allocation, AOT-friendly (de)serialization
 - ✅ **Strongly-typed configuration** — `FinnHubOptions` bound from `appsettings.json` with data-annotation validation on startup
-- ✅ **API key kept out of source** — read from the `FINNHUB_API_KEY` environment variable (or a local `.env` in development via `DotNetEnv`)
+- ✅ **API key kept out of source** — read from the `FINNHUB_API_KEY` environment variable, or from `dotnet user-secrets` in development (a legacy git-ignored `.env` via `DotNetEnv` is still honoured)
 - ✅ **Dual transport** — HTTP (`MapMcp`) for hosted scenarios and STDIO for desktop MCP clients
 
 ## 🚧 Available & Upcoming MCP Capabilities
@@ -92,9 +92,11 @@ dotnet restore
 
 ### 🔐 API Key Configuration
 
-> **Security note:** never commit your API key. Use environment variables or a local `.env` file that is git-ignored.
+> **Security note:** never commit your API key. It belongs in an environment variable, `dotnet user-secrets`, or a git-ignored `.env` — never in source or `appsettings.json`.
 
-#### Option 1: Environment Variable (Recommended)
+#### Option 1: Environment Variable
+
+Best for CI, containers, and MCP host launchers (Claude Desktop/Code `env` blocks).
 
 **macOS/Linux**
 
@@ -114,9 +116,19 @@ $env:FINNHUB_API_KEY="your_api_key_here"
 set FINNHUB_API_KEY=your_api_key_here
 ```
 
-#### Option 2: `.env` File (Development Only)
+#### Option 2: `dotnet user-secrets` (recommended for local development)
 
-Create a `.env` file at the repository root — `DotNetEnv` loads it automatically when the host environment is `Development`:
+Stores the key under `~/.microsoft/usersecrets`, outside the repo tree, so it is never at rest in a working file:
+
+```bash
+dotnet user-secrets set "FinnHub:ApiKey" "your_api_key_here" --project src/FinnHub.MCP.Server
+```
+
+Loaded automatically in the `Development` environment. A `FINNHUB_API_KEY` environment variable still takes precedence when set.
+
+#### Option 3: `.env` File (legacy fallback)
+
+Still honoured in `Development` via `DotNetEnv`, but prefer user-secrets — a `.env` is one `git add -f` away from leaking, so a `pre-commit` hook blocks committing it:
 
 ```bash
 echo "FINNHUB_API_KEY=your_api_key_here" > .env

--- a/src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj
+++ b/src/FinnHub.MCP.Server/FinnHub.MCP.Server.csproj
@@ -3,6 +3,10 @@
     <TargetFramework>net10.0</TargetFramework>
     <RootNamespace>FinnHub.MCP.Server</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
+    <!-- Per-developer secret store for local dev (dotnet user-secrets). Holds FinnHub:ApiKey
+         in ~/.microsoft/usersecrets, outside the repo tree, so the key is never at rest in a
+         working file. Wired into config (Development only) in Program.cs. See CONTRIBUTING.md. -->
+    <UserSecretsId>6aedd249-fb8e-4bf1-b461-505066af6b1f</UserSecretsId>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <Nullable>enable</Nullable>
     <Title>FinnHub MCP Server</Title>

--- a/src/FinnHub.MCP.Server/Program.cs
+++ b/src/FinnHub.MCP.Server/Program.cs
@@ -83,7 +83,21 @@ var basePath = !string.IsNullOrEmpty(hostAssemblyPath)
 builder.Configuration
     .SetBasePath(basePath)
     .AddJsonFile("appsettings.json", optional: false, reloadOnChange: true)
-    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true)
+    .AddJsonFile($"appsettings.{builder.Environment.EnvironmentName}.json", optional: true, reloadOnChange: true);
+
+if (builder.Environment.IsDevelopment())
+{
+    // dotnet user-secrets is the canonical local home for FinnHub:ApiKey — it
+    // lives in ~/.microsoft/usersecrets, outside the repo tree, so the key is
+    // never at rest in a working file. Added here (after the appsettings re-add
+    // above, which would otherwise clobber it with the empty placeholder, and
+    // before AddEnvironmentVariables below, so a launcher-supplied FINNHUB_API_KEY
+    // still wins via the explicit override further down). Store the key with:
+    //   dotnet user-secrets set "FinnHub:ApiKey" <key> --project src/FinnHub.MCP.Server
+    builder.Configuration.AddUserSecrets<Program>();
+}
+
+builder.Configuration
     .AddEnvironmentVariables()
     .AddCommandLine(args);
 


### PR DESCRIPTION
## What

Moves the local-dev Finnhub key out of a plaintext `.env` into `dotnet user-secrets`, and adds a Husky `pre-commit` hook that refuses to stage a `.env`.

**Refs #408** — this is the code/config half. Key rotation + GitHub Actions secret rotation are operator steps that can't happen in a PR (checklist below), so #408 stays open until those are confirmed.

## Why

A live 40-char Finnhub key was sitting at rest in plaintext `.env` on the workstation — gitignored, but one `git add -f` / backup-sync away from leaking. `dotnet user-secrets` keeps the key under `~/.microsoft/usersecrets`, outside the repo tree; the pre-commit hook is the backstop `.gitignore` can't provide.

## Changes

- **`Program.cs`** — `AddUserSecrets<Program>()` in the Development config chain: after the appsettings re-add (which would otherwise clobber it with the empty placeholder) and before `AddEnvironmentVariables` (so a launcher-supplied `FINNHUB_API_KEY` still wins via the explicit override). Precedence: `FINNHUB_API_KEY` env / legacy `.env` → user-secrets → appsettings.
- **csproj** — `<UserSecretsId>`.
- **`.husky/pre-commit`** — blocks staging `.env`; `.env.example` stays allowed. Verified against `.env`, nested `.env`, and `.env.example`.
- **Docs** — README (3-option key config), CONTRIBUTING (setup + hook notes), CLAUDE.md, `.env.example`.

**Decision:** kept `.env`/`DotNetEnv` as a documented *legacy fallback* (so `capture.sh` is unchanged) rather than retiring it. Shout if you'd rather rip `.env` support out entirely — that's a one-line follow-up.

## Operator follow-up (not doable in-PR — tracked in #408)

- [ ] Rotate the key on finnhub.io — treat the old one as **compromised**
- [ ] `dotnet user-secrets set "FinnHub:ApiKey" <new-key> --project src/FinnHub.MCP.Server`
- [ ] Rotate the GitHub Actions `FINNHUB_API_KEY` repo secret (Settings → Secrets → Actions)
- [ ] Update any Claude Desktop/Code MCP host `env` block still carrying the old key

The live key in the local `.env` was scrubbed to a placeholder locally (gitignored, not part of this PR).

## Validation

- `dotnet build` (Release) — clean, 0 warnings (`TreatWarningsAsErrors`)
- `dotnet format --verify-no-changes` — clean
- `dotnet test --filter "Category!=LiveSmoke"` — **868 passing, 0 failing**; `[Required] FinnHub:ApiKey` bind path intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)