### PR TITLE
ci(release): run validate on promotion PRs to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,12 @@ on:
     paths-ignore:
       - 'docs/**'
       - 'assets/**'
+  pull_request:
+    # Runs the validate job on promotion PRs (main -> release) so the required
+    # "Validate Release Branch" status check can report on the PR itself. Only
+    # validate runs on PR events; release/build/publish are gated on push.
+    branches:
+      - release
   workflow_dispatch:
 
 concurrency:
@@ -21,7 +27,7 @@ permissions:
 jobs:
   validate:
     name: ✅ Validate Release Branch
-    if: ${{ github.ref_name == 'release' }}
+    if: ${{ github.ref_name == 'release' || github.base_ref == 'release' }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Permanent fix for the release promotion chicken-and-egg: the `✅ Validate Release Branch` check only ran on push to `release`, so promotion PRs couldn't satisfy it and needed an admin bypass. This adds a `pull_request` trigger (base `release`) so validate runs on the PR. Only validate runs on PR events; release/build/publish stay gated on push.

Also serves as the content-bearing change that re-triggers release-please after the squashed promotion (#473/#474).

🤖 Generated with [Claude Code](https://claude.com/claude-code)