### PR TITLE
ci(release): publish to npm via OIDC only (drop NPM_TOKEN)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,13 +333,10 @@ jobs:
         run: node npm/build/smoke-pack.mjs npm/finnhub-mcp dist/packages
 
       - name: 🚀 Publish to npm (platform packages first, then wrapper)
-        env:
-          # Bootstrap: NPM_TOKEN (granular automation token) creates the
-          # not-yet-existing packages on the first release. Once all 7 exist and a
-          # Trusted Publisher is configured per package, delete the secret —
-          # publishes then run tokenless via OIDC (id-token: write, above).
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          # Tokenless: authenticates via npm OIDC trusted publishing (configured
+          # per package on npmjs.com); --provenance attests via id-token: write
+          # (above). The one-time NPM_TOKEN bootstrap is retired.
           while IFS= read -r pkg; do
             [ -z "$pkg" ] && continue
             echo "::group::npm publish $pkg"


### PR DESCRIPTION
Now that the 7 packages exist with Trusted Publishers and 'disallow tokens' is set, retire the NPM_TOKEN bootstrap: remove `NODE_AUTH_TOKEN` so `npm publish` uses OIDC trusted publishing (id-token: write + --provenance) cleanly. Matches doodleworks-mcp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)