### PR TITLE
refactor(infra): extract shared error handler + unify cache-key construction

### DIFF
--- a/src/FinnHub.MCP.Server.Application/Caching/SymbolCacheKey.cs
+++ b/src/FinnHub.MCP.Server.Application/Caching/SymbolCacheKey.cs
@@ -1,0 +1,41 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Text;
+
+namespace FinnHub.MCP.Server.Application.Caching;
+
+/// <summary>
+/// Builds the logical cache-key segment a service owns, e.g. <c>"quote:s=AAPL"</c> — a prefix
+/// followed by ordered <c>key=value</c> parts joined with <c>':'</c>.
+/// </summary>
+/// <remarks>
+/// Deliberately distinct from <see cref="CacheKey"/>, which adds the outer
+/// <c>finnhub:tenant=…:tier=…</c> namespacing in the Infrastructure cache layer. Routing every
+/// service's <c>BuildCacheKey</c> through here keeps the symbol segment, part ordering, and joining
+/// rules from drifting between services. Callers pass already-formatted string values (dates with
+/// <c>InvariantCulture</c>), so this builder performs no culture-sensitive formatting of its own.
+/// </remarks>
+internal static class SymbolCacheKey
+{
+    /// <summary>
+    /// Composes a logical key from a <paramref name="prefix"/> and ordered <paramref name="parts"/>.
+    /// </summary>
+    /// <param name="prefix">The leading segment (e.g. "quote", "news-pulse").</param>
+    /// <param name="parts">Ordered <c>(key, value)</c> pairs appended as <c>:key=value</c>.</param>
+    /// <returns>The joined logical key, e.g. <c>"profile:s=AAPL:cosmetic=True"</c>.</returns>
+    public static string For(string prefix, params (string Key, string Value)[] parts)
+    {
+        var builder = new StringBuilder(prefix);
+        foreach (var (key, value) in parts)
+        {
+            builder.Append(':').Append(key).Append('=').Append(value);
+        }
+
+        return builder.ToString();
+    }
+}

--- a/src/FinnHub.MCP.Server.Application/Calendar/Services/CalendarService.cs
+++ b/src/FinnHub.MCP.Server.Application/Calendar/Services/CalendarService.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Calendar.Clients;
 using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Calendar.Services;
@@ -80,10 +81,12 @@ public sealed class CalendarService(
         GetCalendarQuery query,
         CancellationToken cancellationToken)
     {
-        var symbolKey = query.Symbol is null ? "all" : query.Symbol.ToUpperInvariant();
-        var cacheKey = string.Create(
-            CultureInfo.InvariantCulture,
-            $"calendar-earnings:s={symbolKey}:f={query.From:yyyy-MM-dd}:t={query.To:yyyy-MM-dd}");
+        var symbolKey = SymbolNormalizer.NormalizeOrAll(query.Symbol);
+        var cacheKey = SymbolCacheKey.For(
+            "calendar-earnings",
+            ("s", symbolKey),
+            ("f", query.From.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            ("t", query.To.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
 
         var events = await cache.GetOrCreateAsync(
             cacheKey,
@@ -122,9 +125,10 @@ public sealed class CalendarService(
         GetCalendarQuery query,
         CancellationToken cancellationToken)
     {
-        var cacheKey = string.Create(
-            CultureInfo.InvariantCulture,
-            $"calendar-ipo:f={query.From:yyyy-MM-dd}:t={query.To:yyyy-MM-dd}");
+        var cacheKey = SymbolCacheKey.For(
+            "calendar-ipo",
+            ("f", query.From.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            ("t", query.To.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
 
         var events = await cache.GetOrCreateAsync(
             cacheKey,
@@ -167,9 +171,10 @@ public sealed class CalendarService(
     {
         // Cache the unfiltered upstream payload — a single fetch serves every
         // country filter the caller might apply on top.
-        var cacheKey = string.Create(
-            CultureInfo.InvariantCulture,
-            $"calendar-economic:f={query.From:yyyy-MM-dd}:t={query.To:yyyy-MM-dd}");
+        var cacheKey = SymbolCacheKey.For(
+            "calendar-economic",
+            ("f", query.From.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+            ("t", query.To.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
 
         var events = await cache.GetOrCreateAsync(
             cacheKey,

--- a/src/FinnHub.MCP.Server.Application/Exchanges/Services/ExchangeSymbolsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Exchanges/Services/ExchangeSymbolsService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Exchanges.Clients;
 using FinnHub.MCP.Server.Application.Exchanges.Features.GetExchangeSymbols;
 using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Exchanges.Services;
@@ -41,7 +42,7 @@ public sealed class ExchangeSymbolsService(
 
         try
         {
-            var cacheKey = $"exchange-symbols:ex={query.Exchange.ToUpperInvariant()}";
+            var cacheKey = SymbolCacheKey.For("exchange-symbols", ("ex", SymbolNormalizer.Normalize(query.Exchange)));
 
             var response = await cache.GetOrCreateAsync(
                 cacheKey,

--- a/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Financials/Services/FinancialsService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Financials.Clients;
 using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Financials.Services;
@@ -98,5 +99,5 @@ public sealed class FinancialsService(
     }
 
     private static string BuildCacheKey(GetFinancialsSnapshotQuery query) =>
-        $"financials:s={query.Symbol.ToUpperInvariant()}:raw={query.IncludeRaw}";
+        SymbolCacheKey.For("financials", ("s", SymbolNormalizer.Normalize(query.Symbol)), ("raw", query.IncludeRaw.ToString()));
 }

--- a/src/FinnHub.MCP.Server.Application/Insiders/Services/InsidersService.cs
+++ b/src/FinnHub.MCP.Server.Application/Insiders/Services/InsidersService.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Insiders.Clients;
 using FinnHub.MCP.Server.Application.Insiders.Features.GetInsiderSignal;
 using FinnHub.MCP.Server.Application.Models;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Insiders.Services;
@@ -38,10 +39,12 @@ public sealed class InsidersService(
 
         try
         {
-            var symbol = query.Symbol.ToUpperInvariant();
-            var cacheKey = string.Create(
-                CultureInfo.InvariantCulture,
-                $"insider-transactions:s={symbol}:f={query.From:yyyy-MM-dd}:t={query.To:yyyy-MM-dd}");
+            var symbol = SymbolNormalizer.Normalize(query.Symbol);
+            var cacheKey = SymbolCacheKey.For(
+                "insider-transactions",
+                ("s", symbol),
+                ("f", query.From.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+                ("t", query.To.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
 
             var transactions = await cache.GetOrCreateAsync(
                 cacheKey,

--- a/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
+++ b/src/FinnHub.MCP.Server.Application/News/Services/NewsService.cs
@@ -5,11 +5,13 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
 using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.News.Clients;
 using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.News.Services;
@@ -43,8 +45,20 @@ public sealed class NewsService(
             // Sentiment is optional (premium-gated). Catch and degrade gracefully.
             var sentiment = await this.TryFetchSentimentAsync(query.Symbol, cancellationToken);
 
-            var currentWeekKey = $"news-pulse:s={query.Symbol.ToUpperInvariant()}:w=current";
-            var prevWeekKey = $"news-pulse:s={query.Symbol.ToUpperInvariant()}:w=prev";
+            // Bake the resolved date window into the key so a midnight-UTC rollover yields a new
+            // key and forces a fresh fetch. Without it, an entry written just before midnight is
+            // served under the same ":w=current" key with the previous day's window until the TTL lapses.
+            var normalizedSymbol = SymbolNormalizer.Normalize(query.Symbol);
+            var currentWeekKey = SymbolCacheKey.For(
+                "news-pulse",
+                ("s", normalizedSymbol),
+                ("from", weekAgo.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+                ("to", today.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
+            var prevWeekKey = SymbolCacheKey.For(
+                "news-pulse",
+                ("s", normalizedSymbol),
+                ("from", twoWeeksAgo.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)),
+                ("to", weekAgo.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture)));
 
             var currentWeekTask = cache.GetOrCreateAsync(
                 currentWeekKey,
@@ -134,7 +148,7 @@ public sealed class NewsService(
         try
         {
             return await cache.GetOrCreateAsync(
-                $"news-sentiment:s={symbol.ToUpperInvariant()}",
+                SymbolCacheKey.For("news-sentiment", ("s", SymbolNormalizer.Normalize(symbol))),
                 CacheTier.News,
                 async ct => await apiClient.GetSentimentAsync(symbol, ct),
                 cancellationToken);

--- a/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
+++ b/src/FinnHub.MCP.Server.Application/Peers/Services/PeersService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Peers.Services;
@@ -86,5 +87,5 @@ public sealed class PeersService(
     }
 
     private static string BuildCacheKey(GetPeersQuery query) =>
-        $"peers:s={query.Symbol.ToUpperInvariant()}:g={query.Grouping}";
+        SymbolCacheKey.For("peers", ("s", SymbolNormalizer.Normalize(query.Symbol)), ("g", query.Grouping.ToString()));
 }

--- a/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Prices/Services/PricesService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Prices.Clients;
 using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Prices.Services;
@@ -86,5 +87,5 @@ public sealed class PricesService(
     }
 
     private static string BuildCacheKey(GetPriceSummaryQuery query) =>
-        $"price-summary:s={query.Symbol.ToUpperInvariant()}:p={query.Period}:c={query.IncludeCandles}";
+        SymbolCacheKey.For("price-summary", ("s", SymbolNormalizer.Normalize(query.Symbol)), ("p", query.Period.ToString()), ("c", query.IncludeCandles.ToString()));
 }

--- a/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Profiles/Services/ProfilesService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Profiles.Clients;
 using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Profiles.Services;
@@ -33,7 +34,7 @@ public sealed class ProfilesService(
 
         try
         {
-            var cacheKey = $"profile:s={query.Symbol.ToUpperInvariant()}:cosmetic={query.IncludeCosmeticFields}";
+            var cacheKey = SymbolCacheKey.For("profile", ("s", SymbolNormalizer.Normalize(query.Symbol)), ("cosmetic", query.IncludeCosmeticFields.ToString()));
 
             var response = await cache.GetOrCreateAsync(
                 cacheKey,

--- a/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
+++ b/src/FinnHub.MCP.Server.Application/Quotes/Services/QuotesService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Quotes.Clients;
 using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Quotes.Services;
@@ -33,7 +34,7 @@ public sealed class QuotesService(
 
         try
         {
-            var cacheKey = $"quote:s={query.Symbol.ToUpperInvariant()}";
+            var cacheKey = SymbolCacheKey.For("quote", ("s", SymbolNormalizer.Normalize(query.Symbol)));
 
             var response = await cache.GetOrCreateAsync(
                 cacheKey,

--- a/src/FinnHub.MCP.Server.Application/Recommendations/Services/RecommendationsService.cs
+++ b/src/FinnHub.MCP.Server.Application/Recommendations/Services/RecommendationsService.cs
@@ -10,6 +10,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Recommendations.Clients;
 using FinnHub.MCP.Server.Application.Recommendations.Features.GetRecommendations;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Recommendations.Services;
@@ -37,8 +38,8 @@ public sealed class RecommendationsService(
 
         try
         {
-            var symbol = query.Symbol.ToUpperInvariant();
-            var cacheKey = $"recommendations:s={symbol}";
+            var symbol = SymbolNormalizer.Normalize(query.Symbol);
+            var cacheKey = SymbolCacheKey.For("recommendations", ("s", symbol));
 
             var snapshots = await cache.GetOrCreateAsync(
                 cacheKey,

--- a/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
+++ b/src/FinnHub.MCP.Server.Application/Search/Services/SearchService.cs
@@ -5,11 +5,13 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Globalization;
 using FinnHub.MCP.Server.Application.Caching;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Models;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+using FinnHub.MCP.Server.Application.Symbols;
 using Microsoft.Extensions.Logging;
 
 namespace FinnHub.MCP.Server.Application.Search.Services;
@@ -116,7 +118,11 @@ public sealed class SearchService(
         var normQuery = query.Query.Trim().ToLowerInvariant();
         var normExchange = string.IsNullOrWhiteSpace(query.Exchange)
             ? "*"
-            : query.Exchange.Trim().ToUpperInvariant();
-        return $"search-symbol:q={normQuery}:ex={normExchange}:lim={query.Limit}";
+            : SymbolNormalizer.Normalize(query.Exchange);
+        return SymbolCacheKey.For(
+            "search-symbol",
+            ("q", normQuery),
+            ("ex", normExchange),
+            ("lim", query.Limit.ToString(CultureInfo.InvariantCulture)));
     }
 }

--- a/src/FinnHub.MCP.Server.Application/Symbols/SymbolNormalizer.cs
+++ b/src/FinnHub.MCP.Server.Application/Symbols/SymbolNormalizer.cs
@@ -1,0 +1,38 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+namespace FinnHub.MCP.Server.Application.Symbols;
+
+/// <summary>
+/// The single canonical symbol-casing rule shared by every cache-key builder. Centralising it
+/// removes the drift where most services upper-cased without trimming and only one trimmed first.
+/// </summary>
+internal static class SymbolNormalizer
+{
+    /// <summary>
+    /// Trims surrounding whitespace then upper-cases (invariant) a ticker or exchange code, so
+    /// <c>" aapl "</c> and <c>"AAPL"</c> resolve to the same cache slot.
+    /// </summary>
+    /// <param name="symbol">The raw symbol or exchange code.</param>
+    /// <returns>The trimmed, upper-invariant form.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="symbol"/> is <c>null</c>.</exception>
+    public static string Normalize(string symbol)
+    {
+        ArgumentNullException.ThrowIfNull(symbol);
+        return symbol.Trim().ToUpperInvariant();
+    }
+
+    /// <summary>
+    /// Like <see cref="Normalize"/>, but maps a <c>null</c> symbol to the literal <c>"all"</c> sentinel
+    /// used by the calendar feeds for an all-symbols query. Branches on <c>null</c> only — an empty or
+    /// whitespace symbol normalises like any other value, matching the prior calendar behaviour exactly.
+    /// </summary>
+    /// <param name="symbol">The optional symbol.</param>
+    /// <returns><c>"all"</c> when <paramref name="symbol"/> is <c>null</c>; otherwise the normalised symbol.</returns>
+    public static string NormalizeOrAll(string? symbol) =>
+        symbol is null ? "all" : Normalize(symbol);
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Calendar/FinnHubCalendarApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Calendar/FinnHubCalendarApiClient.cs
@@ -12,6 +12,7 @@ using FinnHub.MCP.Server.Application.Calendar.Clients;
 using FinnHub.MCP.Server.Application.Calendar.Features.GetCalendar;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -89,7 +90,7 @@ public sealed class FinnHubCalendarApiClient : ICalendarApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "calendar", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubEarningsCalendarResponse? dto;
@@ -196,7 +197,7 @@ public sealed class FinnHubCalendarApiClient : ICalendarApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "calendar", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubIpoCalendarResponse? dto;
@@ -307,7 +308,7 @@ public sealed class FinnHubCalendarApiClient : ICalendarApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "calendar", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubEconomicCalendarResponse? dto;
@@ -366,26 +367,5 @@ public sealed class FinnHubCalendarApiClient : ICalendarApiClient
         }
 
         return events;
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked calendar endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Calendar API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub calendar returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Exchanges/FinnHubExchangesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Exchanges/FinnHubExchangesApiClient.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Exchanges.Clients;
 using FinnHub.MCP.Server.Application.Exchanges.Features.GetExchangeSymbols;
 using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -99,7 +100,7 @@ public sealed class FinnHubExchangesApiClient : IExchangesApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "exchange-symbols", cancellationToken, treatUnauthorizedAsPremium: true).ConfigureAwait(false);
         }
 
         FinnHubSymbolRow[] rows;
@@ -128,30 +129,5 @@ public sealed class FinnHubExchangesApiClient : IExchangesApiClient
             })
             .ToList()
             .AsReadOnly();
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        // Finnhub gates premium-locked exchanges on /stock/symbol behind 401 "You don't have access
-        // to this resource." (not the 403 every other endpoint uses). Treat both as premium-required
-        // so the envelope surfaces premium=true instead of a misleading ServiceUnavailable.
-        if (statusCode is HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked exchange-symbols endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Exchange-symbols API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException(
-            $"FinnHub exchange-symbols returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Financials/FinnHubFinancialsApiClient.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Financials.Clients;
 using FinnHub.MCP.Server.Application.Financials.Features.GetFinancialsSnapshot;
 using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -90,7 +91,7 @@ public sealed class FinnHubFinancialsApiClient : IFinancialsApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "financials", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubFinancialsResponse? dto;
@@ -156,26 +157,5 @@ public sealed class FinnHubFinancialsApiClient : IFinancialsApiClient
             }
         }
         return raw;
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked financials endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Financials API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub financials returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Http/FinnHubResponseErrors.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Http/FinnHubResponseErrors.cs
@@ -1,0 +1,68 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using FinnHub.MCP.Server.Application.Exceptions;
+using Microsoft.Extensions.Logging;
+
+namespace FinnHub.MCP.Server.Infrastructure.Clients.Http;
+
+/// <summary>
+/// Translates a non-success FinnHub HTTP response into the appropriate typed <c>ApiClient*</c>
+/// exception. This is the single shared implementation behind every client's error path — it
+/// replaces the per-client <c>HandleErrorAsync</c> methods that had drifted into eleven near-identical copies.
+/// </summary>
+internal static class FinnHubResponseErrors
+{
+    /// <summary>
+    /// Reads the error body and throws the exception that matches the response status. The method
+    /// always throws; the <see cref="Task"/> return type preserves the callers' <c>await …;</c> shape.
+    /// </summary>
+    /// <param name="response">The non-success response.</param>
+    /// <param name="contentStream">The already-opened response content stream.</param>
+    /// <param name="logger">The calling client's logger.</param>
+    /// <param name="resource">The per-client noun (e.g. "quote") woven into the thrown message and the logs.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <param name="treatUnauthorizedAsPremium">
+    /// When <c>true</c>, 401 Unauthorized is mapped to <see cref="ApiClientPremiumRequiredException"/> alongside 403.
+    /// Only the exchange-symbols client sets this: Finnhub gates its premium <c>/stock/symbol</c> exchanges behind 401.
+    /// </param>
+    /// <exception cref="ApiClientPremiumRequiredException">403 (or 401 when <paramref name="treatUnauthorizedAsPremium"/>).</exception>
+    /// <exception cref="ApiClientHttpException">Any other non-success status.</exception>
+    internal static async Task ThrowForStatusAsync(
+        HttpResponseMessage response,
+        Stream contentStream,
+        ILogger logger,
+        string resource,
+        CancellationToken cancellationToken,
+        bool treatUnauthorizedAsPremium = false)
+    {
+        var statusCode = response.StatusCode;
+
+        using var reader = new StreamReader(contentStream);
+        var errorBody = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
+
+        var premium = statusCode == HttpStatusCode.Forbidden
+            || (treatUnauthorizedAsPremium && statusCode == HttpStatusCode.Unauthorized);
+
+        if (premium)
+        {
+            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
+            logger.LogWarning("Premium-locked {Resource} endpoint: {Endpoint} - {Content}", resource, endpoint, errorBody);
+            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
+        }
+
+        logger.Log(
+            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
+            "{Resource} API error: {StatusCode} - {Content}",
+            resource,
+            statusCode,
+            errorBody);
+
+        throw new ApiClientHttpException($"FinnHub {resource} returned {statusCode}.", statusCode, errorBody);
+    }
+}

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Insiders/FinnHubInsidersApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Insiders/FinnHubInsidersApiClient.cs
@@ -12,6 +12,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Insiders.Clients;
 using FinnHub.MCP.Server.Application.Insiders.Features.GetInsiderSignal;
 using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -87,7 +88,7 @@ public sealed class FinnHubInsidersApiClient : IInsidersApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "insider transactions", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubInsiderTransactionsResponse? dto;
@@ -159,26 +160,5 @@ public sealed class FinnHubInsidersApiClient : IInsidersApiClient
         return string.Create(
             CultureInfo.InvariantCulture,
             $"{trimmed}?symbol={Uri.EscapeDataString(symbol)}&from={fromStr}&to={toStr}");
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked insider transactions endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Insider transactions API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub insider transactions returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/News/FinnHubNewsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/News/FinnHubNewsApiClient.cs
@@ -12,6 +12,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.News.Clients;
 using FinnHub.MCP.Server.Application.News.Features.GetNewsPulse;
 using FinnHub.MCP.Server.Application.Options;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -57,7 +58,8 @@ public sealed class FinnHubNewsApiClient : INewsApiClient
         var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(symbol)}" +
                          $"&from={from:yyyy-MM-dd}&to={to:yyyy-MM-dd}";
 
-        await using var stream = await this.GetStreamAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        using var response = await this.SendAndValidateAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
         FinnHubCompanyNewsArticle[]? articles;
         try
@@ -95,7 +97,8 @@ public sealed class FinnHubNewsApiClient : INewsApiClient
         var endpoint = this.ResolveEndpoint(SentimentEndpoint);
         var requestUri = $"{endpoint.TrimStart('/')}?symbol={Uri.EscapeDataString(symbol)}";
 
-        await using var stream = await this.GetStreamAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        using var response = await this.SendAndValidateAsync(requestUri, cancellationToken).ConfigureAwait(false);
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 
         FinnHubNewsSentimentResponse? dto;
         try
@@ -122,7 +125,13 @@ public sealed class FinnHubNewsApiClient : INewsApiClient
         this._options.EndPoints.FirstOrDefault(e => e.IsActive && string.Equals(e.Name, name, StringComparison.Ordinal))?.Url
         ?? throw new ArgumentException(string.Create(CultureInfo.InvariantCulture, $"Endpoint '{name}' is not configured or inactive"));
 
-    private async Task<Stream> GetStreamAsync(string requestUri, CancellationToken cancellationToken)
+    /// <summary>
+    /// Sends the request, translates a non-success status into a typed exception, and hands the
+    /// live <see cref="HttpResponseMessage"/> back to the caller, who owns its disposal
+    /// (<c>using var response = …</c>). Replaces the old <c>GetStreamAsync</c> that returned a
+    /// stream while leaking the undisposed response.
+    /// </summary>
+    private async Task<HttpResponseMessage> SendAndValidateAsync(string requestUri, CancellationToken cancellationToken)
     {
         this._logger.LogInformation("Requesting news from FinnHub: {RequestUri}", requestUri);
 
@@ -152,38 +161,19 @@ public sealed class FinnHubNewsApiClient : INewsApiClient
             throw new ApiClientCancelledException($"News request cancelled: {requestUri}");
         }
 
-        var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-
         if (!response.IsSuccessStatusCode)
         {
-            await HandleErrorAsync(response, contentStream, cancellationToken, this._logger).ConfigureAwait(false);
+            // ThrowForStatusAsync always throws, so the caller never receives this response —
+            // dispose it here to avoid leaking it on the error path.
+            using (response)
+            {
+                var contentStream = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+                await FinnHubResponseErrors
+                    .ThrowForStatusAsync(response, contentStream, this._logger, "news", cancellationToken)
+                    .ConfigureAwait(false);
+            }
         }
 
-        return contentStream;
-    }
-
-    private static async Task HandleErrorAsync(
-        HttpResponseMessage response,
-        Stream contentStream,
-        CancellationToken ct,
-        ILogger logger)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            logger.LogWarning("Premium-locked news endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "News API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub news returned {statusCode}.", statusCode, errorBody);
+        return response;
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Peers/FinnHubPeersApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Peers/FinnHubPeersApiClient.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Peers.Clients;
 using FinnHub.MCP.Server.Application.Peers.Features.GetPeers;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -90,7 +91,7 @@ public sealed class FinnHubPeersApiClient : IPeersApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "peers", cancellationToken).ConfigureAwait(false);
         }
 
         IReadOnlyList<string> tickers;
@@ -113,28 +114,6 @@ public sealed class FinnHubPeersApiClient : IPeersApiClient
             Peers = tickers,
             Grouping = groupingParam
         };
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked peers endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Peers API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException(
-            $"FinnHub peers returned {statusCode}.", statusCode, errorBody);
     }
 
     private static string MapGrouping(PeersGrouping grouping) => grouping switch

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Prices/FinnHubPricesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Prices/FinnHubPricesApiClient.cs
@@ -12,6 +12,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Prices.Clients;
 using FinnHub.MCP.Server.Application.Prices.Features.GetPriceSummary;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -94,7 +95,7 @@ public sealed class FinnHubPricesApiClient : IPricesApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "candle", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubCandleResponse? dto;
@@ -198,26 +199,5 @@ public sealed class FinnHubPricesApiClient : IPricesApiClient
             PricePeriod.OneYear => ("W", now.AddDays(-365).ToUnixTimeSeconds(), now.ToUnixTimeSeconds(), "1y"),
             _ => throw new ArgumentOutOfRangeException(nameof(period), period, "Unknown period")
         };
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked candle endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Candle API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub candle returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Profiles/FinnHubProfilesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Profiles/FinnHubProfilesApiClient.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Profiles.Clients;
 using FinnHub.MCP.Server.Application.Profiles.Features.GetCompanyProfile;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -86,7 +87,7 @@ public sealed class FinnHubProfilesApiClient : IProfilesApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "profile", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubProfileResponse? dto;
@@ -119,26 +120,5 @@ public sealed class FinnHubProfilesApiClient : IProfilesApiClient
             Phone = query.IncludeCosmeticFields ? dto?.Phone : null,
             WebUrl = query.IncludeCosmeticFields ? dto?.WebUrl : null
         };
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked profile endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Profile API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub profile returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Quotes/FinnHubQuotesApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Quotes/FinnHubQuotesApiClient.cs
@@ -11,6 +11,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Quotes.Clients;
 using FinnHub.MCP.Server.Application.Quotes.Features.GetQuote;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -84,7 +85,7 @@ public sealed class FinnHubQuotesApiClient : IQuotesApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "quote", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubQuoteResponse? dto;
@@ -116,26 +117,5 @@ public sealed class FinnHubQuotesApiClient : IQuotesApiClient
                 ? DateTimeOffset.FromUnixTimeSeconds(ts)
                 : null
         };
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked quote endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Quote API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub quote returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Recommendations/FinnHubRecommendationsApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Recommendations/FinnHubRecommendationsApiClient.cs
@@ -12,6 +12,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Recommendations.Clients;
 using FinnHub.MCP.Server.Application.Recommendations.Features.GetRecommendations;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -85,7 +86,7 @@ public sealed class FinnHubRecommendationsApiClient : IRecommendationsApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorAsync(response, contentStream, cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "recommendations", cancellationToken).ConfigureAwait(false);
         }
 
         FinnHubRecommendationEntry[]? dto;
@@ -134,26 +135,5 @@ public sealed class FinnHubRecommendationsApiClient : IRecommendationsApiClient
         }
 
         return snapshots;
-    }
-
-    private async Task HandleErrorAsync(HttpResponseMessage response, Stream contentStream, CancellationToken ct)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(ct).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning("Premium-locked recommendations endpoint: {Endpoint} - {Content}", endpoint, errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        this._logger.Log(
-            (int)statusCode >= 500 ? LogLevel.Error : LogLevel.Warning,
-            "Recommendations API error: {StatusCode} - {Content}", statusCode, errorBody);
-
-        throw new ApiClientHttpException($"FinnHub recommendations returned {statusCode}.", statusCode, errorBody);
     }
 }

--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -13,6 +13,7 @@ using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Clients;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
 using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Serialization;
 using Microsoft.Extensions.Logging;
@@ -250,53 +251,10 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await this.HandleErrorResponseAsync(response, contentStream, cancellationToken);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "search-symbol", cancellationToken).ConfigureAwait(false);
         }
 
         return await this.DeserializeResponseAsync(contentStream, requestUri, cancellationToken).ConfigureAwait(false);
-    }
-
-    /// <summary>
-    /// Handles HTTP responses with non-success status codes by reading the body and logging an appropriate message.
-    /// </summary>
-    /// <param name="response">The response with error status.</param>
-    /// <param name="contentStream">The stream containing response body.</param>
-    /// <param name="cancellationToken">A cancellation token.</param>
-    /// <exception cref="ApiClientPremiumRequiredException">Thrown when Finnhub returns 403 (premium-locked endpoint).</exception>
-    /// <exception cref="ApiClientHttpException">Thrown with enriched details about any other error.</exception>
-    private async Task HandleErrorResponseAsync(
-        HttpResponseMessage response,
-        Stream contentStream,
-        CancellationToken cancellationToken)
-    {
-        var statusCode = response.StatusCode;
-
-        using var reader = new StreamReader(contentStream);
-        var errorBody = await reader.ReadToEndAsync(cancellationToken).ConfigureAwait(false);
-
-        if (statusCode == HttpStatusCode.Forbidden)
-        {
-            var endpoint = response.RequestMessage?.RequestUri?.AbsolutePath ?? "(unknown)";
-            this._logger.LogWarning(
-                "Premium-locked endpoint from FinnHub API: {Endpoint} - {Content}",
-                endpoint,
-                errorBody);
-            throw new ApiClientPremiumRequiredException(endpoint, errorBody);
-        }
-
-        if ((int)statusCode >= 400 && (int)statusCode < 500)
-        {
-            this._logger.LogWarning("Client error from FinnHub API: {StatusCode} - {Content}", statusCode, errorBody);
-        }
-        else
-        {
-            this._logger.LogError("Server error from FinnHub API: {StatusCode} - {Content}", statusCode, errorBody);
-        }
-
-        throw new ApiClientHttpException(
-            $"FinnHub API returned error status {statusCode}. See logs for more detail.",
-            statusCode,
-            errorBody);
     }
 
     /// <summary>

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Application/Features/News/Services/NewsServiceTests.cs
@@ -152,4 +152,29 @@ public sealed class NewsServiceTests
 
         Assert.Equal(8, result.Data!.TopHeadlines.Count);
     }
+
+    [Fact]
+    public async Task GetPulseAsync_CompanyNewsCacheKeys_EncodeResolvedDateWindow()
+    {
+        // Regression for the midnight-UTC staleness bug (M17): the two company-news cache keys
+        // must bake in the resolved from/to window, not a static ":w=current"/":w=prev" token.
+        // Without it, an entry cached seconds before a UTC date rollover is served under the same
+        // key with the previous day's window until the TTL lapses. Asserting the key *shape*
+        // (date window present, ":w=" token gone) fails on the old keys and passes on the new ones.
+        var query = new GetNewsPulseQuery { QueryId = "q1", Symbol = "AAPL" };
+        this._apiClient.GetSentimentAsync(query.Symbol, Arg.Any<CancellationToken>())
+            .Returns(new NewsSentiment(null, null, null));
+        this._apiClient.GetCompanyNewsAsync(query.Symbol, Arg.Any<DateOnly>(), Arg.Any<DateOnly>(), Arg.Any<CancellationToken>())
+            .Returns(_ => (IReadOnlyList<CompanyNewsArticle>)[new CompanyNewsArticle("h", "u", "src", DateTimeOffset.UtcNow)]);
+
+        await this._sut.GetPulseAsync(query);
+
+        var pulseKeys = this._cache.ObservedKeys
+            .Where(k => k.StartsWith("news-pulse:", StringComparison.Ordinal))
+            .ToList();
+
+        Assert.Equal(2, pulseKeys.Count);
+        Assert.All(pulseKeys, k => Assert.Matches(@"^news-pulse:s=AAPL:from=\d{4}-\d{2}-\d{2}:to=\d{4}-\d{2}-\d{2}$", k));
+        Assert.DoesNotContain(pulseKeys, k => k.Contains(":w=", StringComparison.Ordinal));
+    }
 }

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Caching/SymbolCacheKeyTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Caching/SymbolCacheKeyTests.cs
@@ -1,0 +1,42 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Caching;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Caching;
+
+public sealed class SymbolCacheKeyTests
+{
+    [Fact]
+    public void For_SinglePart_JoinsWithColonEquals()
+    {
+        Assert.Equal("quote:s=AAPL", SymbolCacheKey.For("quote", ("s", "AAPL")));
+    }
+
+    [Fact]
+    public void For_MultiPart_PreservesOrder()
+    {
+        Assert.Equal(
+            "profile:s=AAPL:cosmetic=True",
+            SymbolCacheKey.For("profile", ("s", "AAPL"), ("cosmetic", "True")));
+    }
+
+    [Fact]
+    public void For_DateParts_KeepsInvariantFormattedValues()
+    {
+        Assert.Equal(
+            "calendar-ipo:f=2026-05-16:t=2026-05-23",
+            SymbolCacheKey.For("calendar-ipo", ("f", "2026-05-16"), ("t", "2026-05-23")));
+    }
+
+    [Fact]
+    public void For_PrefixOnly_ReturnsPrefix()
+    {
+        Assert.Equal("exchanges", SymbolCacheKey.For("exchanges"));
+    }
+}

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/Symbols/SymbolNormalizerTests.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/Symbols/SymbolNormalizerTests.cs
@@ -1,0 +1,47 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using FinnHub.MCP.Server.Application.Symbols;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Application.Tests.Unit.Symbols;
+
+public sealed class SymbolNormalizerTests
+{
+    [Theory]
+    [InlineData("aapl", "AAPL")]
+    [InlineData(" aapl ", "AAPL")]
+    [InlineData("AAPL", "AAPL")]
+    [InlineData("brk.b", "BRK.B")]
+    public void Normalize_TrimsAndUppercases(string input, string expected)
+    {
+        Assert.Equal(expected, SymbolNormalizer.Normalize(input));
+    }
+
+    [Fact]
+    public void Normalize_Null_Throws()
+    {
+        Assert.Throws<ArgumentNullException>(() => SymbolNormalizer.Normalize(null!));
+    }
+
+    [Fact]
+    public void NormalizeOrAll_Null_ReturnsAll()
+    {
+        Assert.Equal("all", SymbolNormalizer.NormalizeOrAll(null));
+    }
+
+    [Theory]
+    [InlineData(" msft ", "MSFT")]
+    [InlineData("MSFT", "MSFT")]
+    [InlineData("", "")]
+    public void NormalizeOrAll_NonNull_NormalizesAndNeverWidensToAll(string input, string expected)
+    {
+        // Branches on null only: an empty/whitespace (non-null) symbol normalises like any other
+        // value, so it never collapses into the "all" slot — matches the prior calendar behaviour.
+        Assert.Equal(expected, SymbolNormalizer.NormalizeOrAll(input));
+    }
+}

--- a/tests/FinnHub.MCP.Server.Application.Tests.Unit/TestDoubles/FakeFinnHubCache.cs
+++ b/tests/FinnHub.MCP.Server.Application.Tests.Unit/TestDoubles/FakeFinnHubCache.cs
@@ -26,12 +26,16 @@ internal sealed class FakeFinnHubCache : IFinnHubCache
 
     public int FactoryInvocationCount { get; private set; }
 
+    /// <summary>Every logical key passed to <see cref="GetOrCreateAsync{T}"/>, in call order.</summary>
+    public List<string> ObservedKeys { get; } = [];
+
     public async ValueTask<T> GetOrCreateAsync<T>(
         string key,
         CacheTier tier,
         Func<CancellationToken, ValueTask<T>> factory,
         CancellationToken cancellationToken = default)
     {
+        this.ObservedKeys.Add(key);
         var compositeKey = $"{tier}:{key}";
 
         if (this._entries.TryGetValue(compositeKey, out var cached))

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Http/FinnHubResponseErrorsTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Http/FinnHubResponseErrorsTests.cs
@@ -1,0 +1,91 @@
+﻿// ---------------------------------------------------------------------------------------------------------------------
+//  <copyright>
+//    This file is part of FinnHub MCP Server and is licensed under the MIT License.
+//    See the LICENSE file in the project root for full license information.
+//  </copyright>
+// ---------------------------------------------------------------------------------------------------------------------
+
+using System.Net;
+using System.Text;
+using FinnHub.MCP.Server.Application.Exceptions;
+using FinnHub.MCP.Server.Infrastructure.Clients.Http;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace FinnHub.MCP.Server.Infrastructure.Tests.Unit.Clients.Http;
+
+public sealed class FinnHubResponseErrorsTests
+{
+    private static MemoryStream Body(string text = "error-body") => new(Encoding.UTF8.GetBytes(text));
+
+    private static HttpResponseMessage Response(HttpStatusCode status, string? path = "/api/v1/quote")
+    {
+        var response = new HttpResponseMessage(status);
+        if (path is not null)
+        {
+            response.RequestMessage = new HttpRequestMessage(HttpMethod.Get, "https://finnhub.io" + path);
+        }
+
+        return response;
+    }
+
+    [Fact]
+    public async Task ThrowForStatusAsync_Forbidden_ThrowsPremiumRequiredWithEndpointAndBody()
+    {
+        using var response = Response(HttpStatusCode.Forbidden);
+
+        var ex = await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() =>
+            FinnHubResponseErrors.ThrowForStatusAsync(response, Body(), NullLogger.Instance, "quote", default));
+
+        Assert.Equal("/api/v1/quote", ex.Endpoint);
+        Assert.Equal("error-body", ex.ResponseContent);
+    }
+
+    [Fact]
+    public async Task ThrowForStatusAsync_Unauthorized_WithFlag_ThrowsPremiumRequired()
+    {
+        using var response = Response(HttpStatusCode.Unauthorized);
+
+        await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() =>
+            FinnHubResponseErrors.ThrowForStatusAsync(
+                response, Body(), NullLogger.Instance, "exchange-symbols", default, treatUnauthorizedAsPremium: true));
+    }
+
+    [Fact]
+    public async Task ThrowForStatusAsync_Unauthorized_DefaultFlag_ThrowsHttp()
+    {
+        using var response = Response(HttpStatusCode.Unauthorized);
+
+        var ex = await Assert.ThrowsAsync<ApiClientHttpException>(() =>
+            FinnHubResponseErrors.ThrowForStatusAsync(response, Body(), NullLogger.Instance, "quote", default));
+
+        Assert.Equal(HttpStatusCode.Unauthorized, ex.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(HttpStatusCode.NotFound)]
+    [InlineData(HttpStatusCode.InternalServerError)]
+    [InlineData(HttpStatusCode.BadGateway)]
+    public async Task ThrowForStatusAsync_OtherErrors_ThrowHttpWithStatusBodyAndResourceMessage(HttpStatusCode status)
+    {
+        using var response = Response(status);
+
+        var ex = await Assert.ThrowsAsync<ApiClientHttpException>(() =>
+            FinnHubResponseErrors.ThrowForStatusAsync(response, Body(), NullLogger.Instance, "quote", default));
+
+        Assert.Equal(status, ex.StatusCode);
+        Assert.Equal("error-body", ex.ResponseContent);
+        Assert.Equal($"FinnHub quote returned {status}.", ex.Message);
+    }
+
+    [Fact]
+    public async Task ThrowForStatusAsync_Forbidden_NullRequestMessage_EndpointIsUnknown()
+    {
+        using var response = Response(HttpStatusCode.Forbidden, path: null);
+
+        var ex = await Assert.ThrowsAsync<ApiClientPremiumRequiredException>(() =>
+            FinnHubResponseErrors.ThrowForStatusAsync(response, Body(), NullLogger.Instance, "quote", default));
+
+        Assert.Equal("(unknown)", ex.Endpoint);
+    }
+}


### PR DESCRIPTION
## What

Feature 5.9 (story #406) — collapse the duplicated HTTP error handling and cache-key building across the FinnHub clients and services into shared helpers, and fix the NewsService midnight-UTC cache staleness bug.

Closes #406.

Lands as two commits: `refactor(infra):` (shared error handler + cache-key unification) and `fix(application):` (the NewsService date-window bug).

## Error handling — `FinnHubResponseErrors.ThrowForStatusAsync`
One shared helper replaces **eleven** near-identical per-client `HandleErrorAsync` methods (~305 deleted lines). 403 (and 401 for exchange-symbols, via `treatUnauthorizedAsPremium`) → `PremiumRequired`; everything else → a typed HTTP exception. The per-client noun is a parameter, so each client's log/message text is preserved.

- **News client**: `GetStreamAsync` returned a stream while leaking the undisposed `HttpResponseMessage` (3 leaked per pulse). Replaced by `SendAndValidateAsync`; the caller owns the response via `using var response`, disposed deterministically.

## Cache keys — `SymbolNormalizer` + `SymbolCacheKey`
`SymbolNormalizer.Normalize` (Trim + ToUpperInvariant) and `SymbolCacheKey.For(prefix, parts)` replace ~10 inline `symbol.ToUpperInvariant()` calls and the inconsistent helper-vs-inline key building. **Every migrated key is byte-identical** for trimmed/cased input (verified by the unchanged SearchService cache-identity tests).

## The bug fix (M17)
NewsService company-news keys encoded only `:w=current`/`:w=prev`; the resolved window lived only in the factory closure, so an entry cached just before UTC midnight was served with the previous day's window until TTL. Now the keys bake in the resolved `from`/`to` (`news-pulse:s=…:from=…:to=…`), so a rollover yields a fresh key. New regression test via `FakeFinnHubCache.ObservedKeys`.

## Behavior changes disclosed
- **Search is the only client whose observable behavior changes**: its bespoke thrown-message text and log templates (incl. the 403 premium-log noun) are standardised onto the shared form. No test asserted the old text; the premium *exception* message is unchanged.
- `SymbolNormalizer` now **trims defensively** everywhere (only SearchService did before). For Insiders/Recommendations the normalized symbol is also the value sent upstream — inert for boundary-trimmed input.
- `CalendarService` null→"all" branches on **null only** (byte-identical; no empty→"all" widening).

## Scope note
The issue body's "7 clients / 8 services" count is stale — the actual surface is **11 clients and 11 services**, all migrated.

## Acceptance criteria (#406)
- [x] Shared `FinnHubResponseErrors.ThrowForStatusAsync`; all clients route through it
- [x] Per-client log discrimination preserved (resource parameter)
- [x] `SymbolCacheKey.For` + `SymbolNormalizer` applied across all services
- [x] NewsService keys include the date window (M17)
- [x] News client stream helper restructured for deterministic disposal (M18)
- [x] All tests pass; coverage maintained

## Validation
- `dotnet build` (Release) — clean, 0 warnings (`TreatWarningsAsErrors`)
- `dotnet format --verify-no-changes` — clean
- `dotnet test --filter "Category!=LiveSmoke"` — **892 passing, 0 failing** (+20 net)

> Built from an adversarially-verified blueprint; the verify pass corrected the CalendarService null-branch behavior and the news-test design. Recommend merging with `--merge` to preserve the `refactor:` + `fix:` commits for release-please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)