### PR TITLE
refactor(infra): stop retrying cancellations, add backoff jitter, drop unused package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,9 +85,11 @@ This server is consumed by LLMs — tokens are the constraint, not latency.
 
 ## Resilience
 
-The Finnhub HTTP client is wired with `Microsoft.Extensions.Http.Resilience` (Polly v8) — retry, timeout, circuit-breaker. Don't add ad-hoc `try/catch` around HTTP calls; configure the resilience pipeline instead.
+The Finnhub HTTP clients are wired with hand-rolled Polly v8 policies (`Microsoft.Extensions.Http.Polly` + `Polly`) in `ServiceCollectionExtension.cs` — a retry policy and a circuit breaker registered per client via `AddPolicyHandler`. Don't add ad-hoc `try/catch` around HTTP calls; configure these policies instead. We deliberately do **not** use `Microsoft.Extensions.Http.Resilience.AddStandardResilienceHandler` — keeping the policies explicit makes the 403/401 premium-gating and the rate-limit-header observation handler obvious; that package is intentionally unreferenced.
 
-For 403 responses (premium-locked endpoints): handle these as a typed exception, do **not** retry through Polly. Mark the endpoint as premium-gated and return a structured error.
+The retry policy (3 attempts) retries transient/5xx responses, `HttpRequestException`, and **only timeout-caused** `TaskCanceledException` (`ex.InnerException is TimeoutException`) — a caller cancellation propagates immediately instead of burning ~14s of backoff on a request nobody is waiting for. Backoff is `2^n` seconds plus up to 1s of jitter, so concurrent clients don't retry in lockstep during a 5xx storm.
+
+For 403/401 responses (premium-locked endpoints, premium-gated `/stock/symbol` exchanges): excluded from both the retry and the circuit breaker — they are permanent per-key failures. The clients surface them as a typed `ApiClientPremiumRequiredException`; do **not** retry through Polly.
 
 ## HTTP clients and URI resolution
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,6 @@
   <ItemGroup Label="Microsoft">
     <PackageVersion Include="Microsoft.AspNetCore.OpenApi" Version="10.0.0"/>
     <PackageVersion Include="Microsoft.Extensions.Caching.Hybrid" Version="$(MicrosoftExtensionsVersion)" />
-    <PackageVersion Include="Microsoft.Extensions.Http.Resilience" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="$(MicrosoftExtensionsVersion)" />
     <PackageVersion Include="Microsoft.Extensions.Http" Version="$(MicrosoftExtensionsVersion)" />

--- a/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Extensions/ServiceCollectionExtension.cs
@@ -236,10 +236,17 @@ public static class ServiceCollectionExtension
         return Policy<HttpResponseMessage>
             .HandleResult(res => !res.IsSuccessStatusCode && res.StatusCode is not (HttpStatusCode.Forbidden or HttpStatusCode.Unauthorized))
             .Or<HttpRequestException>()
-            .Or<TaskCanceledException>()
+            // Only retry a TaskCanceledException raised by the HttpClient timeout — a caller
+            // cancellation (the request token was tripped) is intentional and must propagate
+            // immediately, not burn ~14s of backoff retrying a request nobody is waiting for.
+            .Or<TaskCanceledException>(ex => ex.InnerException is TimeoutException)
             .WaitAndRetryAsync(
                 retryCount: 3,
-                sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
+                // Exponential backoff with jitter (up to 1s) so concurrent clients hitting a 5xx
+                // storm don't retry in lockstep — avoids the thundering-herd amplification.
+                sleepDurationProvider: retryAttempt =>
+                    TimeSpan.FromSeconds(Math.Pow(2, retryAttempt))
+                    + TimeSpan.FromMilliseconds(Random.Shared.Next(0, 1000)),
                 onRetry: (outcome, timespan, retryAttempt, context) =>
                 {
                     context["Policy"] = "RetryPolicy";


### PR DESCRIPTION
## What

Feature 5.6 (story #403) — three Polly resilience fixes in `ServiceCollectionExtension.cs`.

Closes #403.

## Decision (AC item 1)
**Keep the hand-rolled Polly policies** (`Microsoft.Extensions.Http.Polly` + `Polly`) rather than migrate to `AddStandardResilienceHandler`. The hand-rolled retry/breaker keep the 403/401 premium-gating and the rate-limit-header observation handler explicit and obvious; the standard handler would bury those behind its defaults for little gain. So this is the S-effort path: fix the policy + drop the unused package.

## Changes
- [x] **No longer retries caller cancellations (M25)** — `.Or<TaskCanceledException>()` → `.Or<TaskCanceledException>(ex => ex.InnerException is TimeoutException)`. A tripped request token now propagates immediately instead of burning ~14s of exponential backoff on a request nobody is waiting for; only an HttpClient *timeout* cancellation retries.
- [x] **Backoff jitter (M26)** — `2^n` seconds **+ up to 1s random**, so concurrent clients don't retry in lockstep during a 5xx storm.
- [x] **Dropped the unreferenced package (M24)** — removed `Microsoft.Extensions.Http.Resilience` from `Directory.Packages.props`. Confirmed via ripgrep: no `PackageReference` or `AddStandardResilienceHandler`/`AddResilienceHandler` anywhere.
- [x] **CLAUDE.md corrected** — the "Resilience" section claimed the `Http.Resilience` handler was wired up (it wasn't). Now describes the hand-rolled pipeline and the cancellation/jitter behavior.

## Validation
- `dotnet build` (Release) — clean, 0 warnings
- `dotnet test --filter "Category!=LiveSmoke"` — **799 passing** (the retry policy lives in `[ExcludeFromCodeCoverage]` DI wiring, exercised by live-smoke; no unit test references it, so no test churn)
- `dotnet format --verify-no-changes` — clean
- No lock-file drift (the removed package was never in the resolved graph)

🤖 Generated with [Claude Code](https://claude.com/claude-code)