### PR TITLE
fix(release): move last-release-sha to config root

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -3,12 +3,12 @@
   "release-type": "simple",
   "include-v-in-tag": true,
   "bump-minor-pre-major": true,
+  "last-release-sha": "bfeab14188afae5b74e258276643bcbcc46ccaf5",
   "changelog-path": "CHANGELOG.md",
   "packages": {
     ".": {
       "release-type": "simple",
       "include-component-in-tag": false,
-      "last-release-sha": "bfeab14188afae5b74e258276643bcbcc46ccaf5",
       "changelog-sections": [
         {"type": "feat", "section": "✨ Features", "hidden": false},
         {"type": "fix", "section": "🐛 Bug Fixes", "hidden": false},


### PR DESCRIPTION
release-please ignored last-release-sha when it was nested under `packages.'.'`, causing the first single-branch run to propose a 1.22.0 with a changelog of already-released commits. Move it to the root level (pinned to bfeab14 = v1.21.0's content on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)