### PR TITLE
refactor(search): align Search client to the Wave A/B shape (safe axes)

### DIFF
--- a/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Clients/Search/FinnHubSearchApiClient.cs
@@ -30,6 +30,8 @@ namespace FinnHub.MCP.Server.Infrastructure.Clients.Search;
 /// </remarks>
 public sealed class FinnHubSearchApiClient : ISearchApiClient
 {
+    private const string EndpointName = "search-symbol";
+
     private readonly HttpClient _httpClient;
     private readonly FinnHubOptions _finnHubOptions;
     private readonly ILogger<FinnHubSearchApiClient> _logger;
@@ -117,7 +119,7 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient
     {
         return this._finnHubOptions
             .EndPoints
-            .FirstOrDefault(x => x is { IsActive: true, Name: "search-symbol" })
+            .FirstOrDefault(x => x is { IsActive: true } && x.Name == EndpointName)
             ?.Url;
     }
 
@@ -251,7 +253,7 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient
 
         if (!response.IsSuccessStatusCode)
         {
-            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, "search-symbol", cancellationToken).ConfigureAwait(false);
+            await FinnHubResponseErrors.ThrowForStatusAsync(response, contentStream, this._logger, EndpointName, cancellationToken).ConfigureAwait(false);
         }
 
         return await this.DeserializeResponseAsync(contentStream, requestUri, cancellationToken).ConfigureAwait(false);
@@ -270,30 +272,19 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient
         string requestUri,
         CancellationToken cancellationToken)
     {
-        var rawJson = string.Empty;
         try
         {
-            using var reader = new StreamReader(contentStream);
-            rawJson = await reader.ReadToEndAsync(cancellationToken);
+            var response = await JsonSerializer
+                .DeserializeAsync(contentStream, FinnHubJsonContext.Default.FinnHubSearchResponse, cancellationToken)
+                .ConfigureAwait(false);
 
-            var response = JsonSerializer.Deserialize(rawJson, FinnHubJsonContext.Default.FinnHubSearchResponse);
-
-            if (response?.Result == null || response.Result.Count == 0)
+            if (response?.Result is null || response.Result.Count == 0)
             {
                 this._logger.LogInformation("FinnHub returned no results for request: {RequestUri}", requestUri);
                 return Array.Empty<FinnHubSymbolResult>().AsReadOnly();
             }
 
-            return response.Result
-                .Select(result => new FinnHubSymbolResult
-                {
-                    Symbol = result.Symbol,
-                    Description = result.Description,
-                    DisplaySymbol = result.DisplaySymbol,
-                    Type = result.Type
-                })
-                .ToList()
-                .AsReadOnly();
+            return response.Result.AsReadOnly();
         }
         catch (JsonException ex)
         {
@@ -306,7 +297,7 @@ public sealed class FinnHubSearchApiClient : ISearchApiClient
 
             throw new ApiClientDeserializationException(
                 "Invalid JSON returned from FinnHub API.",
-                rawJson, ex)
+                innerException: ex)
             {
                 CorrelationId = correlationId,
                 SourceService = "finnhub-api"

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSearchResponse.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSearchResponse.cs
@@ -15,10 +15,11 @@ namespace FinnHub.MCP.Server.Infrastructure.Dtos;
 public sealed class FinnHubSearchResponse
 {
     /// <summary>
-    /// Gets or sets the search results from the FinnHub API.
+    /// Gets the search results from the FinnHub API. Nullable defensively — Finnhub has been
+    /// observed to omit the array entirely for some responses (see the defensive-DTO pattern from PR #167).
     /// </summary>
     [JsonPropertyName("result")]
-    public required List<FinnHubSymbolResult> Result { get; init; }
+    public List<FinnHubSymbolResult>? Result { get; init; }
 
     /// <summary>
     /// Gets or sets the result count from the FinnHub API.

--- a/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSymbolResult.cs
+++ b/src/FinnHub.MCP.Server.Infrastructure/Dtos/FinnHubSymbolResult.cs
@@ -5,6 +5,7 @@
 //  </copyright>
 // ---------------------------------------------------------------------------------------------------------------------
 
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 
 namespace FinnHub.MCP.Server.Infrastructure.Dtos;
@@ -12,29 +13,22 @@ namespace FinnHub.MCP.Server.Infrastructure.Dtos;
 /// <summary>
 /// Represents a single symbol result from the FinnHub API.
 /// </summary>
+[ExcludeFromCodeCoverage]
 public sealed class FinnHubSymbolResult
 {
-    /// <summary>
-    /// Gets or sets the symbol ticker.
-    /// </summary>
+    /// <summary>Gets the symbol ticker.</summary>
     [JsonPropertyName("symbol")]
-    public string? Symbol { get; set; }
+    public string? Symbol { get; init; }
 
-    /// <summary>
-    /// Gets or sets the symbol description.
-    /// </summary>
+    /// <summary>Gets the symbol description.</summary>
     [JsonPropertyName("description")]
-    public string? Description { get; set; }
+    public string? Description { get; init; }
 
-    /// <summary>
-    /// Gets or sets the display symbol.
-    /// </summary>
+    /// <summary>Gets the display symbol.</summary>
     [JsonPropertyName("displaySymbol")]
-    public string? DisplaySymbol { get; set; }
+    public string? DisplaySymbol { get; init; }
 
-    /// <summary>
-    /// Gets or sets the symbol type.
-    /// </summary>
+    /// <summary>Gets the symbol type.</summary>
     [JsonPropertyName("type")]
-    public string? Type { get; set; }
+    public string? Type { get; init; }
 }

--- a/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
+++ b/src/FinnHub.MCP.Server/Tools/Search/SearchSymbolTool.cs
@@ -96,10 +96,6 @@ public sealed class SearchSymbolTool(
             var validatedView = CommonInputValidators.ValidateView(view);
             _ = SearchInputValidator.ValidateFields(fields);
 
-            logger.LogDebug(
-                "Executing search with query: '{Query}', exchange: '{Exchange}', limit: {Limit}, view: {View}",
-                validatedQuery, validatedExchange, validatedLimit, validatedView);
-
             var symbolSearchQuery = new SearchSymbolQueryBuilder()
                 .WithQuery(validatedQuery)
                 .WithExchange(validatedExchange)
@@ -122,7 +118,7 @@ public sealed class SearchSymbolTool(
         }
         catch (OperationCanceledException)
         {
-            logger.LogDebug("Search operation was canceled for '{Tool}'.", toolName);
+            logger.LogDebug("'{Tool}' was cancelled.", toolName);
             throw;
         }
         catch (ArgumentException ex)


### PR DESCRIPTION
## What

Feature 5.3 (story #400) — reduce the Search client's drift from the 6 Wave A/B clients. **5 of 8 axes done; 2 rejected with rationale; 1 deferred.** This one is judgment-heavy — please review the rejections.

**Refs #400** (left open pending your call on the rejected/deferred axes).

## Done — safe, real drift
- [x] **M2** — endpoint name → `private const string EndpointName`.
- [x] **M3** — `JsonSerializer.DeserializeAsync(Stream)` instead of buffer-to-string; dropped the redundant re-projection.
- [x] **M4** — `FinnHubSymbolResult` now `init`-only + `[ExcludeFromCodeCoverage]`.
- [x] **M5** — `FinnHubSearchResponse.Result` nullable, not `required` (defensive-DTO pattern, PR #167).
- [x] **M7** — `SearchSymbolTool` cancellation log aligned to `"'{Tool}' was cancelled."`; extra mid-method `LogDebug` removed.

## Rejected — recommend against (your call)
- [ ] **M1 (relative URI + BaseAddress)** — Search's absolute `BuildRequestUri` is the **slash-tolerant** pattern CLAUDE.md prefers; the relative pattern is the **PR #169 bug class** (silently drops `/v1` without the trailing slash). Aligning Search *to* the fragile pattern for consistency is a robustness regression. If we want uniformity, the better direction is to standardise on Search's absolute pattern — but that's a bigger architectural call, out of scope here.
- [ ] **M6 (remove `fields`)** — `fields` is currently **validated then discarded** (a no-op placeholder), *and* advertised in the live server instructions ("fields for sparse projections"). Cleanly removing it means also updating the advertised description, and it's entangled with the **P7 sparse-projection** work — which should either implement projection or remove the param + the claim together. Better handled in P7 than half-removed here.

## Deferred
- [ ] **M8 (split-Theory validator tests)** — pure test-style restructuring, no behavior/coverage change. Cosmetic; happy to do it if you want the consistency.

## Validation
- `dotnet build` (Release) — clean, 0 warnings (`TreatWarningsAsErrors`)
- `dotnet test --filter "Category!=LiveSmoke"` — **799 passing**
- `dotnet format --verify-no-changes` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)