### PR TITLE
test: consolidate test scaffolding (handler, fixtures, bin path, seals)

### DIFF
--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/Clients/Search/FinnHubSearchApiClientTests.cs
@@ -7,12 +7,10 @@
 // ---------------------------------------------------------------------------------------------------------------------
 
 using System.Net;
-using System.Text.Json;
 using FinnHub.MCP.Server.Application.Exceptions;
 using FinnHub.MCP.Server.Application.Options;
 using FinnHub.MCP.Server.Application.Search.Features.SearchSymbol;
 using FinnHub.MCP.Server.Infrastructure.Clients.Search;
-using FinnHub.MCP.Server.Infrastructure.Dtos;
 using FinnHub.MCP.Server.Infrastructure.Tests.Unit.Fixtures;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -60,7 +58,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     }
 
     [Fact]
-    public void Constructor_WithNullHttpClientFactory_ThrowsArgumentNullException()
+    public void Constructor_WithNullHttpClient_ThrowsArgumentNullException()
     {
         // Act & Assert
         Assert.Throws<ArgumentNullException>(() =>
@@ -155,41 +153,21 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     {
         // Arrange
         var query = new SearchSymbolQuery { Query = "AAPL", QueryId = Guid.NewGuid().ToString() };
-        var expectedResponse = new FinnHubSearchResponse
-        {
-            Count = 1,
-            Result =
-            [
-                new FinnHubSymbolResult
-                {
-                    Symbol = "AAPL",
-                    Description = "Apple Inc",
-                    DisplaySymbol = "AAPL",
-                    Type = "Common Stock"
-                }
-            ]
-        };
 
-        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-        });
-
-        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+        this._messageHandler.SetResponse(HttpStatusCode.OK, Fixture.LoadFinnHub("search-apple"));
 
         // Act
         var result = await this._sut.SearchSymbolAsync(query, CancellationToken.None);
 
-        // Assert
+        // Assert — real captured /search?q=apple payload (11 results; AAPL is one of them).
         Assert.NotNull(result);
         Assert.Equal("AAPL", result.Query);
         Assert.NotNull(result.QueryId);
         Assert.Equal("finnhub-api", result.Source);
-        Assert.Single(result.Symbols);
-        Assert.Equal("AAPL", result.Symbols[0].Symbol);
-        Assert.Equal("Apple Inc", result.Symbols[0].Description);
-        Assert.Equal("AAPL", result.Symbols[0].DisplaySymbol);
-        Assert.Equal("Common Stock", result.Symbols[0].Type);
+        var aapl = Assert.Single(result.Symbols, s => s.Symbol == "AAPL");
+        Assert.Equal("Apple Inc", aapl.Description);
+        Assert.Equal("AAPL", aapl.DisplaySymbol);
+        Assert.Equal("Common Stock", aapl.Type);
     }
 
     [Fact]
@@ -203,18 +181,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
             QueryId = Guid.NewGuid().ToString()
         };
 
-        var expectedResponse = new FinnHubSearchResponse
-        {
-            Count = 0,
-            Result = []
-        };
-
-        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-        });
-
-        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+        this._messageHandler.SetResponse(HttpStatusCode.OK, """{"count":0,"result":[]}""");
 
         // Act
         await this._sut.SearchSymbolAsync(query, CancellationToken.None);
@@ -268,18 +235,7 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     {
         // Arrange
         var query = new SearchSymbolQuery { Query = "INVALID", QueryId = Guid.NewGuid().ToString() };
-        var expectedResponse = new FinnHubSearchResponse
-        {
-            Count = 0,
-            Result = []
-        };
-
-        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-        });
-
-        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+        this._messageHandler.SetResponse(HttpStatusCode.OK, """{"count":0,"result":[]}""");
 
         // Act
         var result = await this._sut.SearchSymbolAsync(query, CancellationToken.None);
@@ -371,27 +327,10 @@ public sealed class FinnHubSearchApiClientTests : IDisposable
     {
         // Arrange
         var query = new SearchSymbolQuery { Query = "TEST", QueryId = Guid.NewGuid().ToString() };
-        var expectedResponse = new FinnHubSearchResponse
-        {
-            Count = 1,
-            Result =
-            [
-                new FinnHubSymbolResult
-                {
-                    Symbol = null,
-                    Description = null,
-                    DisplaySymbol = null,
-                    Type = null
-                }
-            ]
-        };
-
-        var jsonResponse = JsonSerializer.Serialize(expectedResponse, new JsonSerializerOptions
-        {
-            PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-        });
-
-        this._messageHandler.SetResponse(HttpStatusCode.OK, jsonResponse);
+        // Null upstream fields must project to empty strings, not nulls.
+        this._messageHandler.SetResponse(
+            HttpStatusCode.OK,
+            """{"count":1,"result":[{"symbol":null,"description":null,"displaySymbol":null,"type":null}]}""");
 
         // Act
         var result = await this._sut.SearchSymbolAsync(query, CancellationToken.None);

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/MockHttpMessageHandler.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/MockHttpMessageHandler.cs
@@ -36,6 +36,18 @@ public class MockHttpMessageHandler : HttpMessageHandler
         this._response = null;
     }
 
+    /// <summary>
+    /// Sets a response with the given status and lets the caller configure it (e.g. add response
+    /// headers). Lets header-sensitive tests share this handler instead of hand-rolling a stub.
+    /// </summary>
+    public void SetResponse(HttpStatusCode statusCode, Action<HttpResponseMessage> configureResponse)
+    {
+        var response = new HttpResponseMessage(statusCode);
+        configureResponse(response);
+        this._response = response;
+        this._exception = null;
+    }
+
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         this.LastRequest = request;

--- a/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/RateLimiting/RateLimitHeaderHandlerTests.cs
+++ b/tests/FinnHub.MCP.Server.Infrastructure.Tests.Unit/RateLimiting/RateLimitHeaderHandlerTests.cs
@@ -143,7 +143,8 @@ public sealed class RateLimitHeaderHandlerTests
         // Build the handler chain locally and dispose each link in declared order.
         // Using HttpMessageInvoker rather than HttpClient avoids CA2000's
         // false-positive on inline handler construction.
-        using var inner = new StubHandler(status, configureResponse);
+        using var inner = new MockHttpMessageHandler();
+        inner.SetResponse(status, configureResponse);
         using var handler = new RateLimitHeaderHandler(tracker, NullLogger<RateLimitHeaderHandler>.Instance)
         {
             InnerHandler = inner
@@ -151,15 +152,5 @@ public sealed class RateLimitHeaderHandlerTests
         using var invoker = new HttpMessageInvoker(handler, disposeHandler: false);
         using var request = new HttpRequestMessage(HttpMethod.Get, "https://example/");
         using var response = await invoker.SendAsync(request, CancellationToken.None);
-    }
-
-    private sealed class StubHandler(HttpStatusCode status, Action<HttpResponseMessage> configure) : HttpMessageHandler
-    {
-        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
-        {
-            var response = new HttpResponseMessage(status);
-            configure(response);
-            return Task.FromResult(response);
-        }
     }
 }

--- a/tests/FinnHub.MCP.Server.Tests.LiveSmoke/FinnHub.MCP.Server.Tests.LiveSmoke.csproj
+++ b/tests/FinnHub.MCP.Server.Tests.LiveSmoke/FinnHub.MCP.Server.Tests.LiveSmoke.csproj
@@ -17,4 +17,12 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\FinnHub.MCP.Server\FinnHub.MCP.Server.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <!-- Inject the server's bin path at build time so the live-smoke host can find its
+         co-located appsettings.json without a fragile runtime parent-directory walk. -->
+    <AssemblyAttribute Include="System.Reflection.AssemblyMetadataAttribute">
+      <_Parameter1>ServerBinDir</_Parameter1>
+      <_Parameter2>$([System.IO.Path]::GetFullPath('$(MSBuildProjectDirectory)/../../src/FinnHub.MCP.Server/bin/$(Configuration)/$(TargetFramework)'))</_Parameter2>
+    </AssemblyAttribute>
+  </ItemGroup>
 </Project>

--- a/tests/FinnHub.MCP.Server.Tests.LiveSmoke/LiveSmokeFactory.cs
+++ b/tests/FinnHub.MCP.Server.Tests.LiveSmoke/LiveSmokeFactory.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Reflection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 
@@ -39,21 +40,18 @@ public sealed class LiveSmokeFactory : WebApplicationFactory<Program>
 
     private static string ServerBinPath()
     {
-        // The test assembly resolves to tests/.../bin/Debug|Release/net10.0/.
-        // The server's bin output is at src/FinnHub.MCP.Server/bin/<config>/net10.0/.
-        // Walk back to the repo root then forward to the server project's bin.
-        var here = AppContext.BaseDirectory;
-        var configDir = new DirectoryInfo(here).Parent
-                        ?? throw new InvalidOperationException("Could not find net10.0 parent.");
-        var configName = configDir.Name; // "Debug" or "Release"
+        // The server's bin path is injected at build time via
+        // [AssemblyMetadata("ServerBinDir", ...)] (see the .csproj). Build-time injection survives
+        // the test-project directory restructures that the old runtime parent-directory walk did not.
+        var serverBin = typeof(LiveSmokeFactory).Assembly
+            .GetCustomAttributes<AssemblyMetadataAttribute>()
+            .FirstOrDefault(a => a.Key == "ServerBinDir")?.Value;
 
-        // configDir is "Debug" or "Release" → ../bin → ../<test-project>
-        // → ../tests → ../<repo-root>. That's four .Parent hops.
-        var repoRoot = configDir.Parent?.Parent?.Parent?.Parent
-                       ?? throw new InvalidOperationException("Could not walk back to repo root.");
-
-        var serverBin = Path.Combine(
-            repoRoot.FullName, "src", "FinnHub.MCP.Server", "bin", configName, "net10.0");
+        if (string.IsNullOrEmpty(serverBin))
+        {
+            throw new InvalidOperationException(
+                "ServerBinDir assembly metadata was not injected — check the test project's AssemblyAttribute.");
+        }
 
         if (!Directory.Exists(serverBin))
         {

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Middleware/WrappedToolsExtensionsTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Middleware/WrappedToolsExtensionsTests.cs
@@ -17,7 +17,7 @@ using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Middleware;
 
-public class WrappedToolsExtensionsTests
+public sealed class WrappedToolsExtensionsTests
 {
     [Fact]
     public void WithWrappedTools_RegistersOneMiddlewareWrapperPerToolMethod()

--- a/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchInputValidatorTests.cs
+++ b/tests/FinnHub.MCP.Server.Tests.Unit/Tools/Search/SearchInputValidatorTests.cs
@@ -11,7 +11,7 @@ using Xunit;
 
 namespace FinnHub.MCP.Server.Tests.Unit.Tools.Search;
 
-public class SearchInputValidatorTests
+public sealed class SearchInputValidatorTests
 {
     [Theory]
     [InlineData("AAPL", false)]


### PR DESCRIPTION
## What

Feature 5.7 — Theme 7 test-scaffolding consolidation (story #404). Test-only; no production code touched.

Closes #404.

## Changes (5 AC items)
- [x] **M31** — `RateLimitHeaderHandlerTests` drops its private `StubHandler` and uses the shared `MockHttpMessageHandler`, which gains a `SetResponse(status, Action<HttpResponseMessage>)` overload so header-sensitive tests can configure the response.
- [x] **M32** — `FinnHubSearchApiClientTests` replaces the four reflection-based `JsonSerializer.Serialize` round-trips: the happy path loads the real `search-apple` fixture; the empty/null edge cases use small inline raw JSON in the real camelCase shape. The now-unused `System.Text.Json` / `Infrastructure.Dtos` usings are removed.
- [x] **M33** — `LiveSmokeFactory.ServerBinPath` reads a build-time `[AssemblyMetadata("ServerBinDir", …)]` injected by the test `.csproj`, instead of the runtime four-`Parent`-hop walk. Survives test-project directory restructures. Verified the injected value resolves to the real server bin dir.
- [x] **M34** — sealed `SearchInputValidatorTests` and `WrappedToolsExtensionsTests` to match the rest of the suite.
- [x] Renamed `Constructor_WithNullHttpClientFactory_…` → `Constructor_WithNullHttpClient_…` (the parameter is an `HttpClient`, not a factory).

## Validation
- `dotnet build` (Release, incl. LiveSmoke) — clean, 0 warnings (`TreatWarningsAsErrors`)
- `dotnet test --filter "Category!=LiveSmoke"` — **892 passing, 0 failing**
- `dotnet format --verify-no-changes` — clean
- Injected `ServerBinDir` → `…/src/FinnHub.MCP.Server/bin/Release/net10.0` (exists)

> `test:` type — hidden from the changelog per the release-please config, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)