### PR TITLE
ci(release): harden npm publish with smoke-pack + publishConfig

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -320,6 +320,12 @@ jobs:
             --out dist/packages > dist/publish-order.txt
           echo "Publish order:"; cat dist/publish-order.txt
 
+      - name: 🔍 Smoke-test the packages before publishing
+        # Pack each package (dry run) and assert the launcher, binaries,
+        # appsettings.json, and version lockstep are all present — fail before
+        # publishing rather than ship a broken package to npm.
+        run: node npm/build/smoke-pack.mjs npm/finnhub-mcp dist/packages
+
       - name: 🚀 Publish to npm (platform packages first, then wrapper)
         env:
           # Bootstrap: NPM_TOKEN (granular automation token) creates the
@@ -331,6 +337,6 @@ jobs:
           while IFS= read -r pkg; do
             [ -z "$pkg" ] && continue
             echo "::group::npm publish $pkg"
-            npm publish "$pkg" --provenance --access public
+            npm publish "$pkg" --provenance --access public --ignore-scripts
             echo "::endgroup::"
           done < dist/publish-order.txt

--- a/npm/build/make-platform-packages.mjs
+++ b/npm/build/make-platform-packages.mjs
@@ -92,6 +92,7 @@ for (const { rid, os, cpu } of MATRIX) {
     os: [os],
     cpu: [cpu],
     files: ["bin/"],
+    publishConfig: { access: "public", provenance: true },
     license: "MIT",
     repository: { type: "git", url: "git+https://github.com/SalZaki/finnhub-mcp.git" },
     homepage: "https://github.com/SalZaki/finnhub-mcp#readme",

--- a/npm/build/smoke-pack.mjs
+++ b/npm/build/smoke-pack.mjs
@@ -1,0 +1,68 @@
+// Smoke-test the npm packages BEFORE publishing: pack each and assert the
+// critical files are actually inside the tarball, and that versions are in
+// lockstep. Catches the class of bug where a file is silently excluded (e.g. a
+// .gitignore `bin/` rule swallowing bin/launcher.js) or a wrapper/platform
+// version skew — both of which would otherwise only surface as a broken install.
+//
+// Usage: node npm/build/smoke-pack.mjs <wrapperDir> [packagesDir]
+//   wrapperDir  : the wrapper package dir (npm/finnhub-mcp)
+//   packagesDir : dir of generated platform packages (CI: dist/packages) — optional
+
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+let failed = false;
+const fail = (m) => { console.error(`✗ ${m}`); failed = true; };
+const ok = (m) => console.log(`✓ ${m}`);
+
+function packedFiles(dir) {
+  const out = execFileSync("npm", ["pack", "--dry-run", "--json"], { cwd: dir, encoding: "utf8" });
+  const meta = JSON.parse(out);
+  return (meta[0]?.files ?? []).map((f) => f.path);
+}
+
+function assertFiles(label, dir, required) {
+  const files = packedFiles(dir);
+  const missing = required.filter((r) => !files.includes(r));
+  if (missing.length) {
+    fail(`${label}: tarball missing ${missing.join(", ")}`);
+    console.error(`  packed: ${files.join(", ") || "(none)"}`);
+  } else {
+    ok(`${label}: ${required.join(", ")} present`);
+  }
+}
+
+const wrapperDir = process.argv[2] ?? path.resolve("npm/finnhub-mcp");
+const packagesDir = process.argv[3];
+
+// 1) Wrapper must ship the launcher + postinstall + checksums (the gitignore-bug class).
+assertFiles("wrapper finnhub-mcp", wrapperDir, [
+  "package.json",
+  "bin/launcher.js",
+  "scripts/install.js",
+  "scripts/checksums.json",
+]);
+
+// 2) Wrapper version must match every optionalDependency version (skew = broken install).
+const wrapper = JSON.parse(fs.readFileSync(path.join(wrapperDir, "package.json"), "utf8"));
+const skew = Object.entries(wrapper.optionalDependencies ?? {})
+  .filter(([, v]) => v !== wrapper.version)
+  .map(([n, v]) => `${n}@${v}`);
+if (skew.length) fail(`version skew: wrapper@${wrapper.version} but ${skew.join(", ")}`);
+else ok(`version lockstep: optionalDependencies all == ${wrapper.version}`);
+
+// 3) Each generated platform package must ship its binary + appsettings.json.
+if (packagesDir && fs.existsSync(packagesDir)) {
+  for (const name of fs.readdirSync(packagesDir)) {
+    const dir = path.join(packagesDir, name);
+    if (!fs.statSync(dir).isDirectory()) continue;
+    const exe = name.includes("win32-") ? "bin/finnhub-mcp.exe" : "bin/finnhub-mcp";
+    assertFiles(`platform ${name}`, dir, ["package.json", exe, "bin/appsettings.json"]);
+  }
+} else {
+  console.log("• no packages dir given — skipping platform-package checks");
+}
+
+if (failed) { console.error("\nsmoke-pack FAILED"); process.exit(1); }
+console.log("\nsmoke-pack OK");

--- a/npm/finnhub-mcp/package.json
+++ b/npm/finnhub-mcp/package.json
@@ -2,6 +2,10 @@
   "name": "finnhub-mcp",
   "version": "0.0.0-dev",
   "description": "Model Context Protocol (MCP) server for Finnhub financial data. Launches the native finnhub-mcp server over stdio — no .NET SDK required.",
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "bin": {
     "finnhub-mcp": "bin/launcher.js"
   },


### PR DESCRIPTION
Follow-up to #471, modeling the proven `doodleworks-mcp` release setup.

- **smoke-pack guard** (`npm/build/smoke-pack.mjs`, wired into `publish-npm` before `npm publish`): packs each package dry-run and asserts the launcher, platform binaries, `appsettings.json`, and wrapper/optionalDependency **version lockstep** are present — fails before a broken package ships. Catches the `.gitignore`-swallowed-launcher class we already hit, plus version skew. Verified locally (passes on good packages, fails when `launcher.js` is removed).
- **publishConfig** `{ access: public, provenance: true }` on the wrapper + generated platform manifests (declarative, matches doodleworks).
- **`--ignore-scripts`** on publish.

Refs #464 #467

🤖 Generated with [Claude Code](https://claude.com/claude-code)